### PR TITLE
Send email when added to team

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,2 @@
+MAILTRAP_USER=InboxUsername
+MAILTRAP_PASSWORD=InboxPassword

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /config/database.yml
 .ruby-version
 .ruby-gemset
-
+.env
 .DS_Store
 
 # Ignore bundler config

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development do
   gem 'pry'
   gem 'spring'
   gem 'spring-commands-rspec'
+  gem 'foreman'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.3)
+    dotenv (1.0.2)
     erubis (2.7.0)
     execjs (2.0.2)
     factory_girl (4.4.0)
@@ -106,6 +107,9 @@ GEM
     font-awesome-sass-rails (3.0.2.2)
       railties (>= 3.1.1)
       sass-rails (>= 3.1.1)
+    foreman (0.77.0)
+      dotenv (~> 1.0.2)
+      thor (~> 0.19.1)
     gh (0.14.0)
       addressable
       backports
@@ -317,6 +321,7 @@ DEPENDENCIES
   feedjira (~> 1.6.0)
   ffaker
   font-awesome-sass-rails
+  foreman
   gh (~> 0.14)
   hashr
   jquery-rails

--- a/README.md
+++ b/README.md
@@ -56,15 +56,19 @@ bundle exec rake db:drop db:create db:migrate
 
 ### Mailtrap
 
-To avoid accidentally sending out mails to real addresses we user [Mailtrap](https://mailtrap.io).
-Create an account and inbox there and add the username and password from to your environment.
-Depending on your environment put the following lines in `.zshrc` (if you use ZSH) or `.bash_profile` (if you use BASH):
+To avoid accidentally sending out mails to real addresses we suggest
+[Mailtrap](https://mailtrap.io).
+You can create a free account there with an inbox to 'trap' emails sent from
+your development environment.
 
-```
-export MAILTRAP_USER=>>USERNAME<<
-export MAILTRAP_PASSWORD=>>PASSWORD<<
-```
-_**Note:** Replace `>>USERNAME<<` & `>>PASSOWORD<<` according to the Mailtrap-Inbox._
+Copy the `.env-example` to `.env` and replace `InboxUsername` and
+`InboxPassword` with your own username and password from your mailtrap
+inbox.
+
+Now when running the command `foreman` *before* any command in this project
+directory the variables from `.env` will be loaded into the environment.
+
+E.g. `foreman run rails server` or `foreman run rails console`.
 
 ## Testing
 

--- a/app/mailers/role_mailer.rb
+++ b/app/mailers/role_mailer.rb
@@ -1,0 +1,11 @@
+class RoleMailer < ActionMailer::Base
+  include ActionView::Helpers::TextHelper
+
+  default from: ENV['EMAIL_FROM'] || 'summer-of-code-team@railsgirls.com'
+
+  def user_added_to_team(role)
+    @role = role
+    mail to: @role.user.email,
+         subject: "[rgsoc-teams] You have been added to the #{@role.team.name} team."
+  end
+end

--- a/app/mailers/role_mailer.rb
+++ b/app/mailers/role_mailer.rb
@@ -4,6 +4,9 @@ class RoleMailer < ActionMailer::Base
   default from: ENV['EMAIL_FROM'] || 'summer-of-code-team@railsgirls.com'
 
   def user_added_to_team(role)
+    return unless role.user.present? &&
+                  role.team.present? &&
+                  role.user.email.present?
     @role = role
     mail to: @role.user.email,
          subject: "[rgsoc-teams] You have been added to the #{@role.team.name} team."

--- a/app/views/role_mailer/user_added_to_team.html.slim
+++ b/app/views/role_mailer/user_added_to_team.html.slim
@@ -1,0 +1,14 @@
+doctype html
+html
+  head
+    meta content="text/html; charset=UTF-8" http-equiv="Content-Type"
+
+    style
+      | html, body {
+      |   font-family: Helvetica, sans-serif;
+      | }
+  body
+    p
+      | You have been added to the
+      a[href=team_url(@role.team)] @role.team.name
+      | as a #{@role.name}.

--- a/app/views/role_mailer/user_added_to_team.html.slim
+++ b/app/views/role_mailer/user_added_to_team.html.slim
@@ -9,6 +9,6 @@ html
       | }
   body
     p
-      | You have been added to the
-      a[href=team_url(@role.team)] @role.team.name
+      ' You have been added to the
+      a>[href=team_url(@role.team)]= @role.team.name
       | as a #{@role.name}.

--- a/app/views/role_mailer/user_added_to_team.text.erb
+++ b/app/views/role_mailer/user_added_to_team.text.erb
@@ -1,0 +1,3 @@
+You have been added to the <%= @role.team.name %> as a <%= @role.name %>.
+
+Visit the team at <%= team_url(@role.team) %>

--- a/app/workers/background_mailer_worker.rb
+++ b/app/workers/background_mailer_worker.rb
@@ -1,0 +1,7 @@
+class BackgroundMailerWorker
+  include SuckerPunch::Job
+
+  def perform(mailer)
+    mailer.deliver
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,7 @@ RgsocTeams::Application.configure do
     authentication: :cram_md5,
     enable_starttls_auto: true
   }
+  config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
 
   config.eager_load = false
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,16 +23,20 @@ RgsocTeams::Application.configure do
   config.assets.debug = true
 
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    user_name: ENV['MAILTRAP_USER'],
-    password: ENV['MAILTRAP_PASSWORD'],
-    address: 'mailtrap.io',
-    domain: 'mailtrap.io',
-    port: '2525',
-    authentication: :cram_md5,
-    enable_starttls_auto: true
-  }
+  if ENV['MAILTRAP_USER'].present? && ENV['MAILTRAP_PASSWORD'].present?
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      user_name: ENV['MAILTRAP_USER'],
+      password: ENV['MAILTRAP_PASSWORD'],
+      address: 'mailtrap.io',
+      domain: 'mailtrap.io',
+      port: '2525',
+      authentication: :cram_md5,
+      enable_starttls_auto: true
+    }
+  else
+    config.action_mailer.raise_delivery_errors = false
+  end
   config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
 
   config.eager_load = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,6 +25,7 @@ RgsocTeams::Application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.raise_delivery_errors = false
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,7 +25,6 @@ RgsocTeams::Application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-  config.action_mailer.raise_delivery_errors = false
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr

--- a/config/initializers/monkey_patch_mail.rb
+++ b/config/initializers/monkey_patch_mail.rb
@@ -1,0 +1,10 @@
+# This is a monkey patch on Mail::Message
+# You can and should remove this when upgrading to Rails 4.2
+
+module Mail
+  class Message
+    def deliver_later
+      BackgroundMailerWorker.new.async.perform(self)
+    end
+  end
+end

--- a/lib/mailer_previews/role_mailer_preview.rb
+++ b/lib/mailer_previews/role_mailer_preview.rb
@@ -1,0 +1,5 @@
+class RoleMailerPreview < ActionMailer::Preview
+  def user_added_to_team
+    RoleMailer.user_added_to_team(Role.first)
+  end
+end

--- a/spec/mailers/application_form_mailer_spec.rb
+++ b/spec/mailers/application_form_mailer_spec.rb
@@ -1,7 +1,5 @@
 require "spec_helper"
 
-ENV['EMAIL_FROM'] = Faker::Internet.email
-
 describe ApplicationFormMailer do
   let(:application) { FactoryGirl.build_stubbed(:application) }
   subject { ApplicationFormMailer.new_application(application) }

--- a/spec/mailers/role_mailer_spec.rb
+++ b/spec/mailers/role_mailer_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe RoleMailer, type: :mailer do
+  describe 'user_added_to_team' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:team) { FactoryGirl.create(:team) }
+    let(:role) { FactoryGirl.create(:mentor_role, user: user, team: team) }
+
+    before do
+      subject
+    end
+
+    subject do
+      described_class.user_added_to_team(role)
+    end
+
+    it 'has ENV["EMAIL_FROM"] as from' do
+      expect(subject.from).to include(ENV['EMAIL_FROM'])
+    end
+
+    it 'has a the users email as to' do
+      expect(subject.to).to include(user.email)
+    end
+
+    it 'sets the subject' do
+      expect(subject.subject).to eq("[rgsoc-teams] You have been added to the #{team.name} team.")
+    end
+  end
+end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -14,4 +14,47 @@ describe Role do
       expect(Role.includes?('student')).to eq true
     end
   end
+
+  describe 'create' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:team) { FactoryGirl.create(:team) }
+    let(:mailer) { double('RoleMailer') }
+
+    before do
+      allow(RoleMailer).to receive(:user_added_to_team).and_return(mailer)
+      allow(mailer).to receive(:deliver_later)
+      subject
+    end
+
+    shared_examples 'a guide role' do
+      it 'sends a noticiation to the user' do
+        expect(RoleMailer).to have_received(:user_added_to_team).with(subject)
+        expect(mailer).to have_received(:deliver_later)
+      end
+    end
+
+    subject do
+      user.roles.create team: team, name: role_name
+    end
+
+    context 'when the user is added as a student' do
+      let(:role_name) { 'student' }
+
+      it 'does not send a noticiation' do
+        expect(RoleMailer).to_not have_received(:user_added_to_team).with(subject)
+      end
+    end
+
+    context 'when the user is added as a coach' do
+      let(:role_name) { 'coach' }
+
+      it_behaves_like 'a guide role'
+    end
+
+    context 'when the user is added as a coach' do
+      let(:role_name) { 'mentor' }
+
+      it_behaves_like 'a guide role'
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-ENV['EMAIL_FROM'] ||= 'test@rg.com'
+
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
@@ -32,6 +32,7 @@ require 'cancan/matchers'
 require 'sucker_punch/testing/inline'
 require 'factory_girl_rails'
 
+ENV['EMAIL_FROM'] = Faker::Internet.email
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
This addresses the first item on https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/144 (Send an email when added to a team).

A few notes on what I have done:

1. I have monkey patched Mail::Message to respond to `:deliver_later` in `config/initializers/monkey_patch_mail.rb`. I've done this to make upgrading to Rails 4.2 easier when we have ActiveJob available. It essentially puts the mailer in a background job. This should be removed when upgrading to 4.2 .
2. I've added the [foreman gem](https://github.com/ddollar/foreman). It is nicer and easier to have your environment variables in a `.env` file. I've also added `.env` to the .gitignore file. I can update the readme to reflect this in the Mailtrap section.
3. I had a bit of trouble with other tests failing because they were trying to deliver the email. I've set `action_mailer.raise_delivery_errors` to `false`. Let me know if this is unacceptable, and I'll find another way.

![Wiggle](http://i.imgur.com/4nQacF3.gif)

Bed time!