### PR TITLE
Properly display Application data field labels

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -18,6 +18,10 @@ class Application < ActiveRecord::Base
   scope :hidden, -> { where('applications.hidden IS NOT NULL and applications.hidden = ?', true) }
   scope :visible, -> { where('applications.hidden IS NULL or applications.hidden = ?', false) }
 
+  def self.data_label(key)
+    ApplicationDraft.human_attribute_name(key)
+  end
+
   def name
     [team.try(:name), project_name].reject(&:blank?).join ' - '
   end

--- a/app/views/applications/show.html.slim
+++ b/app/views/applications/show.html.slim
@@ -35,7 +35,7 @@
 
   h2 Submitted Application
   - @application.application_data.each do |title, value|
-    h4 = title
+    h4 = Application.data_label(title)
     p  = auto_link(simple_format(value || 'n/a'))
 
   #comments

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,8 @@ en:
         student0_application_location: Location during the summer (1st student)
         student0_banking_info: Banking Information (1st student)
         student0_application_minimum_money: Minimum Money (1st student)
+        student0_name: Name (1st student)
+        student1_name: Name (2nd student)
         student1_application_about: Background (2nd student)
         student1_application_motivation: Motivation (2nd student)
         student1_application_gender_identification: Gender Self-Identification (2nd student)
@@ -37,7 +39,9 @@ en:
         student1_application_location: Location during the summer (2nd student)
         student1_banking_info: Banking Information (2nd student)
         student1_application_minimum_money: Minimum Money (2nd student)
-
+        misc_info: Additional information
+        voluntary: Voluntary team
+        heard_about_it: How have you heard about the program?
 
       job_offer:
         paid: Paid?


### PR DESCRIPTION
This addresses #206 by adding some missing locale strings and displaying these in the `Application#show` view for the `Application`'s data.