### PR TITLE
Legend updated.

### DIFF
--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -17,4 +17,4 @@ table.table.table-striped.table-bordered.table-condensed
       td = link_to_team_members(team, :student)
 
 p.hint
-  | <i class="icon-star-empty"></i> Sponsored team
+  | <i class="icon-star"></i> Sponsored team


### PR DESCRIPTION
Use a full instead of an empty star to signal a sponsored team.
