### PR TITLE
added mentors to list of mailable roles

### DIFF
--- a/app/models/mailing.rb
+++ b/app/models/mailing.rb
@@ -1,5 +1,5 @@
 class Mailing < ActiveRecord::Base
-  TO = %w(teams students coaches helpdesk organizers supervisors developers)
+  TO = %w(teams students coaches helpdesk organizers supervisors developers mentors)
 
   serialize :to
 


### PR DESCRIPTION
This is to add the mentors role to the list of available roles to send an email to.

specs were run, no failures.