### PR TITLE
fixes contributors json to include all supervisors

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -6,7 +6,7 @@ class Role < ActiveRecord::Base
   ADMIN_ROLES = %w(organizer developer)
   ROLES = TEAM_ROLES + OTHER_ROLES + ADMIN_ROLES
 
-  GUIDE_ROLES = %w(coach mentor)
+  GUIDE_ROLES = %w(coach mentor supervisor)
   CONTRIBUTOR_ROLES = ADMIN_ROLES + GUIDE_ROLES
 
   belongs_to :user


### PR DESCRIPTION
This should fix issue #249

Would like to create another issue to cache the json file as it take a bucket load of time to load.

Note:  'supervisors' have been added to the 'GUIDE_ROLES'. This has a side effect of adding supervisors to any 'team' email that is sent out. I would like to confirm that this is ok, before merging.

