### PR TITLE
Point Apple touch devices to correct path for icon

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -7,6 +7,7 @@ html
     = csrf_meta_tags
     = javascript_include_tag 'application'
     meta name="globalsign-domain-verification" content="lxWVzYarpxERoV37Oi163Dafdz4TSvi5e-7pAuWosV"
+    link rel="apple-touch-icon" href="/images/apple-touch-icon.png"
 
   body class=controller.controller_name
     = render 'layouts/header'


### PR DESCRIPTION
There already exists an `apple-touch-icon.png`, but it is not at the standard path. Add a `link` tag to the header so Apple touch devices use the correct path.