### PR TITLE
Validate readiness of ApplicationDraft

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -42,7 +42,7 @@ class ApplicationDraftsController < ApplicationController
   end
 
   def check
-    if application_draft.valid?(:apply)
+    if application_draft.ready?
       flash[:notice] = "You're ready to apply \o/"
     else
       flash[:alert]  = 'There are still some fields missing'

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -66,7 +66,7 @@ class ApplicationDraft < ActiveRecord::Base
   end
 
   def ready?
-    false # valid?(:apply)
+    valid?(:apply)
   end
 
   def state

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe ApplicationDraftsController do
 
       context 'for a valid draft' do
         before do
-          allow_any_instance_of(ApplicationDraft).to receive(:valid?).with(:apply).and_return(true)
+          allow_any_instance_of(ApplicationDraft).to receive(:ready?).and_return(true)
         end
 
         it 'is go' do

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -209,6 +209,10 @@ RSpec.describe ApplicationDraft do
   end
 
   describe '#ready?' do
+    before do
+      allow(subject).to receive(:students).and_return([])
+    end
+
     it 'returns false' do
       expect(subject).not_to be_ready
     end


### PR DESCRIPTION
This pull request enables the validation of `ApplicationDraft`'s `ready` state.

This brings us a step closer to completing #163.