### PR TITLE
Removed cc and bcc from each email that gets sent.

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -10,7 +10,7 @@ class Mailer < ActionMailer::Base
 
   def email(submission)
     set submission
-    mail subject: subject, from: from, to: to, cc: cc, bcc: bcc
+    mail subject: subject, from: from, to: to
   end
 
   private

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -24,11 +24,11 @@ describe Mailer do
   end
 
   it 'renders the cc' do
-    mail.cc.should == ['cc@email.com']
+    mail.cc.should be_nil
   end
 
   it 'renders the bcc' do
-    mail.bcc.should == ['bcc@email.com']
+    mail.bcc.should be_nil
   end
 
   it 'renders the subject' do

--- a/spec/models/mailing_spec.rb
+++ b/spec/models/mailing_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe Mailing do
+  let(:mailing) { Mailing.new(from: 'from@email.com', to: Role::ROLES,
+    cc: 'cc@email.com', bcc: 'bcc@email.com', subject: 'subject', body: '# body') }
+
   it { should have_many(:submissions).dependent(:destroy) }
 
   describe '#sent?' do
@@ -8,7 +11,11 @@ describe Mailing do
   end
 
   describe '#submit' do
-    pending 'TODO'
+    it 'should deliver seperate emails to all recipients (incl. cc and bcc)' do
+      role = create :coach_role
+      mailing.save!
+      expect{mailing.submit}.to change{Submission.count}.by(mailing.emails.count)
+    end
   end
 
   describe '#recipients' do

--- a/spec/models/recepients_spec.rb
+++ b/spec/models/recepients_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Recipients do
+  let(:mailing) { build :mailing, cc: 'cc@email.com', bcc: 'bcc@email.com' }
+  let(:recipients) { Recipients.new mailing }
+
+  it "should collect all email addresses" do
+    user_email = random_email
+    recipients.stub user_emails: [user_email]
+    expect(recipients.emails).to eq([mailing.cc, mailing.bcc, user_email])
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,3 +44,11 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :view
   config.extend ControllerMacros,     type: :controller
 end
+
+def random_name letters=rand(10)+10
+  [*('a'..'z')].sample(letters).join
+end
+
+def random_email
+  "#{random_name}@railsgirls.com"
+end


### PR DESCRIPTION
Emails are sent to each address separately - no matter if in "to", "cc" or "bcc". Including cc and bcc in each email caused multiple emails to these addresses. Removing the cc and bcc from each mail solves this.

Fixes #46
# pairwithme with @beanieboi
