### PR TITLE
Add MIT license text

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Travis CI GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
Every FOSS project should have one :smile: 

Besides, it appears that we need one to get a free SSL cert (see #107).

Legal stuff: _technically_ we'd have to ask all previous contributors if they are willing to license their contributions under the MIT license (or whatever license we end up with). But, uhm, can we just skip this? :wink: 

---

**Update**: Contributors (Checked: consents to having their contributions licensed under the MIT license)
- [x] svenfuchs
- [x] bastilian
- [x] carpodaster
- [x] joneslee85
- [x] pxlpnk
- [x] aishty
- [x] tjmcewan
- [x] AkshataDM
- [x] benedikt
- [x] lislis
- [x] cypher
- [x] sindhus
- [x] carlad
- [x] sareg0
- [x] lucaspinto
- [x] plexus
- [x] beanieboi
- [x] AlexTi
- [x] robinboening
- [x] anikalindtner

Contributors whose commits only included deletions:
- tbuehlmann
- patriciagao
