### PR TITLE
Use ApplicationDrafts#apply controller action instead of that for Application

### DIFF
--- a/app/views/application_drafts/new.html.slim
+++ b/app/views/application_drafts/new.html.slim
@@ -61,7 +61,7 @@ p.attention
 
 - if application_draft.draft?
   - if application_draft.ready?
-    = simple_form_for application_draft, url: apply_application_path(application_draft.application), method: :put do |f|
+    = simple_form_for application_draft, url: apply_application_draft_path(application_draft.application), method: :put do |f|
       .actions
         = f.button :submit, 'Apply', class: 'btn btn-success'
   - elsif application_draft.persisted?


### PR DESCRIPTION
While working on #163, I took a look at the Rails routes, and saw that we don't have a controller action for `Application#apply`, but we do have one for `ApplicationDraft#apply`. Using this one instead fixes a few issues I've been having and makes sense to me. Any chance that this is the action we wanted to use?

Thanks in advance!