### PR TITLE
Dont show teams without apps in todos

### DIFF
--- a/app/controllers/applications/todos_controller.rb
+++ b/app/controllers/applications/todos_controller.rb
@@ -6,6 +6,8 @@ class Applications::TodosController < ApplicationController
   include TodoHelper
 
   def index
-    @teams = Team.includes(:students, :applications)
+    @teams = Team.joins(:applications)
+                 .where('"applications_count" > 0')
+                 .includes(:students, :applications)
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -52,7 +52,7 @@ class Application < ActiveRecord::Base
   include HasSeason
 
   belongs_to :application_draft
-  belongs_to :team
+  belongs_to :team, inverse_of: :applications, counter_cache: true
   belongs_to :signatory, class_name: 'User', foreign_key: :signed_off_by
 
   validates :team, :application_data, presence: true

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -12,7 +12,7 @@ class Team < ActiveRecord::Base
   attr_accessor :checked
 
   has_one :project, dependent: :destroy
-  has_many :applications, dependent: :nullify
+  has_many :applications, dependent: :nullify, inverse_of: :team
   has_many :application_drafts, dependent: :nullify
   has_many :roles, dependent: :destroy
   has_many :members, class_name: 'User', through: :roles, source: :user

--- a/db/migrate/20150430091437_add_applications_count_to_teams.rb
+++ b/db/migrate/20150430091437_add_applications_count_to_teams.rb
@@ -1,0 +1,14 @@
+class AddApplicationsCountToTeams < ActiveRecord::Migration
+  def up
+    add_column :teams, :applications_count, :integer, null: false, default: 0
+    add_index :teams, :applications_count
+
+    Team.find_each do |team|
+      Team.reset_counters team.id, :applications
+    end
+  end
+
+  def down
+    remove_column :teams, :applications_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150418134622) do
+ActiveRecord::Schema.define(version: 20150430091437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,8 +49,8 @@ ActiveRecord::Schema.define(version: 20150418134622) do
     t.datetime "applied_at"
     t.integer  "updater_id"
     t.text     "state",                       default: "draft", null: false
-    t.text     "project_plan"
     t.integer  "position"
+    t.text     "project_plan"
     t.integer  "signed_off_by"
   end
 
@@ -215,8 +215,8 @@ ActiveRecord::Schema.define(version: 20150418134622) do
 
   create_table "teams", force: true do |t|
     t.string   "name"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.string   "log_url"
     t.text     "description"
     t.integer  "number"
@@ -230,9 +230,11 @@ ActiveRecord::Schema.define(version: 20150418134622) do
     t.date     "last_checked_at"
     t.integer  "last_checked_by"
     t.integer  "season_id"
-    t.boolean  "invisible",       default: false
+    t.boolean  "invisible",          default: false
+    t.integer  "applications_count", default: 0,     null: false
   end
 
+  add_index "teams", ["applications_count"], name: "index_teams_on_applications_count", using: :btree
   add_index "teams", ["season_id"], name: "index_teams_on_season_id", using: :btree
 
   create_table "users", force: true do |t|

--- a/spec/controllers/applications/todos_controller_spec.rb
+++ b/spec/controllers/applications/todos_controller_spec.rb
@@ -7,6 +7,7 @@ describe Applications::TodosController, type: :controller do
     let(:role) { FactoryGirl.create(:reviewer_role, team: nil) }
     let(:current_user) { role.user }
     let!(:teams) { FactoryGirl.create_list(:team, 2, :applying_team, :with_applications) }
+    let!(:team_without_application) { FactoryGirl.create(:team) }
     let!(:team_rating) { teams.sample.ratings.create(user: current_user) }
     let!(:student_rating) { teams.sample.students.sample.ratings.create(user: current_user) }
     let!(:application_rating) { teams.sample.applications.sample.ratings.create(user: current_user) }
@@ -20,7 +21,11 @@ describe Applications::TodosController, type: :controller do
     end
 
     it 'assigns @teams' do
-      expect(assigns(:teams)).to eq(Team.all)
+      expect(assigns(:teams)).to match_array(teams)
+    end
+
+    it '@teams does not include teams without applications' do
+      expect(assigns(:teams)).to_not include(team_without_application)
     end
 
     it 'renders the tables' do


### PR DESCRIPTION
I understand the todos page shouldn't show teams that don't have applications. This PR should resolve that.

Note: I'm using a counter_cache of applications on teams. While it is possible to use a join to count, it's terribly inefficient.