### PR TITLE
fix sending of emails to teamless users

### DIFF
--- a/app/views/mailings/_form.html.slim
+++ b/app/views/mailings/_form.html.slim
@@ -10,7 +10,7 @@
     .col-md-4
       = f.input :seasons, as: :check_boxes, collection: Season.pluck(:name), blank: true, required: false
     .col-md-4
-      = f.input :group, as: :radio_buttons, collection: Mailing.groups.map { |k, v| [k.humanize, k.to_s] }, checked: 'everyone', required: false
+      = f.input :group, as: :radio_buttons, collection: Mailing.groups.map { |k, v| [k.humanize, k.to_s] }, required: false
     .col-md-4
       = f.input :to, as: :check_boxes, collection: Mailing::TO.map { |k| [k.capitalize, k] }, blank: false, required: false
   = f.input :from, placeholder: 'From'

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -24,6 +24,10 @@ FactoryGirl.define do
       name 'helpdesk'
     end
 
+    factory :developer_role do
+      name 'developer'
+    end
+
     factory :supervisor_role do
       name 'supervisor'
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -59,6 +59,12 @@ FactoryGirl.define do
       end
     end
 
+    factory :developer do
+      after(:create) do |user|
+        FactoryGirl.create(:developer_role, user: user)
+      end
+    end
+
     factory :supervisor do
       after(:create) do |user|
         FactoryGirl.create(:supervisor_role, user: user)

--- a/spec/models/recipients_spec.rb
+++ b/spec/models/recipients_spec.rb
@@ -68,7 +68,7 @@ describe Recipients do
       let!(:unselected_students) { FactoryGirl.create_list(:student, 2, team: unselected_team) }
 
       context 'when group is selected_teams' do
-        let(:group) { 'selected_teams'}
+        let(:group) { 'selected_teams' }
 
         it 'only returns students that belong to a selected team' do
           expect(subject.users).to match_array(selected_students)
@@ -76,7 +76,7 @@ describe Recipients do
       end
 
       context 'when group is unselected_teams' do
-        let(:group) { 'unselected_teams'}
+        let(:group) { 'unselected_teams' }
 
         it 'only returns students that belong to an unselected team' do
           expect(subject.users).to match_array(unselected_students)
@@ -85,10 +85,20 @@ describe Recipients do
 
       context 'when group is everyone' do
         let(:group) { 'everyone' }
+
+        it 'returns students that belong to either selected or unselected teams' do
+          expect(subject.users).to match_array(selected_students + unselected_students)
+        end
       end
 
-      it 'returns students that belong to either selected or unselected teams' do
-        expect(subject.users).to match_array(selected_students + unselected_students)
+      context 'when to is just organizers' do
+        let(:to) { %w(organizers) }
+        let!(:helpdesks) { FactoryGirl.create_list(:helpdesk, 2) }
+        let!(:organizers) { FactoryGirl.create_list(:organizer, 2 ) }
+
+        it 'returns all organizers' do
+          expect(subject.users).to match_array(organizers)
+        end
       end
     end
 
@@ -100,9 +110,18 @@ describe Recipients do
       let!(:students) { FactoryGirl.create_list(:student, 2, team: team) }
       let!(:coaches) { FactoryGirl.create_list(:coach, 2, team: team) }
       let!(:other_students) { FactoryGirl.create_list(:student, 2) }
+      let!(:organizers) { FactoryGirl.create_list(:organizer, 2 ) }
 
       it 'only returns students that belong to the 2015 season' do
         expect(subject.users).to match_array(students)
+      end
+
+      context 'when to includes organizers and students' do
+        let(:to) { %w(students organizers developers helpdesk) }
+
+        it 'returns students and organizers' do
+          expect(subject.users).to match_array(students + organizers)
+        end
       end
     end
   end


### PR DESCRIPTION
This one was hard. When joining two roles and teams together, AR ensures that the records are connected and excludes records that are not connected via all three models. So in the case of organizers, not belonging to a team via their `organizer` associated role excluded them from the recipients.

Although I have added some more test, there are many permutations I have not considered, so I doubt this will be the last time we will need to do something with the mailer.