### PR TITLE
teams info page fixes

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -34,7 +34,7 @@ class Team < ActiveRecord::Base
 
   class << self
     def ordered(sort = {})
-      order([sort[:order] || 'kind, name || projects', sort[:direction] || 'asc'].join(' '))
+      order([sort[:order] || 'kind, name', sort[:direction] || 'asc'].join(' '))
     end
 
     def visible

--- a/app/views/teams_info/index.html.slim
+++ b/app/views/teams_info/index.html.slim
@@ -5,7 +5,7 @@ h1.header
 table.table.table-striped.table-bordered.table-condensed
   tr
     th Name
-    th Students (irc)
+    th Students
     th = sortable "created_at", "Last Activity"
     - if admin?
       th Blog post


### PR DESCRIPTION
this fixes issue #252. The projects column in the teams table was removed last year from the database, and this was a simple side-effect of it.