### PR TITLE
Application drafts index

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -6,6 +6,10 @@ class ApplicationDraftsController < ApplicationController
 
   helper_method :application_draft
 
+  def index
+    @application_drafts = current_user.application_drafts.order('created_at DESC')
+  end
+
   def new
     redirect_to new_team_path, alert: 'You need to be in a team as a student' unless current_user.student?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ActiveRecord::Base
   end
   has_many :applications
   has_many :teams, -> { uniq }, through: :roles
+  has_many :application_drafts, through: :teams
   has_many :attendances
   has_many :conferences, through: :attendances
 

--- a/app/views/application_drafts/index.html.slim
+++ b/app/views/application_drafts/index.html.slim
@@ -1,0 +1,16 @@
+h1.header
+  = icon('inbox')
+  span Application drafts
+
+table.table.table-striped.table-bordered.table-condensed
+  thead
+    tr
+      th Project Name
+      th Team
+      th Created
+  tbody
+    - @application_drafts.each do |draft|
+      tr
+        td= link_to draft.project_name, edit_application_draft_path(draft)
+        td= link_to draft.team.display_name, team_path(draft.team), class: "team #{draft.team.kind}"
+        td= draft.created_at

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -26,6 +26,31 @@ RSpec.describe ApplicationDraftsController do
       allow(controller).to receive_messages(current_user: user)
     end
 
+    describe 'GET index' do
+      let!(:student_role) { FactoryGirl.create :student_role, user: user, team: team }
+      let!(:drafts) { FactoryGirl.create_list(:application_draft, 2, team: team) }
+
+      subject do
+        get :index
+      end
+
+      before do
+        subject
+      end
+
+      it 'assigns @application_drafts' do
+        expect(assigns(:application_drafts)).to match_array(drafts)
+      end
+
+      it 'renders index' do
+        expect(response).to render_template(:index)
+      end
+
+      it 'responds with 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
     describe 'GET new' do
       it 'redirects if not part of a students team' do
         get :new

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,7 @@ describe User do
   end
 
   it { expect(subject).to have_many(:teams) }
+  it { expect(subject).to have_many(:application_drafts) }
   it { expect(subject).to have_many(:applications) }
   it { expect(subject).to have_many(:attendances) }
   it { expect(subject).to have_many(:conferences) }


### PR DESCRIPTION
This resolves the second item in https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/144

It is not linked anywhere at the moment, feel free to shoot me directions on where this link should go and I'll pop it in.

The table is a bit sparse, not sure what needs to go in there, but the functionality is there, again, let me know what other columns should exist.

While looking at the routes I noticed this:

```Ruby
resources :application_drafts, except: [:show, :destroy] do
  put :apply, on: :member
end
```

The `put :apply` route doesn't seem to have an action, is this right?