### PR TITLE
Speed up specs

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.strategy = :truncation, { pre_count: true }
     DatabaseCleaner.clean_with(:truncation)
   end
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :truncation, { pre_count: true }
+    DatabaseCleaner.strategy = :truncation, { pre_count: true, reset_ids: false }
     DatabaseCleaner.clean_with(:truncation)
   end
 


### PR DESCRIPTION
Just getting started with this project, and the first thing i do after setting it up is run the specs...

By adding a few arguments to db_cleaner you can speed things up quite substantially.

**Before:**
```
Finished in 2 minutes 16.6 seconds (files took 4.14 seconds to load)
493 examples, 0 failures, 8 pending
```

**After:**
```
Finished in 21.66 seconds (files took 3.88 seconds to load)
493 examples, 0 failures, 8 pending
```

This change takes advantage of the `pre_count` feature, while disabling the ids being reset which takes a long time.

See https://github.com/DatabaseCleaner/database_cleaner#additional-activerecord-options-for-truncation