### PR TITLE
Separate first and second round conferences

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -31,7 +31,7 @@ class ConferencesController < ApplicationController
     def conference_params
       params[:conference] ? params.require(:conference).permit(
         :name, :url, :location, :twitter, :tickets, :flights, :accomodation,
-        :'starts_on(1i)', :'starts_on(2i)', :'starts_on(3i)',
+        :'starts_on(1i)', :'starts_on(2i)', :'starts_on(3i)', :round,
         :'ends_on(1i)', :'ends_on(2i)', :'ends_on(3i)',
         attendances_attributes: [:id, :github_handle, :_destroy]
       ) : {}

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,6 +1,7 @@
 class Conference < ActiveRecord::Base
   has_many :attendances
   has_many :attendees, through: :attendances, source: :user
+  validates_presence_of :round
 
   accepts_nested_attributes_for :attendances
 

--- a/app/views/conferences/_form.html.slim
+++ b/app/views/conferences/_form.html.slim
@@ -14,6 +14,7 @@
   = f.input :ends_on,   order: [:day, :month, :year], input_html: { class: 'short' }
   = f.input :tickets
   = f.input :flights
+  = f.input :round
   = f.input :accomodation
 
   h3 Attendees

--- a/app/views/conferences/index.html.slim
+++ b/app/views/conferences/index.html.slim
@@ -4,7 +4,7 @@ nav.actions
 
 h1.header
   / = icon('group')
-  span Conferences
+  span Conferences (2nd round)
 
 table.table.table-striped.table-bordered.table-condensed.conferences
   tr
@@ -14,7 +14,7 @@ table.table.table-striped.table-bordered.table-condensed.conferences
     th Attendees
     th Tickets left
 
-  - conferences.each do |conference|
+  - Conference.where(round: 2).each do |conference|
     tr
       td = link_to conference.name, conference
       td = conference.location
@@ -23,3 +23,24 @@ table.table.table-striped.table-bordered.table-condensed.conferences
       td = conference.tickets_left
 
 p = link_to "View as Calendar", calendar_path
+p = link_to "Show/Hide First Round Conferences", "#", onclick: "$('.first-conferences').toggle()"
+
+.first-conferences style='display:none;'
+  h1.header
+    / = icon('group')
+    span Conferences (1st round)
+  table.table.table-striped.table-bordered.table-condensed.conferences
+    tr
+      th = sortable 'name', 'Conference'
+      th = sortable 'location', 'Location'
+      th = sortable 'starts_on', 'Date'
+      th Attendees
+      th Tickets left
+
+    - Conference.where(round: 1).each do |conference|
+      tr
+        td = link_to conference.name, conference
+        td = conference.location
+        td = format_conference_date(conference.starts_on, conference.ends_on)
+        td = conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-'
+        td = conference.tickets_left

--- a/db/migrate/20150912075151_add_round_to_conferences.rb
+++ b/db/migrate/20150912075151_add_round_to_conferences.rb
@@ -1,0 +1,9 @@
+class AddRoundToConferences < ActiveRecord::Migration
+  def up
+    add_column :conferences, :round, :integer, default: 1
+  end
+
+  def down
+    remove_column :conferences, :round, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150625085615) do
+ActiveRecord::Schema.define(version: 20150912075151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,8 +49,8 @@ ActiveRecord::Schema.define(version: 20150625085615) do
     t.datetime "applied_at"
     t.integer  "updater_id"
     t.text     "state",                       default: "draft", null: false
-    t.text     "project_plan"
     t.integer  "position"
+    t.text     "project_plan"
     t.integer  "signed_off_by"
   end
 
@@ -114,8 +114,9 @@ ActiveRecord::Schema.define(version: 20150625085615) do
     t.integer  "tickets"
     t.integer  "accomodation"
     t.integer  "flights"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.integer  "round",                    default: 1
   end
 
   create_table "events", force: :cascade do |t|
@@ -172,7 +173,7 @@ ActiveRecord::Schema.define(version: 20150625085615) do
     t.integer  "user_id"
     t.boolean  "pick"
     t.integer  "rateable_id"
-    t.string   "rateable_type",  limit: 255
+    t.string   "rateable_type"
   end
 
   add_index "ratings", ["rateable_id", "rateable_type"], name: "index_ratings_on_rateable_id_and_rateable_type", using: :btree

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Conference do
   it { is_expected.to have_many(:attendances) }
   it { is_expected.to have_many(:attendees) }
+  it { is_expected.to validate_presence_of(:round) }
 
   describe 'scopes' do
     subject { Conference }


### PR DESCRIPTION
This hides the first round conferences in the conferences view and allows users to toggle them.

NB: All existing conferences will be set to have taken place in the first round