### PR TITLE
Implement claiming and tweeting about conferences

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 
 require 'cgi'
+require 'uri'
 module ApplicationHelper
 
   TIMEZONES = ActiveSupport::TimeZone.all.map{|t| t.tzinfo.name}.uniq.sort
@@ -18,6 +19,11 @@ module ApplicationHelper
     else
       link_to 'Apply now', apply_path
     end
+  end
+
+  def conference_tweet_link(conference)
+    tweet = "I really want to go to #{conference.name} this year! #{conference.twitter} @Railsgirlssoc"
+    "https://twitter.com/intent/tweet?text=#{URI.escape(tweet)}"
   end
 
   def avatar_url(user, size: 200)

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -46,6 +46,17 @@
   h3.page-header I am interested in:
 
   = f.collection_check_boxes :interested_in, User::INTERESTS.to_a, :first, :last, item_wrapper_tag: 'div', item_wrapper_class: 'interested_in'
+      
+  - if Conference.any?
+    h3.page-header Conferences
+    fieldset.conferences
+      .header
+        label Conference
+      = f.simple_fields_for :attendances do |s|
+        = s.input :conference_id, as: :select, collection: conferences, required: false, label: false
+        
+        = s.link_to_remove 'Remove'
+      = f.link_to_add 'I want to attend a conference!', :attendances, class: 'btn btn-primary form-btn-group'
 
   h3.page-header Private information
   p.help-block This information will only be visible to yourself and organizers.

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -48,10 +48,12 @@ nav.actions
     ul.conferences
       - @user.attendances.includes(:conference).order('conferences.starts_on').each do |a|
         li
-          p
-            ' #{link_to a.conference.name, a.conference}
-            ' (#{a.conference.location}, #{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
-          - if can?(:crud, a)
+          - if @user == current_user
+            p
+              ' #{link_to a.conference.name, a.conference}
+              ' (#{a.conference.location}, #{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
+              ' #{link_to "Tweet About It!", conference_tweet_link(a.conference), class: 'btn btn-default'}
+          - if can?(:crud, a) and admin?
             ul.actions
               - if a.confirmed?
                 li Confirmed


### PR DESCRIPTION
The tweet will be automatically generated to include the name of the
conference as well as its twitter username and that of Rails Girls
Summer of Code.

Students can pick confs when editing their profile from those added and can 'claim' that they want to go to them. They can then tweet their desire to attend.

An example of the tweet is shown below:
"I really want to go to eurucamp this year! @ eurucamp @ Railsgirlssoc"