### PR TITLE
updates supervisor read permissions for user profile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,3 +401,6 @@ DEPENDENCIES
   uglifier (~> 2.5.0)
   unicorn
   webmock
+
+BUNDLED WITH
+   1.10.4

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -47,7 +47,7 @@ class Ability
     can :crud, Mailing    if user.admin?
     can :crud, Submission if user.admin?
     can :crud, :comments  if user.admin?
-    can :read, :users_info if user.admin?
+    can :read, :users_info if user.admin? || user.supervisor?
 
     # activities
     can :read, :feed_entry

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -127,6 +127,10 @@ class User < ActiveRecord::Base
     roles.admin.any?
   end
 
+  def supervisor?
+    roles.supervisor.any?
+  end
+
   def student?
     roles.student.any?
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -51,6 +51,36 @@ describe Ability do
         end
       end
 
+      describe 'to read user info' do
+        context 'if not an admin or supervisor' do
+          before do
+            allow(user).to receive(:admin?).and_return(false)
+            allow(user).to receive(:supervisor?).and_return(false)
+          end
+
+          it { expect(ability).not_to be_able_to(:read, :users_info) }
+        end
+
+        context 'if an admin' do
+          before do
+            allow(user).to receive(:admin?).and_return(true)
+            allow(user).to receive(:supervisor?).and_return(false)
+          end
+
+          it { expect(ability).to be_able_to(:read, :users_info) }
+        end
+
+        context 'if a supervisor' do
+          before do
+            allow(user).to receive(:admin?).and_return(false)
+            allow(user).to receive(:supervisor?).and_return(true)
+          end
+
+          it { expect(ability).to be_able_to(:read, :users_info) }
+        end
+
+      end
+
       describe 'access to mailings' do
         let!(:mailing) { Mailing.new }
         let!(:user) { FactoryGirl.create(:student) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -182,6 +182,18 @@ describe User do
     end
   end
 
+  describe '#supervisor?' do
+    it 'returns false for users w/o a role' do
+      expect(subject).not_to be_supervisor
+    end
+
+    it 'returns true if user has a supervisor role' do
+      supervisor = FactoryGirl.create(:supervisor)
+      expect(supervisor).to be_supervisor
+    end
+  end
+
+
   describe '#current_student?' do
     it 'returns false for users w/o a role' do
       expect(subject).not_to be_current_student


### PR DESCRIPTION
This does the following things to solve issue #236 

- updates the permissions for supervisors to a 'read' permission for a user's email address on their profile page i.e. the 'show' view for a user
https://teams.railsgirlssummerofcode.org/users/user-id
- implements three new tests in 'ability_spec'
_1. context 'if not an admin or supervisor'_
_2. context 'if an admin'_
_3. context 'if a supervisor'_
- implements two new tests in 'user_spec', under describe '#supervisor?'

Anyway, please review and let me know what you think.


