### PR TITLE
minor styling fix to team show view in rating area

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -428,6 +428,9 @@ h1.header
   .comment p
     font-size: 1em
 
+#team
+  margin-right: 420px
+
 #content .well h3
   padding: 0
   margin-top: 0


### PR DESCRIPTION
this keeps the text from being hidden by the rating box. it's not perfect (the margin on the left is still weird, for some reason), but it's a start.