### PR TITLE
Conference feature improvements

### DIFF
--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -103,15 +103,6 @@
     = f.input :application_minimum_money, as: :text, label: 'How much money do you need at the very minimum per month to sustain yourself while working fulltime on an Open Source project? Please give a short summary of your costs including rent, living costs, special circumstances.', hint: 'The total of the stipend will be decided on case-by-case basis, taking into consideration data from the world bank plus individual living situations.', input_html: { rows: 4 }
 
   - if admin?
-    h3.page-header Conferences
-    fieldset.conferences
-      .header
-        label Conference
-      = f.simple_fields_for :attendances do |s|
-        = s.input :conference_id, as: :select, collection: conferences, required: false, label: false
-        = s.link_to_remove 'Remove'
-      = f.link_to_add 'Add another conference', :attendances, class: 'btn btn-primary form-btn-group'
-
     h3.page-header Roles
     = f.simple_fields_for :roles do |r|
         = r.input :team_id, as: :select, collection: @teams, required: false

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -54,7 +54,7 @@
       .header
         label Conference
       = f.simple_fields_for :attendances do |s|
-        = s.input :conference_id, as: :select, collection: conferences, required: false, label: false
+        = s.input :conference_id, as: :select, collection: conferences, required: false, label: false, selected: 1
         
         = s.link_to_remove 'Remove'
       = f.link_to_add 'I want to add another conference!', :attendances, class: 'btn btn-primary form-btn-group'

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -54,7 +54,7 @@
       .header
         label Conference
       = f.simple_fields_for :attendances do |s|
-        = s.input :conference_id, as: :select, collection: conferences, required: false, label: false, selected: 1
+        = s.input :conference_id, as: :select, collection: conferences, required: false, label: false, default: 1
         
         = s.link_to_remove 'Remove'
       = f.link_to_add 'I want to add another conference!', :attendances, class: 'btn btn-primary form-btn-group'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -48,10 +48,10 @@ nav.actions
     ul.conferences
       - @user.attendances.includes(:conference).order('conferences.starts_on').each do |a|
         li
-          - if @user == current_user
-            p
-              ' #{link_to a.conference.name, a.conference}
-              ' (#{a.conference.location}, #{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
+          p
+            ' #{link_to a.conference.name, a.conference}
+            ' (#{a.conference.location}, #{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
+            - if @user == current_user
               ' #{link_to "Tweet About It!", conference_tweet_link(a.conference), class: 'btn btn-default'}
           - if can?(:crud, a) and admin?
             ul.actions


### PR DESCRIPTION
This adds/fixes the following:

- Conference attendance for students can no longer be added by admins. This is no longer needed, as students can do this on their own now. Admins will simply confirm them.
- The conference attendance on a students' page is now visible to everyone, as opposed to only them. The tweet button is visible only to them.
- The dropdown for selecting a conference now has as a default value the first conference instead of having a blank value