### PR TITLE
[RFC] Use a state machine to manage ApplicationDraft states

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'aws-sdk'
 
 gem 'rollbar', '~> 1.4.4'
 
+gem 'aasm'
+
 group :production do
   gem 'unicorn'
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (4.1.0)
     actionmailer (4.1.1)
       actionpack (= 4.1.1)
       actionview (= 4.1.1)
@@ -307,6 +308,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   aws-sdk
   better_errors
   bootstrap-kaminari-views

--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -95,7 +95,7 @@ class ApplicationDraftsController < ApplicationController
   end
 
   def disallow_modifications_after_submission
-    if application_draft.state.applied?
+    if application_draft.applied?
       redirect_to application_drafts_path, alert: 'You cannot modify this application anymore'
     end
   end

--- a/app/helpers/application_drafts_helper.rb
+++ b/app/helpers/application_drafts_helper.rb
@@ -1,14 +1,14 @@
 module ApplicationDraftsHelper
 
   def may_edit?(student)
-    application_draft.state.draft? &&
+    application_draft.draft? &&
       current_student &&
       current_student.id == student.try(:id)
 
   end
 
   def draft_state(draft)
-    label_class = draft.state.draft? ? 'label-default' : 'label-success'
+    label_class = draft.draft? ? 'label-default' : 'label-success'
     content_tag :span, draft.state.titleize, class: "label #{label_class}"
   end
 

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -84,9 +84,7 @@ class ApplicationDraft < ActiveRecord::Base
         self.applied_at = applied_at_time || Time.now
       end
 
-      # If the transition should only happen if the object is `ready?`,
-      # add a :guard => :ready? here
-      transitions :from => :draft, :to => :applied
+      transitions :from => :draft, :to => :applied, :guard => :ready?
     end
   end
 

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -71,11 +71,7 @@ class ApplicationDraft < ActiveRecord::Base
     false # valid?(:apply)
   end
 
-  def state
-    aasm_state
-  end
-
-  aasm :no_direct_assignment => true do
+  aasm :column => :state, :no_direct_assignment => true do
     state :draft, :initial => true
     state :applied
 

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -2,6 +2,8 @@ class ApplicationDraft < ActiveRecord::Base
 
   include HasSeason
 
+  include AASM
+
   # FIXME
   STUDENT0_REQUIRED_FIELDS = Student::REQUIRED_DRAFT_FIELDS.map { |m| "student0_#{m}" }
   STUDENT1_REQUIRED_FIELDS = Student::REQUIRED_DRAFT_FIELDS.map { |m| "student1_#{m}" }
@@ -69,8 +71,19 @@ class ApplicationDraft < ActiveRecord::Base
     false # valid?(:apply)
   end
 
-  def state
-    (applied_at? ? 'applied' : 'draft').inquiry
+  aasm :column => :state, :no_direct_assignment => true do
+    state :draft, :initial => true
+    state :applied
+
+    event :submit_application do
+      after do |applied_at_time = nil|
+        self.applied_at = applied_at_time || Time.now
+      end
+
+      # If the transition should only happen if the object is `ready?`,
+      # add a :guard => :ready? here
+      transitions :from => :draft, :to => :applied
+    end
   end
 
   private

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -71,7 +71,11 @@ class ApplicationDraft < ActiveRecord::Base
     false # valid?(:apply)
   end
 
-  aasm :column => :state, :no_direct_assignment => true do
+  def state
+    aasm_state
+  end
+
+  aasm :no_direct_assignment => true do
     state :draft, :initial => true
     state :applied
 

--- a/app/views/application_drafts/new.html.slim
+++ b/app/views/application_drafts/new.html.slim
@@ -36,8 +36,8 @@ p.attention
     -# = f.input :attended_rg_workshop, as: :text, label: 'Did you ever attend a Rails/Ruby workshop?', hint: ' Please give us a little bit of history about yourself and your pair (if any)', input_html: { rows: '5' }
     -# = f.input :skills, as: :text, label: 'Please give us a summary of your skills', hint: 'Please add a summary for your pair if you have one, too.', input_html: { rows: '5' }
     -# = f.input :learing_summary, as: :text, label: 'Please summarize what you have been doing to learn programming since your first workshop', hint: 'E.g. Study Group, learning rails by doing exercises etc. Please add a summary for your pair if you have one, too.', input_html: { rows: '5' }
-    = f.input :project_name, as: :string, label: 'What project are you planning to work on?', placeholder: 'Project Name', input_html: { disabled: !application_draft.as_student? || application_draft.state.applied? }
-    = f.input :project_url, as: :url, label: 'What project are you planning to work on?', placeholder: 'https://github.com/rails-girls-summer-of-code/projects/issues/NN', hint: "If the project you want to work on is not listed in #{link_to 'our repository', 'https://github.com/rails-girls-summer-of-code/projects/issues/', target: :blank} yet, ping the mentor to submit it.".html_safe, input_html: { disabled: !application_draft.as_student? || application_draft.state.applied? }
+    = f.input :project_name, as: :string, label: 'What project are you planning to work on?', placeholder: 'Project Name', input_html: { disabled: !application_draft.as_student? || application_draft.applied? }
+    = f.input :project_url, as: :url, label: 'What project are you planning to work on?', placeholder: 'https://github.com/rails-girls-summer-of-code/projects/issues/NN', hint: "If the project you want to work on is not listed in #{link_to 'our repository', 'https://github.com/rails-girls-summer-of-code/projects/issues/', target: :blank} yet, ping the mentor to submit it.".html_safe, input_html: { disabled: !application_draft.as_student? || application_draft.applied? }
 
   fieldset
     legend Filled in by coach(es)
@@ -48,18 +48,18 @@ p.attention
   fieldset
     legend Miscellaneous
     -# = f.input :project_period, as: :text, label: 'When do you plan to work on this?', hint: 'We are aiming at July 1st to September 30th for most students, but you can be flexible. Please discuss this with your team.', input_html: { rows: '5' }
-    = f.input :voluntary, as: :boolean, label: 'We could join the RGSoC as a voluntary team', input_html: { disabled: !application_draft.as_student? || application_draft.state.applied? }
-    = f.input :voluntary_hours_per_week, as: :integer, label: 'As a voluntary team, how many hours per week would you be able to work in the project?', input_html: { disabled: !application_draft.as_student? || application_draft.state.applied? }
-    = f.input :heard_about_it, as: :text, label: 'How have you heard about the program?', input_html: { rows: 3, disabled: !application_draft.as_student? || application_draft.state.applied? }
-    = f.input :misc_info, as: :text, label: 'Anything else to add?', input_html: { rows: 4 }, hint: 'Address anything that you feel is relevant to your application and was not covered previously.', input_html: { disabled: !application_draft.as_student? || application_draft.state.applied? }
+    = f.input :voluntary, as: :boolean, label: 'We could join the RGSoC as a voluntary team', input_html: { disabled: !application_draft.as_student? || application_draft.applied? }
+    = f.input :voluntary_hours_per_week, as: :integer, label: 'As a voluntary team, how many hours per week would you be able to work in the project?', input_html: { disabled: !application_draft.as_student? || application_draft.applied? }
+    = f.input :heard_about_it, as: :text, label: 'How have you heard about the program?', input_html: { rows: 3, disabled: !application_draft.as_student? || application_draft.applied? }
+    = f.input :misc_info, as: :text, label: 'Anything else to add?', input_html: { rows: 4 }, hint: 'Address anything that you feel is relevant to your application and was not covered previously.', input_html: { disabled: !application_draft.as_student? || application_draft.applied? }
 
-  - if application_draft.state.draft?
+  - if application_draft.draft?
     .actions
       = f.button :submit, 'Save as draft', class: 'btn'
       - unless application_draft.ready?
         .help-block Your application is not yet ready for submission
 
-- if application_draft.state.draft?
+- if application_draft.draft?
   - if application_draft.ready?
     = simple_form_for application_draft, url: apply_application_path(application_draft.application), method: :put do |f|
       .actions

--- a/db/migrate/20150324110320_add_application_draft_aasm_state_column.rb
+++ b/db/migrate/20150324110320_add_application_draft_aasm_state_column.rb
@@ -1,5 +1,5 @@
 class AddApplicationDraftAasmStateColumn < ActiveRecord::Migration
   def change
-    add_column :application_drafts, :state, :text, :default => 'draft', :null => false
+    add_column :application_drafts, :aasm_state, :text, :default => 'draft', :null => false
   end
 end

--- a/db/migrate/20150324110320_add_application_draft_aasm_state_column.rb
+++ b/db/migrate/20150324110320_add_application_draft_aasm_state_column.rb
@@ -1,0 +1,5 @@
+class AddApplicationDraftAasmStateColumn < ActiveRecord::Migration
+  def change
+    add_column :application_drafts, :state, :text, :default => 'draft', :null => false
+  end
+end

--- a/db/migrate/20150324110320_add_application_draft_aasm_state_column.rb
+++ b/db/migrate/20150324110320_add_application_draft_aasm_state_column.rb
@@ -1,5 +1,5 @@
 class AddApplicationDraftAasmStateColumn < ActiveRecord::Migration
   def change
-    add_column :application_drafts, :aasm_state, :text, :default => 'draft', :null => false
+    add_column :application_drafts, :state, :text, :default => 'draft', :null => false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150317173730) do
+ActiveRecord::Schema.define(version: 20150324110320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20150317173730) do
     t.datetime "updated_at"
     t.datetime "applied_at"
     t.integer  "updater_id"
+    t.text     "state",                       default: "draft", null: false
   end
 
   add_index "application_drafts", ["season_id"], name: "index_application_drafts_on_season_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 20150324110320) do
     t.datetime "updated_at"
     t.datetime "applied_at"
     t.integer  "updater_id"
-    t.text     "aasm_state",                  default: "draft", null: false
+    t.text     "state",                       default: "draft", null: false
   end
 
   add_index "application_drafts", ["season_id"], name: "index_application_drafts_on_season_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 20150324110320) do
     t.datetime "updated_at"
     t.datetime "applied_at"
     t.integer  "updater_id"
-    t.text     "state",                       default: "draft", null: false
+    t.text     "aasm_state",                  default: "draft", null: false
   end
 
   add_index "application_drafts", ["season_id"], name: "index_application_drafts_on_season_id", using: :btree

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe ApplicationDraftsController do
       end
 
       it 'will not update an application draft that has already been submitted' do
+        allow(draft).to receive(:ready?).and_return(true)
         draft.submit_application(1.hour.ago)
         draft.save
 

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -142,7 +142,9 @@ RSpec.describe ApplicationDraftsController do
       end
 
       it 'will not update an application draft that has already been submitted' do
-        draft.update applied_at: 1.hour.ago
+        draft.submit_application(1.hour.ago)
+        draft.save
+
         expect {
           patch :update, id: draft.to_param, application_draft: { misc_info: 'Foo!' }
         }.not_to change { draft.reload.misc_info }

--- a/spec/helpers/application_drafts_helper_spec.rb
+++ b/spec/helpers/application_drafts_helper_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ApplicationDraftsHelper do
         end
 
         context 'when the draft has been submitted' do
-          let(:application_draft) { ApplicationDraft.new(applied_at: 1.hour.ago) }
+          let(:application_draft) { ApplicationDraft.new.tap { |ad| ad.submit_application(1.hour.ago) } }
 
           it 'returns false' do
             expect(may_edit? student).to be_falsey

--- a/spec/helpers/application_drafts_helper_spec.rb
+++ b/spec/helpers/application_drafts_helper_spec.rb
@@ -62,7 +62,12 @@ RSpec.describe ApplicationDraftsHelper do
         end
 
         context 'when the draft has been submitted' do
-          let(:application_draft) { ApplicationDraft.new.tap { |ad| ad.submit_application(1.hour.ago) } }
+          let(:application_draft) do
+            ApplicationDraft.new.tap do |ad|
+              allow(ad).to receive(:ready?).and_return(true)
+              ad.submit_application(1.hour.ago)
+            end
+          end
 
           it 'returns false' do
             expect(may_edit? student).to be_falsey

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -220,6 +220,7 @@ RSpec.describe ApplicationDraft do
     end
 
     it 'returns "applied" when applied_at is set' do
+      allow(subject).to receive(:ready?).and_return(true)
       subject.submit_application(1.day.ago)
       expect(subject).to be_applied
     end

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -216,12 +216,12 @@ RSpec.describe ApplicationDraft do
 
   describe '#state' do
     it 'returns "draft" when applied_at is blank' do
-      expect(subject.state).to be_draft
+      expect(subject).to be_draft
     end
 
     it 'returns "applied" when applied_at is set' do
-      subject.applied_at = 1.day.ago
-      expect(subject.state).to be_applied
+      subject.submit_application(1.day.ago)
+      expect(subject).to be_applied
     end
   end
 


### PR DESCRIPTION
Previously, the state of an ApplicationDraft was controlled by setting
`*_by` attributes. While this works as long as there is a small number
of states, this gets complicated quickly if the possible states
increases, as well as managing transitions between states.

When an ApplicationDraft transitions from the 'draft' state to the
'applied' state by calling `submit_application`, it sets the
`applied_at` column to either a supplied DateTime, or the current
DateTime.

Missing/ToDo: The `ready?` method seems to be intended as a
guard to make sure an ApplicationDraft is ready to be submitted,
but it currently always returns false, and so it can't be used as a
transition guard.