### PR TITLE
fix text flowing over supervisors' check up box

### DIFF
--- a/app/assets/stylesheets/global.css.sass
+++ b/app/assets/stylesheets/global.css.sass
@@ -1,5 +1,5 @@
 // Global styles
-// 
+//
 // Site-wide used styles.
 
 *
@@ -273,11 +273,16 @@ nav
     ul
       margin-left: 0
 
+  .information
+    ul
+      padding-left: 0
+
   .comment
     h3
-      font-size: 0.9rem
+      font-size: 1.4rem
+      font-weight: bold
     p
-      font-size: 0.9rem
+      font-size: 1.3rem
 
 .status_updates, .activities
   img
@@ -449,11 +454,15 @@ h1.header
 
 .supervising
   position: relative
+  overflow: auto
+  h5
+    width: 30%
   .information
     position: absolute
     top: 20px
     right: 20px
-    text-align: right
+    text-align: left
+    width: 35%
 
 .form-btn-group
   margin: 1em 0 2em


### PR DESCRIPTION
This is a quick fix for issue #267.

Below is a the screenshot of what it will look like when merged.

![supervisorcomments](https://cloud.githubusercontent.com/assets/1307818/8806482/23d58bce-2fd7-11e5-882d-ce2c03ec79cb.png)

Note that there is now a scroll, to stop the text flowing out of the 'y' bounds of the grey box. To make reading easier, the text is now aligned left instead of right. It creates two more distinct columns. By no means perfect, and this may be temporary before Team Cheesy gets to the supervisors' dashboard.


All tests passing still.