### PR TITLE
Split up rating process and order fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.2.1'
+# ruby '2.2.1'
 
 gem 'rails', '~> 4.1.1'
 gem 'pg'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-# ruby '2.2.1'
+ruby '2.2.1'
 
 gem 'rails', '~> 4.1.1'
 gem 'pg'

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -201,6 +201,7 @@ nav
       display: block
       img
         width: 20px
+        height: 20px
 
     &.conferences
       td

--- a/app/controllers/applications/students_controller.rb
+++ b/app/controllers/applications/students_controller.rb
@@ -1,0 +1,22 @@
+class Applications::StudentsController < ApplicationController
+  # include ApplicationsHelper
+
+  # before_filter :store_filters, only: :index
+  # before_filter :persist_order, only: :index
+  # before_filter :checktime, only: [:new, :create]
+  before_action :authenticate_user!
+  before_filter -> { require_role 'reviewer' }, except: [:new, :create]
+  respond_to :html
+
+  def show
+    @student = User.find(params[:id])
+    @applications = @student.applications
+    @rating = @student.ratings.where(user: current_user).first_or_initialize
+    @data = RatingData.new(@rating.data)
+
+    # unless @application.hidden
+    #   @prev = prev_application
+    #   @next = next_application
+    # end
+  end
+end

--- a/app/controllers/applications/students_controller.rb
+++ b/app/controllers/applications/students_controller.rb
@@ -1,9 +1,4 @@
 class Applications::StudentsController < ApplicationController
-  # include ApplicationsHelper
-
-  # before_filter :store_filters, only: :index
-  # before_filter :persist_order, only: :index
-  # before_filter :checktime, only: [:new, :create]
   before_action :authenticate_user!
   before_filter -> { require_role 'reviewer' }, except: [:new, :create]
   respond_to :html
@@ -13,10 +8,5 @@ class Applications::StudentsController < ApplicationController
     @applications = @student.applications
     @rating = @student.ratings.where(user: current_user).first_or_initialize
     @data = RatingData.new(@rating.data)
-
-    # unless @application.hidden
-    #   @prev = prev_application
-    #   @next = next_application
-    # end
   end
 end

--- a/app/controllers/applications/teams_controller.rb
+++ b/app/controllers/applications/teams_controller.rb
@@ -8,11 +8,6 @@ class Applications::TeamsController < ApplicationController
     @applications = @team.applications
     @rating = find_or_initialize_rating(@team)
     @data = RatingData.new(@rating.data)
-
-    # unless @application.hidden
-    #   @prev = prev_application
-    #   @next = next_application
-    # end
   end
 
   private

--- a/app/controllers/applications/teams_controller.rb
+++ b/app/controllers/applications/teams_controller.rb
@@ -1,0 +1,23 @@
+class Applications::TeamsController < ApplicationController
+  before_action :authenticate_user!
+  before_filter -> { require_role 'reviewer' }, except: [:new, :create]
+  respond_to :html
+
+  def show
+    @team = Team.find(params[:id])
+    @applications = @team.applications
+    @rating = find_or_initialize_rating(@team)
+    @data = RatingData.new(@rating.data)
+
+    # unless @application.hidden
+    #   @prev = prev_application
+    #   @next = next_application
+    # end
+  end
+
+  private
+
+  def find_or_initialize_rating(rateable)
+    @team.ratings.find_or_initialize_by(user: current_user)
+  end
+end

--- a/app/controllers/applications/todos_controller.rb
+++ b/app/controllers/applications/todos_controller.rb
@@ -1,0 +1,26 @@
+class Applications::TodosController < ApplicationController
+  before_action :authenticate_user!
+  before_filter -> { require_role 'reviewer' }, except: [:new, :create]
+  respond_to :html
+
+  private
+
+    def students
+      @students ||= todo.students
+    end
+    helper_method :students
+
+    def teams
+      @teams ||= todo.teams
+    end
+    helper_method :teams
+
+    def applications
+      @applications ||= todo.applications
+    end
+    helper_method :applications
+
+    def todo
+      Application::Todo.new(current_user)
+    end
+end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -45,7 +45,9 @@ class ApplicationsController < ApplicationController
 
   def show
     @application = Application.find(params[:id])
+    @application_data = @application.data_for(:application, @application)
     @rating = find_or_initialize_rating
+    p @rating
     @data = RatingData.new(@rating.data)
     unless @application.hidden
       @prev = prev_application
@@ -115,9 +117,7 @@ class ApplicationsController < ApplicationController
   end
 
   def find_or_initialize_rating
-    @application.ratings.find_or_initialize_by(user: current_user) do |rating|
-      rating.data = Hashr.new(@application.rating_defaults)
-    end
+   Rating.where(user: current_user, rateable: @application).first_or_initialize
   end
 
   def prev_application

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -48,10 +48,6 @@ class ApplicationsController < ApplicationController
     @application_data = @application.data_for(:application, @application)
     @rating = find_or_initialize_rating
     @data = RatingData.new(@rating.data)
-    # unless @application.hidden
-    #   @prev = prev_application
-    #   @next = next_application
-    # end
   end
 
   private

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -48,10 +48,10 @@ class ApplicationsController < ApplicationController
     @application_data = @application.data_for(:application, @application)
     @rating = find_or_initialize_rating
     @data = RatingData.new(@rating.data)
-    unless @application.hidden
-      @prev = prev_application
-      @next = next_application
-    end
+    # unless @application.hidden
+    #   @prev = prev_application
+    #   @next = next_application
+    # end
   end
 
   private

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -47,7 +47,6 @@ class ApplicationsController < ApplicationController
     @application = Application.find(params[:id])
     @application_data = @application.data_for(:application, @application)
     @rating = find_or_initialize_rating
-    p @rating
     @data = RatingData.new(@rating.data)
     unless @application.hidden
       @prev = prev_application
@@ -117,7 +116,9 @@ class ApplicationsController < ApplicationController
   end
 
   def find_or_initialize_rating
-   Rating.where(user: current_user, rateable: @application).first_or_initialize
+    Rating.where(user: current_user, rateable: @application).first_or_initialize do |rating|
+      rating.data = Hashr.new(@application.rating_defaults)
+    end
   end
 
   def prev_application

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -5,7 +5,7 @@ class RatingsController < ApplicationController
   def create
     rating = find_or_initialize_rating
     rating.update_attributes(rating_params)
-    redirect_to params[:return_to]
+    redirect_to next_path(rating.rateable)
   end
 
   def update
@@ -34,4 +34,18 @@ class RatingsController < ApplicationController
     rating = rating.first_or_initialize
     rating
   end
+
+  def next_path(current)
+    if subject = Application::Todo.new(current_user, current).next
+      send(PATHS[subject.class.name.underscore.to_sym], subject)
+    else
+      Application
+    end
+  end
+
+  PATHS = {
+    user: 'applications_student_path',
+    team: 'applications_team_path',
+    application: 'application_path'
+  }
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,7 +100,7 @@ module ApplicationHelper
   end
 
   def country_for_application(application)
-    country = application.country.present? ? application.country : application.team.students.map(&:country).reject(&:blank?).join(', ')
+    country = application.country
     country = 'US' if country == 'United States of America'
     country = 'UK' if country == 'United Kingdom'
     country
@@ -179,6 +179,19 @@ module ApplicationHelper
     content_tag(:li, :class => :user) do
       avatar_url(member, size: 40) +
         link_to(member.name_or_handle, member)
+    end
+  end
+
+  def link_to_application_team_members(team, role = :member)
+    team.send(role.to_s.pluralize).sort_by(&:name_or_handle).map do |student|
+      link_to_application_team_member(student)
+    end.join.html_safe
+  end
+
+  def link_to_application_team_member(member)
+    content_tag(:li, :class => :user) do
+      avatar_url(member, size: 40) +
+        link_to(member.name_or_handle, applications_student_path(member))
     end
   end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -85,7 +85,7 @@ class Application < ActiveRecord::Base
   end
 
   def student_name
-    team.students.first.name
+    team.students.first.try(:name)
   end
 
   def country

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -76,12 +76,16 @@ class Application < ActiveRecord::Base
     [team.try(:name), project_name].reject(&:blank?).join(' - ')
   end
 
+  def team_name
+    team.name
+  end
+
   def project_name
     application_data['project_name']
   end
 
   def student_name
-    application_data['student_name']
+    team.students.first.name
   end
 
   def country

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,4 +1,54 @@
 class Application < ActiveRecord::Base
+  class Data < Struct.new(:data, :role, :subject)
+    ORDER = [
+      nil,
+
+      :student0_name, :student1_name,
+      :student0_application_location, :student1_application_location,
+      :student0_application_gender_identification, :student1_application_gender_identification,
+      :student0_application_minimum_money, :student1_application_minimum_money,
+      :student0_application_coding_level, :student1_application_coding_level,
+      :student0_application_skills, :student1_application_skills,
+      :student0_application_learning_period, :student1_application_learning_period,
+      :student0_application_learning_history, :student1_application_learning_history,
+      :student0_application_code_samples, :student1_application_code_samples,
+      :student0_application_about, :student1_application_about,
+      :student0_application_community_engagement, :student1_application_community_engagement,
+
+      :coaches_hours_per_week, :coaches_why_team_successful, :voluntary, :voluntary_hours_per_week, :heard_about_it,
+
+      :project_name, :project_url, :project_plan,
+    ]
+
+    def extract
+      sort(data.slice(*keys))
+    end
+
+    def keys
+      case role
+      when :student     then data.keys.grep(/^#{role}#{student_ix}/)
+      when :team        then data.keys.grep(/(voluntary|heard_about|coaches_hours|team)/)
+      when :application then data.keys.grep(/(project)/)
+      else raise("Unknown role for Application::Data: #{role}")
+      end
+    end
+
+    def student_ix
+      handle = subject.github_handle.downcase.gsub(/\d/, '')
+      name = subject.name.downcase.gsub(/\d/, '')
+      key = ['student0_name', 'student1_name'].detect do |key|
+        value = data[key].downcase
+        handle.include?(value) || name.include?(value) || value.include?(handle) || value.include?(name)
+      end
+      key.gsub(/\D/, '') if key
+    end
+
+    def sort(data)
+      keys = data.keys.map(&:to_sym).sort { |lft, rgt| (ORDER.index(lft) || 99) <=> (ORDER.index(rgt) || 99) }
+      keys.map(&:to_s).inject({}) { |result, key| result.merge(key => data[key]) }
+    end
+  end
+
   include HasSeason
 
   belongs_to :application_draft
@@ -12,7 +62,7 @@ class Application < ActiveRecord::Base
   FLAGS = [:hidden, :cs_student, :remote_team, :mentor_pick,
            :volunteering_team, :in_team, :duplicate, :selected, :remote_team]
 
-  has_many :ratings
+  has_many :ratings, as: :rateable
   has_many :comments
 
   scope :hidden, -> { where('applications.hidden IS NOT NULL and applications.hidden = ?', true) }
@@ -30,12 +80,20 @@ class Application < ActiveRecord::Base
     application_data['student_name']
   end
 
+  def country
+    @country ||= super.present? ? super : team.students.map(&:country).reject(&:blank?).join(', ')
+  end
+
   def location
     application_data['location']
   end
 
   def minimum_money
     application_data['minimum_money']
+  end
+
+  def data_for(role, subject)
+    Data.new(application_data, role, subject).extract
   end
 
   def average_skill_level
@@ -47,6 +105,10 @@ class Application < ActiveRecord::Base
     ratings.where(pick: true).count
   end
 
+  def rating
+    total_rating(:mean)
+  end
+
   def total_rating(type, options = {})
     total = calc_rating(type, options)
     total += COACHING_COMPANY_WEIGHT if coaching_company.present?
@@ -56,18 +118,11 @@ class Application < ActiveRecord::Base
   end
 
   def calc_rating(type, options)
-    types = { truncated: :mean, weighted: :wma }
-    values = ratings.map { |rating| rating.value(options) }.sort
-    values.shift && values.pop if type == :truncated
-    rating = values.size > 0 ? values.send(types[type] || type).round_to(1) : 0
-    rating
-  rescue
-    -1 # wma seems to have issues with less than 2 values
+    Rating::Calc.new(self, type, options).calc
   end
 
-  def rating_defaults
-    keys = [:women_priority, :skill_level, :practice_time, :project_time, :support]
-    keys.inject({}) { |defaults, key| defaults.merge(key => send("estimated_#{key}")) }
+  def combined_ratings
+    ratings.to_a + team.combined_ratings
   end
 
   def sponsor_pick?
@@ -82,68 +137,5 @@ class Application < ActiveRecord::Base
       flags_will_change!
       value != '0' ? flags.concat([flag.to_sym]).uniq : flags.delete(flag.to_sym)
     end
-  end
-
-  def estimated_women_priority
-    5 + (seems_to_have_pair? ? 5 : 0)
-  end
-
-  def estimated_skill_level
-    if seems_to_have_pair?
-      values = [student_skill_level, pair_skill_level].sort
-      ((values.first.to_f + values.last.to_f * 2) / 3).round
-    else
-    end
-  end
-
-  def estimated_practice_time
-    if seems_to_have_pair?
-      [student_practice_time.to_i, pair_practice_time.to_i].max
-    else
-      student_practice_time
-    end
-  end
-
-  def estimated_project_time
-    10
-  end
-
-  def estimated_support
-    value = application_data['hours_per_coach']
-    return unless value =~ /^\d+$/
-
-    case value.to_i
-    when 5 then 8
-    when 3 then 5
-    when 1 then 1
-    end
-  end
-
-  def seems_to_have_pair?
-    !!pair_skill_level
-  end
-
-  def student_skill_level
-    application_data['coding_level'].try(:to_i)
-  end
-
-  def pair_skill_level
-    application_data['coding_level_pair'].try(:to_i)
-  end
-
-  PRACTICE_TIME = {
-    'Between 1 and 3 months'  => 2,
-    'Between 3 and 6 months'  => 4,
-    'Between 6 and 9 months'  => 6,
-    'Between 9 and 12 months' => 8,
-    'More that 12 months'     => 10
-  }
-
-  def student_practice_time
-    PRACTICE_TIME[application_data['learning_since_workshop']]
-  end
-
-  def pair_practice_time
-    PRACTICE_TIME[application_data['learning_since_workshop_pair']]
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -93,6 +93,7 @@ class Application < ActiveRecord::Base
   end
 
   def data_for(role, subject)
+    p application_data
     Data.new(application_data, role, subject).extract
   end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -125,6 +125,11 @@ class Application < ActiveRecord::Base
     ratings.to_a + team.combined_ratings
   end
 
+  def rating_defaults
+    keys = [:women_priority, :skill_level, :practice_time, :project_time, :support]
+    keys.inject({}) { |defaults, key| defaults.merge(key => send("estimated_#{key}")) }
+  end
+
   def sponsor_pick?
     sponsor_pick.present?
   end
@@ -137,5 +142,69 @@ class Application < ActiveRecord::Base
       flags_will_change!
       value != '0' ? flags.concat([flag.to_sym]).uniq : flags.delete(flag.to_sym)
     end
+  end
+
+  def estimated_women_priority
+    5 + (seems_to_have_pair? ? 5 : 0)
+  end
+
+  def estimated_skill_level
+    if seems_to_have_pair?
+      values = [student_skill_level, pair_skill_level].sort
+      ((values.first.to_f + values.last.to_f * 2) / 3).round
+    else
+      student_skill_level
+    end
+  end
+
+  def estimated_practice_time
+    if seems_to_have_pair?
+      [student_practice_time.to_i, pair_practice_time.to_i].max
+    else
+      student_practice_time
+    end
+  end
+
+  def estimated_project_time
+    10
+  end
+
+  def estimated_support
+    value = application_data['coaches_hours_per_week']
+    return unless value =~ /^\d+$/
+
+    case value.to_i
+    when 5 then 8
+    when 3 then 5
+    when 1 then 1
+    end
+  end
+
+  def seems_to_have_pair?
+    !!pair_skill_level
+  end
+
+  def student_skill_level
+    application_data['student0_application_coding_level'].try(:to_i)
+  end
+
+  def pair_skill_level
+    application_data['student1_application_coding_level'].try(:to_i)
+  end
+
+  PRACTICE_TIME = {
+    'Between 1 and 3 months'  => 2,
+    'Between 3 and 6 months'  => 4,
+    'Between 6 and 9 months'  => 6,
+    'Between 9 and 12 months' => 8,
+    'More that 12 months'     => 10
+  }
+
+  def student_practice_time
+    PRACTICE_TIME[application_data['learning_since_workshop']]
+  end
+
+  def pair_practice_time
+    PRACTICE_TIME[application_data['learning_since_workshop_pair']]
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -73,7 +73,11 @@ class Application < ActiveRecord::Base
   end
 
   def name
-    [team.try(:name), project_name].reject(&:blank?).join ' - '
+    [team.try(:name), project_name].reject(&:blank?).join(' - ')
+  end
+
+  def project_name
+    application_data['project_name']
   end
 
   def student_name
@@ -93,7 +97,6 @@ class Application < ActiveRecord::Base
   end
 
   def data_for(role, subject)
-    p application_data
     Data.new(application_data, role, subject).extract
   end
 

--- a/app/models/application/table.rb
+++ b/app/models/application/table.rb
@@ -1,6 +1,14 @@
+require 'forwardable'
+
 class Application
   class Table
     class Row
+      extend Forwardable
+
+      def_delegators :application, :id, :location, :team_name, :project_name, :student_name,
+        :total_picks, :coaching_company, :average_skill_level, :mentor_pick, :volunteering_team?,
+        :remote_team, :cs_student, :in_team
+
       attr_reader :names, :application, :options
 
       def initialize(names, application, options)
@@ -9,20 +17,9 @@ class Application
         @options = options
       end
 
-      def id
-        application.id
-      end
-
-      def location
-        application.country
-      end
-
-      def total_picks
-        application.total_picks
-      end
-
       def total_rating(column, options)
-        application.total_rating(column, options)
+        rating = application.total_rating(column, options).to_f
+        rating.nan? ? 0.0 : rating
       end
 
       def ratings
@@ -61,12 +58,12 @@ class Application
 
     def sort(rows)
       case order = options[:order].to_sym
-      when :id, :location
-        rows.sort_by(&order)
       when :picks
         sort_by_picks(rows).reverse
-      when
+      when :mean, :median, :weighted, :truncated
         rows.sort_by { |row| row.total_rating(order, options) }.reverse
+      else
+        rows.sort_by(&order)
       end
     end
 

--- a/app/models/application/table.rb
+++ b/app/models/application/table.rb
@@ -9,6 +9,14 @@ class Application
         @options = options
       end
 
+      def id
+        application.id
+      end
+
+      def location
+        application.country
+      end
+
       def total_picks
         application.total_picks
       end
@@ -52,19 +60,12 @@ class Application
     end
 
     def sort(rows)
-      rows.sort_by do |row|
-        if options[:order] == 'picks'
-          row.total_picks
-        else
-          row.total_rating(order, options)
-        end
-      end.reverse
-    end
-
-    def sort(rows)
-      if options[:order] == 'picks'
+      case order = options[:order].to_sym
+      when :id, :location
+        rows.sort_by(&order)
+      when :picks
         sort_by_picks(rows).reverse
-      else
+      when
         rows.sort_by { |row| row.total_rating(order, options) }.reverse
       end
     end

--- a/app/models/application/todo.rb
+++ b/app/models/application/todo.rb
@@ -1,0 +1,94 @@
+class Application
+  class Todo < Struct.new(:user, :subject)
+    class TeamNotFound < StandardError
+      def initialize(subject)
+        super("Could not find team for #{subject.inspect}")
+      end
+    end
+
+    def next
+      detect_next_subject
+    rescue TeamNotFound => e
+      puts e.message, e.backtrace
+    end
+
+    def students
+      user_ids = Application.joins(team: :roles).where('roles.name' => :student).pluck(:user_id)
+      rated_ids = Rating.where(user: user, rateable_type: 'User').pluck(:rateable_id)
+      students = User.where(id: user_ids).order(:id)
+      students = students.where('id NOT IN (?)', rated_ids) unless rated_ids.empty?
+      students
+    end
+
+    def teams
+      rated_ids = Rating.where(user: user, rateable_type: 'Team').pluck(:rateable_id)
+      teams = Team.order(:id)
+      teams = teams.where('id NOT IN (?)', rated_ids) unless rated_ids.empty?
+      teams
+    end
+
+    def applications
+      rated_ids = Rating.where(user: user, rateable_type: 'Application').pluck(:rateable_id)
+      applications = Application.order(:id)
+      applications = applications.where('id NOT IN (?)', rated_ids) unless rated_ids.empty?
+      applications
+    end
+
+    private
+
+      def detect_next_subject
+        case subject
+        when nil
+          first_student
+        when Application
+          applications_rated? ? next_teams_first_student : next_team_application(subject.team)
+        when Team
+          next_team_application
+        when User
+          other = other_student
+          return other if other
+          rated?(current_team) ? next_team_application : current_team
+        end
+      end
+
+      def first_student
+        ids = Role.where(name: :student).pluck(:id)
+        User.where(id: ids).order(:id).first
+      end
+
+      def next_teams_first_student
+        ids = Rating.where(user: user, rateable_type: 'Team').pluck(:id)
+        team = Team.where('id > ? AND id NOT IN (?)', subject.team.id, ids).order(:id).first
+        team.students.first
+      end
+
+      def next_team_application(subject = self.subject)
+        subject.applications.detect { |application| !rated?(application) }
+      end
+
+      def applications_rated?
+        subject.team.applications.all? { |application| rated?(application) }
+      end
+
+      def students_rated?
+        current_team.students.all? { |student| rated?(student) }
+      end
+
+      def rated?(rateable)
+        Rating.where(user: user, rateable: rateable).exists?
+      end
+
+      def single_student_team?
+        current_team.students.size == 1
+      end
+
+      def current_team
+        @current_team ||= subject.teams.first or raise(TeamNotFound.new(subject))
+      end
+
+      def other_student
+        other = current_team.students.reject { |student| student.id == subject.id }.first
+        other if !rated?(other)
+      end
+  end
+end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,4 +1,41 @@
 class Rating < ActiveRecord::Base
+  class Calc
+    TYPES = { truncated: :mean, weighted: :wma }
+
+    attr_reader :subject, :type, :options
+
+    def initialize(subject, type = :mean, options = {})
+      @subject = subject
+      @type = type
+      @options = options
+    end
+
+    def calc
+      values = by_user.map(&:mean)
+      # p [subject.class.name, values].flatten
+      values.empty? ? 0 : values.send(TYPES[type] || type).round_to(1)
+    end
+
+    private
+
+      def by_user
+        groups = ratings.group_by(&:user_id).values
+        # groups.map { |ratings| ratings.map { |rating| rating.values(options) }.flatten }
+        groups.map { |ratings| ratings.map { |rating| rating.value(options) }.flatten }
+      end
+
+      def ratings
+        case subject
+        when Application
+          subject.ratings + subject.team.ratings + subject.team.students.map(&:ratings).flatten
+        when Team
+          subject.ratings + subject.students.map(&:ratings).flatten
+        when User
+          subject.ratings
+        end
+      end
+  end
+
   class << self
     def user_names
       User.find(pluck(:user_id).uniq).map(&:name)
@@ -9,7 +46,11 @@ class Rating < ActiveRecord::Base
     end
 
     def by(user)
-      where(user: user)
+      where(user_id: user.id)
+    end
+
+    def for(type, id)
+      where(rateable_type: type, rateable_id: id)
     end
   end
 
@@ -17,14 +58,29 @@ class Rating < ActiveRecord::Base
 
   belongs_to :application
   belongs_to :user
+  belongs_to :rateable, polymorphic: true
 
   def data
     Hashr.new(super)
   end
 
+  def woman?
+    data[:is_woman] == 1
+  end
+
   def value(options = {})
-    data = self.data
-    data = data.except(:bonus) unless options[:bonus_points]
-    data.values.sum
+    values = values(options)
+    values.empty? ? 0 : values.mean
+  end
+
+  def values(options = {})
+    data = self.data.except(:min_money, :is_woman)
+    data = data.merge(bonus: data[:bonus] + 10) if options[:bonus_points] && data[:bonus]
+    data.map { |key, value| weight_for(key, value) }
+  end
+
+  def weight_for(key, value)
+    return value unless WEIGHTS[key]
+    WEIGHTS[key][value] or raise("Unknown weight for #{key.inspect}/#{value.inspect}")
   end
 end

--- a/app/models/rating_data.rb
+++ b/app/models/rating_data.rb
@@ -7,7 +7,8 @@ class RatingData
 
   FIELDS = [
     :women_priority, :skill_level, :practice_time,
-    :project_time, :support, :planning, :bonus
+    :project_time, :support, :planning, :bonus,
+    :is_woman, :min_money
   ]
 
   attr_accessor *FIELDS

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -30,10 +30,10 @@ class Student < SimpleDelegator
 
   def current_drafts
     @current_drafts ||= if current_team
-                         current_team.application_drafts.current
-                       else
-                         []
-                       end
+      current_team.application_drafts.current
+    else
+      []
+    end
   end
 
   def current_draft

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -24,6 +24,7 @@ class Team < ActiveRecord::Base
   has_one :last_activity, -> { order('id DESC') }, class_name: 'Activity'
   has_many :comments
   belongs_to :event
+  has_many :ratings, as: :rateable
 
   accepts_nested_attributes_for :roles, :sources, :project, allow_destroy: true
 
@@ -42,6 +43,21 @@ class Team < ActiveRecord::Base
 
   def application
     @application ||= applications.where(season_id: Season.current.id).first
+  end
+
+  # def rating
+  #   values = students.map { |student| student.rating }.flatten
+  #   rating = values.empty? ? 0 : values.inject(&:+) / values.size
+  #   values = [rating] + ratings.map(&:value)
+  #   values.empty? ? 0 : values.sum.to_f / values.size
+  # end
+
+  def rating(type = :mean, options = { bonus_points: true })
+    Rating::Calc.new(self, type, options).calc
+  end
+
+  def combined_ratings
+    ratings.to_a + students.map { |student| student.ratings }.flatten
   end
 
   def set_number

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,8 +59,10 @@ class User < ActiveRecord::Base
   end
   has_many :teams, -> { uniq }, through: :roles
   has_many :application_drafts, through: :teams
+  has_many :applications, through: :teams
   has_many :attendances
   has_many :conferences, through: :attendances
+  has_many :ratings, as: :rateable
 
   validates :github_handle, presence: true, uniqueness: true
   validates :homepage, format: { with: URL_PREFIX_PATTERN }, allow_blank: true
@@ -107,7 +109,10 @@ class User < ActiveRecord::Base
     def with_interest(interest)
       where(":interest = ANY(interested_in)", interest: interest)
     end
+  end
 
+  def rating(type = :mean, options = {})
+    Rating::Calc.new(self, type, options).calc
   end
 
   def just_created?

--- a/app/views/applications/_application.html.slim
+++ b/app/views/applications/_application.html.slim
@@ -2,10 +2,12 @@
 
 tr class=application_classes_for(application)
   td = row_counter + 1
+  td.id
+    = link_to application.id, application
   td.team
-    = link_to application.team.name, application.team
+    = link_to application.team.name, applications_team_path(application.team)
   td.name
-    = link_to_team_members(application.team, :student)
+    = link_to_application_team_members(application.team, :student)
   td.project
     = format_application_project(application)
   td.location

--- a/app/views/applications/index.html.slim
+++ b/app/views/applications/index.html.slim
@@ -50,8 +50,8 @@ table#applications.table.table-striped.table-bordered.table-condensed.table-hove
         th = link_to_ordered 'R', :remote_team
       - if display_cs_students?
         th = link_to_ordered 'CS', :cs_student
-      - if display_in_teams?
-        th = link_to_ordered 'I', :in_teams
+      / - if display_in_teams?
+      /   th = link_to_ordered 'I', :in_team
       / - if display_duplicates?
       /   th = link_to_ordered 'D', :duplicate
 

--- a/app/views/applications/index.html.slim
+++ b/app/views/applications/index.html.slim
@@ -24,6 +24,7 @@ table#applications.table.table-striped.table-bordered.table-condensed.table-hove
   thead
     tr
       th #
+      th = link_to_ordered 'ID', :id
 
       th = link_to_ordered 'Team', :team_name
       th = link_to_ordered 'Student', :student_name
@@ -51,8 +52,8 @@ table#applications.table.table-striped.table-bordered.table-condensed.table-hove
         th = link_to_ordered 'CS', :cs_student
       - if display_in_teams?
         th = link_to_ordered 'I', :in_teams
-      - if display_duplicates?
-        th = link_to_ordered 'D', :duplicate
+      / - if display_duplicates?
+      /   th = link_to_ordered 'D', :duplicate
 
   tbody
     = render partial: 'applications/application', collection: @applications.rows, as: :row

--- a/app/views/applications/show.html.slim
+++ b/app/views/applications/show.html.slim
@@ -6,7 +6,7 @@
     = link_to @next ? 'Next &rarr;'.html_safe : '', @next, class: 'right'
 
 #application
-  h1 = "Application: #{@application.team.name}/#{@application.project_name} (#{@application.total_rating(:mean)})"
+  h1 = "Application: #{@application.name} (#{@application.total_rating(:mean)})"
 
   ul
     li = link_to "Team: #{@application.team.name} (#{@application.team.rating})", applications_team_path(@application.team)

--- a/app/views/applications/show.html.slim
+++ b/app/views/applications/show.html.slim
@@ -6,7 +6,14 @@
     = link_to @next ? 'Next &rarr;'.html_safe : '', @next, class: 'right'
 
 #application
-  h1 = @application.student_name
+  h1 = "Application: #{@application.team.name}/#{@application.project_name} (#{@application.total_rating(:mean)})"
+
+  ul
+    li = link_to "Team: #{@application.team.name} (#{@application.team.rating})", applications_team_path(@application.team)
+
+  ul
+    - @application.team.students.each do |student|
+      li = link_to "Student: #{student.name} (#{student.rating})", applications_student_path(student)
 
   h2 Additional Info
 
@@ -14,6 +21,7 @@
 
   p = @application.misc_info
 
+  = @application.coaching_company
   table.misc_info
     tbody
       tr
@@ -34,7 +42,7 @@
         td = format_application_flags(@application)
 
   h2 Submitted Application
-  - @application.application_data.each do |title, value|
+  - @application_data.each do |title, value|
     h4 = Application.data_label(title)
     p  = auto_link(simple_format(value || 'n/a'))
 
@@ -50,45 +58,17 @@
 
 
 #rating
-  = simple_form_for [@application, @rating] do |f|
+  = simple_form_for @rating do |f|
+    = hidden_field_tag :return_to, request.url
 
     = f.simple_fields_for :data, @data do |d|
+      = f.input :rateable_type, :as => :hidden, input_html: { value: @rating.rateable_type }
+      = f.input :rateable_id,   :as => :hidden, input_html: { value: @rating.rateable_id }
       = f.input :pick, label: "My Pick"
 
-      h3 A. Women get priority
-
-      .button_group
-        = d.collection_radio_buttons :women_priority, WOMEN_PRIORITY, :first, :last, checked: @data.women_priority
-
-      h3 B. Experience/skill level
-
-      = d.input :skill_level, as: :string, required: false, label: false, input_html: { value: @data.skill_level }
-      p.hint round([higher value] * 2 + [lower value]) / 3)
-
-      h3 C. Practice time
-
-      .button_group
-        = d.collection_radio_buttons :practice_time, PRACTICE_TIME, :first, :last, checked: @data.practice_time
-
-      h3 D. Project time
-
-      .button_group
-        = d.collection_radio_buttons :project_time, PROJECT_TIME, :first, :last, checked: @data.project_time
-
-      h3 E. Planning quality
-
+      h3 A. Planning quality
       .button_group
         = d.collection_radio_buttons :planning, PLANNING, :first, :last, checked: @data.planning
-
-      h3 F. Support
-
-      .button_group
-        = d.collection_radio_buttons :support, SUPPORT, :first, :last, checked: @data.support
-
-      h3 G. Extra points
-
-      = d.input :bonus, as: :string, required: false, label: false, input_html: { value: @data.bonus }
-      p.hint up to 10: great overall impression, women who have been discriminated against, have a difficult background etc.
 
     = f.submit 'Save'
 

--- a/app/views/applications/students/show.html.slim
+++ b/app/views/applications/students/show.html.slim
@@ -1,0 +1,50 @@
+// .nav
+//   - if @prev
+//     = link_to @prev ? '&larr; Previous'.html_safe : '', @prev, class: 'left'
+//   = link_to 'Overview', applications_path
+//   - if @next
+//     = link_to @next ? 'Next &rarr;'.html_safe : '', @next, class: 'right'
+
+#student
+  h1 = "Student: #{@student.name}"
+
+  ul
+    - @student.applications.each do |application|
+      = link_to "Application: #{application.team.name}/#{application.project_name} (#{application.total_rating(:mean)})", application
+
+  ul
+    - @student.teams.each do |team|
+       li = link_to "Team: #{team.name} (#{team.rating})", applications_team_path(team)
+
+  - @applications.each do |application|
+    h2 = "Submitted Application (#{application.project_name})"
+    - application.data_for(:student, @student).each do |title, value|
+      h4 = Application.data_label(title)
+      p  = auto_link(simple_format(value || 'n/a'))
+
+
+#rating
+  = simple_form_for @rating do |f|
+    = hidden_field_tag :return_to, request.url
+
+    = f.simple_fields_for :data, @data do |d|
+      = f.input :rateable_type, :as => :hidden, input_html: { value: @rating.rateable_type }
+      = f.input :rateable_id,   :as => :hidden, input_html: { value: @rating.rateable_id }
+
+      h3 A. Women get priority
+      p
+        = d.input :is_woman, checked: @data.is_woman, as: :boolean
+
+      h3 B. Experience/skill level
+      .button_group
+        = d.collection_radio_buttons :skill_level, SKILL_LEVELS, :first, :last, checked: @data.skill_level
+
+      h3 C. Minimum money
+      p
+        = d.input :min_money, as: :string, required: false, label: false, input_html: { value: @data.min_money }
+
+      h3 D. Practice time
+      .button_group
+        = d.collection_radio_buttons :practice_time, PRACTICE_TIME, :first, :last, checked: @data.practice_time
+
+    = f.submit 'Save'

--- a/app/views/applications/students/show.html.slim
+++ b/app/views/applications/students/show.html.slim
@@ -1,9 +1,9 @@
-// .nav
-//   - if @prev
-//     = link_to @prev ? '&larr; Previous'.html_safe : '', @prev, class: 'left'
-//   = link_to 'Overview', applications_path
-//   - if @next
-//     = link_to @next ? 'Next &rarr;'.html_safe : '', @next, class: 'right'
+.nav
+  - if @prev
+    = link_to @prev ? '&larr; Previous'.html_safe : '', @prev, class: 'left'
+  = link_to 'Overview', applications_path
+  - if @next
+    = link_to @next ? 'Next &rarr;'.html_safe : '', @next, class: 'right'
 
 #student
   h1 = "Student: #{@student.name}"

--- a/app/views/applications/students/show.html.slim
+++ b/app/views/applications/students/show.html.slim
@@ -10,7 +10,7 @@
 
   ul
     - @student.applications.each do |application|
-      li = link_to "Application: #{application.team.name}/#{application.project_name} (#{application.total_rating(:mean)})", application
+      li = link_to "Application: #{application.name} (#{application.total_rating(:mean)})", application
 
   ul
     - @student.teams.each do |team|

--- a/app/views/applications/students/show.html.slim
+++ b/app/views/applications/students/show.html.slim
@@ -10,7 +10,7 @@
 
   ul
     - @student.applications.each do |application|
-      = link_to "Application: #{application.team.name}/#{application.project_name} (#{application.total_rating(:mean)})", application
+      li = link_to "Application: #{application.team.name}/#{application.project_name} (#{application.total_rating(:mean)})", application
 
   ul
     - @student.teams.each do |team|

--- a/app/views/applications/teams/show.html.slim
+++ b/app/views/applications/teams/show.html.slim
@@ -1,9 +1,9 @@
-// .nav
-//   - if @prev
-//     = link_to @prev ? '&larr; Previous'.html_safe : '', @prev, class: 'left'
-//   = link_to 'Overview', applications_path
-//   - if @next
-//     = link_to @next ? 'Next &rarr;'.html_safe : '', @next, class: 'right'
+.nav
+  - if @prev
+    = link_to @prev ? '&larr; Previous'.html_safe : '', @prev, class: 'left'
+  = link_to 'Overview', applications_path
+  - if @next
+    = link_to @next ? 'Next &rarr;'.html_safe : '', @next, class: 'right'
 
 #team
   h1 = "Team: #{@team.name} (#{@team.rating})"

--- a/app/views/applications/teams/show.html.slim
+++ b/app/views/applications/teams/show.html.slim
@@ -10,7 +10,7 @@
 
   ul
     - @team.applications.each do |application|
-      = link_to "Application: #{@team.name}/#{application.project_name} (#{application.rating})", application
+      = link_to "Application: #{application.name} (#{application.rating})", application
 
   ul
     - @team.students.each do |student|

--- a/app/views/applications/teams/show.html.slim
+++ b/app/views/applications/teams/show.html.slim
@@ -1,0 +1,45 @@
+// .nav
+//   - if @prev
+//     = link_to @prev ? '&larr; Previous'.html_safe : '', @prev, class: 'left'
+//   = link_to 'Overview', applications_path
+//   - if @next
+//     = link_to @next ? 'Next &rarr;'.html_safe : '', @next, class: 'right'
+
+#team
+  h1 = "Team: #{@team.name} (#{@team.rating})"
+
+  ul
+    - @team.applications.each do |application|
+      = link_to "Application: #{@team.name}/#{application.project_name} (#{application.rating})", application
+
+  ul
+    - @team.students.each do |student|
+       li = link_to "Student: #{student.name} (#{student.rating})", applications_student_path(student)
+
+  - @applications.each do |application|
+    h2 = "Submitted Application (#{application.project_name})"
+    - application.data_for(:team, @team).each do |title, value|
+      h4 = Application.data_label(title)
+      p  = auto_link(simple_format(value || 'n/a'))
+
+#rating
+  = simple_form_for @rating do |f|
+    = hidden_field_tag :return_to, request.url
+
+    = f.simple_fields_for :data, @data do |d|
+      = f.input :rateable_type, :as => :hidden, input_html: { value: @rating.rateable_type }
+      = f.input :rateable_id,   :as => :hidden, input_html: { value: @rating.rateable_id }
+
+      h3 A. Support
+      .button_group
+        = d.collection_radio_buttons :support, SUPPORT, :first, :last, checked: @data.support
+
+      h3 B. Extra points
+      = d.input :bonus, as: :string, required: false, label: false, input_html: { value: @data.bonus }
+      p.hint up to 10: great overall impression, women who have been discriminated against, have a difficult background etc.
+
+    = f.submit 'Save'
+
+      h3 H. Mentor pick
+      h3 I. Sponsor pick
+      p these can to be global ...

--- a/app/views/applications/todos/index.html.slim
+++ b/app/views/applications/todos/index.html.slim
@@ -1,0 +1,20 @@
+h1 Students
+
+ul
+  - students.each do |student|
+    li
+      = link_to student.name, applications_student_path(student)
+
+h1 Teams
+
+ul
+  - teams.each do |team|
+    li
+      = link_to team.name, applications_team_path(team)
+
+h1 Applications
+
+ul
+  - applications.each do |application|
+    li
+      = link_to application.name, application_path(application)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,6 +4,8 @@
 GITHUB_APP_ID     = Rails.env.production? ? ENV['GITHUB_APP_ID']     : 'cc17063f6602cc4878ff'
 GITHUB_APP_SECRET = Rails.env.production? ? ENV['GITHUB_APP_SECRET'] : 'e93988593b6f7bfa1d0ff2cf10438ee3e547f8a4'
 
+OmniAuth.config.full_host = "http://localhost:3000" # wat, keeps missing the port for the redirect_uri without this
+
 Devise.setup do |config|
   config.omniauth :github, GITHUB_APP_ID, GITHUB_APP_SECRET, :scope => 'user:email'
   config.secret_key = ENV['DEVISE_SECRET'] || 'adc96b68ccb1630810f073823ea5f942df52649385b04e18223b845dd66c7f48ca9641ca2ed456ae4755fbb24f7b08e2ceaeaa21cac8e0aead38a9f60e831392'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@
 GITHUB_APP_ID     = Rails.env.production? ? ENV['GITHUB_APP_ID']     : 'cc17063f6602cc4878ff'
 GITHUB_APP_SECRET = Rails.env.production? ? ENV['GITHUB_APP_SECRET'] : 'e93988593b6f7bfa1d0ff2cf10438ee3e547f8a4'
 
-OmniAuth.config.full_host = "http://localhost:3000" # wat, keeps missing the port for the redirect_uri without this
+# OmniAuth.config.full_host = "http://localhost:3000" # wat, keeps missing the port for the redirect_uri without this
 
 Devise.setup do |config|
   config.omniauth :github, GITHUB_APP_ID, GITHUB_APP_SECRET, :scope => 'user:email'

--- a/config/initializers/ratings.rb
+++ b/config/initializers/ratings.rb
@@ -1,37 +1,75 @@
-WOMEN_PRIORITY = [
-  [10, '2 women pair'] ,
-  [5, 'mixed pair or single women'],
-  [0, 'men pair']
-]
+# WOMEN_PRIORITY = [
+#   [10, '2 women pair'] ,
+#   [5, 'mixed pair or single women'],
+#   [0, 'men pair']
+# ]
+#
+# PRACTICE_TIME = [
+#   [0, 'less than a month'],
+#   [1, '1-3 months'],
+#   [2, '3-6 months'],
+#   [4, '6-9 months'],
+#   [8, '9-12 months'],
+#   [10, 'more than 12 months']
+# ]
+#
+# SUPPORT = [
+#   [10, 'fulltime support'],
+#   [8, '5-8 hours a day'],
+#   [5, '3-4 hours a day'],
+#   [3, '1-2 hours a day'],
+#   [1, '1 hour a day']
+# ]
+#
+# PLANNING = [
+#   [5,  'has a proper is a plan'],
+#   [1,  'project named or week plan'],
+#   [0,  'project undecided']
+# ]
 
-PROJECT_TIME = [
-  [10, 'full 3 months'],
-  [7, '2-3 months'],
-  [0, 'less than 2 months']
+WOMEN_PRIORITY = [
+  [0, '2 women pair'],
+  [1, 'mixed pair or single women'],
+  [2, 'men pair']
 ]
 
 PRACTICE_TIME = [
-  [0, 'less than a month'],
-  [2, '1-3 months'],
-  [4, '3-6 months'],
-  [6, '6-9 months'],
-  [8, '9-12 months'],
-  [10, 'more than 12 months']
+  [0, 'more than 12 months'],
+  [1, '9-12 months'],
+  [2, '6-9 months'],
+  [3, '3-6 months'],
+  [4, '1-3 months'],
+  [5, 'less than a month'],
+]
+
+SKILL_LEVELS = [
+  [0, '5: Is used to refactoring'],
+  [1, '4: Has contributed to Open Source'],
+  [2, '3: Can write a unit test'],
+  [3, '2: Can write a method'],
+  [4, '1: Knows data types'],
 ]
 
 SUPPORT = [
-  [10, 'fulltime support'],
-  [8, '5 hours a day'],
-  [5, '3 hours a day'],
-  [1, '1 hour a day']
+  [0, 'fulltime support'],
+  [1, '5-6 hours a day'],
+  [2, '3-4 hours a day'],
+  [3, '1-2 hours a day'],
+  [4, '1 hour a day']
 ]
 
 PLANNING = [
-  [10, 'very thorough plan'],
-  [5,  'there is a plan'],
-  [2,  'project named'],
-  [0,  'project undecided']
+  [0,  'has a proper is a plan'],
+  [1,  'project named or weak plan'],
+  [2,  'project undecided']
 ]
+
+WEIGHTS = {
+  practice_time: [10, 6, 3, 2, 1, 0],
+  skill_level:   [10, 6, 3, 1, 0],
+  support:       [10, 8, 6, 4, 2],
+  planning:      [10, 6, 0]
+}
 
 SPONSOR_PICK = 20
 MENTOR_PICK = 10

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,9 +28,12 @@ RgsocTeams::Application.routes.draw do
   resources :attendances
   resources :contributors, only: :index
 
+  namespace :applications do
+    get 'students/:id', to: 'students#show', as: 'student'
+    get 'teams/:id', to: 'teams#show', as: 'team'
+    get 'todos', to: 'todos#index', as: 'todos'
+  end
   resources :applications
-  get 'applications/students/:id', to: 'applications/students#show', as: 'applications_student'
-  get 'applications/teams/:id', to: 'applications/teams#show', as: 'applications_team'
   resources :ratings
 
   resources :application_drafts, except: [:show, :destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,9 +28,10 @@ RgsocTeams::Application.routes.draw do
   resources :attendances
   resources :contributors, only: :index
 
-  resources :applications do
-    resources :ratings
-  end
+  resources :applications
+  get 'applications/students/:id', to: 'applications/students#show', as: 'applications_student'
+  get 'applications/teams/:id', to: 'applications/teams#show', as: 'applications_team'
+  resources :ratings
 
   resources :application_drafts, except: [:show, :destroy] do
     member do

--- a/db/migrate/20150418105037_ratings_polymorphic_rateable.rb
+++ b/db/migrate/20150418105037_ratings_polymorphic_rateable.rb
@@ -1,0 +1,7 @@
+class RatingsPolymorphicRateable < ActiveRecord::Migration
+  def change
+    add_column :ratings, :rateable_id, :integer
+    add_column :ratings, :rateable_type, :string
+    add_index :ratings, [:rateable_id, :rateable_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150413192627) do
+ActiveRecord::Schema.define(version: 20150418105037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,8 +49,8 @@ ActiveRecord::Schema.define(version: 20150413192627) do
     t.datetime "applied_at"
     t.integer  "updater_id"
     t.text     "state",                       default: "draft", null: false
-    t.integer  "position"
     t.text     "project_plan"
+    t.integer  "position"
     t.integer  "signed_off_by"
   end
 
@@ -160,13 +160,17 @@ ActiveRecord::Schema.define(version: 20150413192627) do
   end
 
   create_table "ratings", force: true do |t|
-    t.integer  "application_id"
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
     t.boolean  "pick"
+    t.integer  "application_id"
+    t.integer  "rateable_id"
+    t.string   "rateable_type"
   end
+
+  add_index "ratings", ["rateable_id", "rateable_type"], name: "index_ratings_on_rateable_id_and_rateable_type", using: :btree
 
   create_table "roles", force: true do |t|
     t.integer  "team_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,8 +49,8 @@ ActiveRecord::Schema.define(version: 20150418105037) do
     t.datetime "applied_at"
     t.integer  "updater_id"
     t.text     "state",                       default: "draft", null: false
-    t.text     "project_plan"
     t.integer  "position"
+    t.text     "project_plan"
     t.integer  "signed_off_by"
   end
 
@@ -160,12 +160,12 @@ ActiveRecord::Schema.define(version: 20150418105037) do
   end
 
   create_table "ratings", force: true do |t|
+    t.integer  "application_id"
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
     t.boolean  "pick"
-    t.integer  "application_id"
     t.integer  "rateable_id"
     t.string   "rateable_type"
   end

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -2,12 +2,12 @@ FactoryGirl.define do
   factory :application do
     team
     application_data {{
-      coding_level: 2,
+      student0_application_coding_level: 2,
+      student1_application_coding_level: 2,
       student_name: FFaker::Name.name,
       location: FFaker::Address.city,
       minimum_money: rand(100),
-      coding_level_pair: 5,
-      hours_per_coach: 3
+      coaches_hours_per_week: 3
     }}
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -117,7 +117,7 @@ describe Application do
           1 => 1
         }
         hours.each do |key, value|
-          allow(subject).to receive(:application_data).and_return('hours_per_coach' => key.to_s)
+          allow(subject).to receive(:application_data).and_return('coaches_hours_per_week' => key.to_s)
           expect(subject.estimated_support).to eq(value)
         end
       end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -29,7 +29,7 @@ describe Application do
 
     it 'derives its name from its team and project name' do
       subject.team = build_stubbed(:team, name: 'Foobar')
-      subject.project_name = 'Hello World'
+      subject.application_data['project_name'] = 'Hello World'
 
       expect(subject.name).to eql 'Foobar - Hello World'
     end
@@ -83,8 +83,17 @@ describe Application do
     end
   end
 
+  describe 'student_name' do
+    let(:team)    { FactoryGirl.build(:team, students: [student]) }
+    let(:student) { FactoryGirl.build(:student) }
+
+    before { allow(subject).to receive(:team).and_return(team) }
+
+    it { expect(subject.student_name).to eq student.name }
+  end
+
   describe 'proxy methods' do
-    proxy_methods = %w(student_name location minimum_money)
+    proxy_methods = %w(location minimum_money)
 
     proxy_methods.each do |key|
       describe key do


### PR DESCRIPTION
Ratings were previously given per application. We have split up the application creation process so people do not have to enter their, e.g. students or team details twice. 

This change also splits up the rating process in the same way. I.e. ratings to students are given based on  student-related fields, ratings to teams are given based on team-related fields, etc.

Also, fields displayed are now sorted by, kinda, relevance and topic, on each of the respective pages.

# TODO

- [x] After creating a rating for a student, redirect to the user rating page for the next student. once both students were rated, redirect to their team rating page, then their application pages. Then redirect to the next student on the next team, and so on.
- [x] Have a todo list for selection committee members: Link to users, teams and applications that do not have a rating from `current_user`, yet.
- [x] Fix sorting for some of the headers.
- [x] Fix displaying the project name