### PR TITLE
save error and sent at on submissions

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -11,6 +11,11 @@ class Mailer < ActionMailer::Base
   def email(submission)
     set submission
     mail subject: subject, from: from, to: to
+  rescue => e
+    submission.error = e.message
+  ensure
+    submission.sent_at = Time.now.utc
+    submission.save!
   end
 
   private
@@ -20,4 +25,3 @@ class Mailer < ActionMailer::Base
       @mailing = submission.mailing
     end
 end
-

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -11,6 +11,10 @@ describe Mailer do
   let(:html_body)  { message_part(mail, :html) }
   let(:text_body)  { message_part(mail, :plain) }
 
+  subject do
+    described_class.email(submission).deliver_now
+  end
+
   it 'renders the subject' do
     expect(mail.subject).to eq('subject')
   end
@@ -46,5 +50,24 @@ describe Mailer do
   it 'renders the body (text)' do
     expect(text_body).to match('# body')
   end
-end
 
+  it 'sets the sent_at on the submission' do
+    subject
+    expect(submission.sent_at).to_not be_nil
+  end
+
+  context 'when mail raises an exception' do
+    before do
+      allow_any_instance_of(described_class).to receive(:mail).and_raise("i'm an error")
+      subject
+    end
+
+    it 'saves the error to the submisssion' do
+      expect(submission.error).to eq("i'm an error")
+    end
+
+    it 'sets the sent_at on the submission' do
+      expect(submission.sent_at).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
In the upgrade to 4.2 I think I removed this: https://github.com/rails-girls-summer-of-code/rgsoc-teams/commit/1f4bb2ca03c87e34e681301fd24efb091bc02a4f#diff-a96b7164d6c7405c9b73329852bb415dL15

That was what was persisting the error and setting the sent_at on the submissions.