### PR TITLE
Applications state machine

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,9 @@ class ApplicationController < ActionController::Base
   end
 
   def current_season
-    @season ||= Season.current
+    #TEMP solution to find the application form
+    #@season ||= Season.current
+    @season = Season.find(2)
   end
 
   def current_student

--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -142,10 +142,10 @@ class ApplicationDraftsController < ApplicationController
   end
 
   def extended_team
-    @extended_team ||= begin
-                        team = ApplicationDraft.find(params[:id]).team
-                        team if (team.coaches + team.mentors).include? current_user
-                      end
+    # @extended_team ||= begin
+    #                     team = ApplicationDraft.find(params[:id]).team
+    #                     team if (team.coaches + team.mentors).include? current_user
+    #                   end
   end
 
   def open_draft

--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -37,6 +37,7 @@ class ApplicationDraftsController < ApplicationController
     if application_draft.update(application_draft_params)
       update_student!
       redirect_to [:edit, application_draft], notice: 'Your application draft was saved.'
+      #add case:
     else
       render :new
     end

--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -37,7 +37,8 @@ class ApplicationDraftsController < ApplicationController
     if application_draft.update(application_draft_params)
       update_student!
       redirect_to [:edit, application_draft], notice: 'Your application draft was saved.'
-      #add case:
+      #if button value = save do this, if button value = final check set state: final
+
     else
       render :new
     end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -17,9 +17,6 @@ class ApplicationsController < ApplicationController
 
   def update
     @application = Application.find(params[:id])
-    #if button value = save do this, if button value = final check set state: final
-    #BUT there is an :update in application_drafts_controller as well
-
     if @application.update_attributes(application_params)
       redirect_to action: :index
     else

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -17,6 +17,9 @@ class ApplicationsController < ApplicationController
 
   def update
     @application = Application.find(params[:id])
+    #if button value = save do this, if button value = final check set state: final
+    #BUT there is an :update in application_drafts_controller as well
+
     if @application.update_attributes(application_params)
       redirect_to action: :index
     else

--- a/app/controllers/orga/applications_controller.rb
+++ b/app/controllers/orga/applications_controller.rb
@@ -7,7 +7,7 @@ class Orga::ApplicationsController < ApplicationController
   before_action :authenticate_user!, except: :new
   before_action -> { require_role 'reviewer' }, except: [:new, :create]
   respond_to :html
-
+    
   def index
     @applications = applications_table
   end

--- a/app/views/application_drafts/new.html.slim
+++ b/app/views/application_drafts/new.html.slim
@@ -51,12 +51,17 @@ p.attention
 
   - if application_draft.draft?
     .actions
-      = f.button :submit, 'Save as draft', class: 'btn'
-      - unless application_draft.ready?
+      = f.button :submit, 'Save as draft', value: 'Draft', class: 'btn'
+      /- unless application_draft.ready?
         .help-block Your application is not yet ready for submission
 
-- if application_draft.draft?
-  - if application_draft.ready? && application_draft.as_student?
+      /This should go trigger the transition to :final
+      = f.button :submit, 'Ready to submit? ...', value: 'Final', class: 'btn'
+
+- if application_draft.final?
+  /as_student? is checked in state machine; here needed again? Or redundant?
+  /- if application_draft.ready? && application_draft.as_student?
+  - if application_draft.ready?
     = simple_form_for application_draft, url: apply_application_draft_path(application_draft), method: :put do |f|
       .actions
         = f.button :submit, 'Apply', class: 'btn btn-success'


### PR DESCRIPTION
First try to a smoother workflow with the application form.
I added an extra state 'final' to the state machine, in between 'draft' and 'applied'. 
The new 'final' state marks the end of filling in the form (by both students and coaches). 'Final' starts a validation check and makes it clear that only the students are allowed to submit the final draft.
In the old situation, all the validations and notices were packed within the 'draft' state. 
I hope the extra state will make it easier to guide the users through the process of the application form. 
  
I am not totally happy with the states and transitions yet, but I am thinking about it, and explore the state machines possibilities. 
Before we go into that, I have a few questions about things I encountered. 
         
 