### PR TITLE
add some bootstrap magic to the teams form, close #152

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -438,3 +438,6 @@ h1.header
     top: 20px
     right: 19px
     text-align: right
+
+.form-btn-group
+  margin: 1em 0 2em

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -10,7 +10,8 @@
     Please see the #{link_to 'Help section', page_path('help')} for information about teams.
   = f.input :name, placeholder: 'Any name you like ...', label: 'Team Name'
 
-  h4 Members
+  .page-header
+    h2 Members
   fieldset
     = f.simple_fields_for :roles do |r|
       = r.input :github_handle, required: false
@@ -23,8 +24,10 @@
               label
                 = r.radio_button :name, role, required: true
                 = role.capitalize
-          = r.link_to_remove 'Remove team member'
-    = f.link_to_add 'Add another member', :roles
+          .form-btn-group
+            = r.link_to_remove 'Remove team member', class: 'btn btn-default'
+  .form-group.form-btn-group
+    = f.link_to_add 'Add another member', :roles, class: 'btn btn-primary col-sm-offset-3'
 
   - if !admin?
     = f.simple_fields_for :project do |p|
@@ -47,7 +50,8 @@
     - if can? :read, :users_info
       = f.input :post_info, label: 'Blog post info'
 
-  h4 Sources
+  .page-header
+    h2 Sources
 
   p.help-block
     | We will aggregate activities for all teams on the Activity page. Sources
@@ -67,8 +71,10 @@
               label
                 = s.radio_button :kind, kind, required: true
                 = kind.capitalize
-          = s.link_to_remove 'Remove'
-    = f.link_to_add 'Add another source', :sources
+          .form-btn-group
+            = s.link_to_remove 'Remove', class: 'btn btn-default'
+    .form-group.form-btn-group
+      = f.link_to_add 'Add another source', :sources, class: 'btn btn-primary col-sm-offset-3'
 
   - if admin?
     = f.input :season_id, as: :select, collection: Season.order('name DESC') { |e| [s.name, s.id] }


### PR DESCRIPTION
I can't do pixel perfect alignment since the nesting of the form elements is kind of scary (no offense!).
I don't want to touch the javascript right now, but if the 'add team member' forms were appended differently one could use the bootstrap grid as it should be.
But that's a different story