### PR TITLE
Sprint 3: Divides supervisor dashboard into responsive boxes

### DIFF
--- a/app/assets/stylesheets/supervisor/dashboard.css.sass
+++ b/app/assets/stylesheets/supervisor/dashboard.css.sass
@@ -3,7 +3,6 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .dashboard-box
-  background-color: $lightestgray
   margin-bottom: 1rem
   h3, h4, h5
     margin: 0 !important
@@ -16,6 +15,8 @@
     margin-bottom: 1rem
     label
       font-weight: normal
+  .background-color
+    background-color: $lightestgray
 
 section.team-title
   background-color: $lightgray

--- a/app/assets/stylesheets/supervisor/dashboard.css.sass
+++ b/app/assets/stylesheets/supervisor/dashboard.css.sass
@@ -2,10 +2,10 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.min-heigth
-  min-height: 630px
+.min-height
+  min-height: 42rem
   section:nth-child(2)
-    min-height: 388.5px
+    min-height: 25.9rem
 
 .dashboard-box
   margin-bottom: 1rem

--- a/app/assets/stylesheets/supervisor/dashboard.css.sass
+++ b/app/assets/stylesheets/supervisor/dashboard.css.sass
@@ -2,6 +2,11 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
+.min-heigth
+  min-height: 630px
+  section:nth-child(2)
+    min-height: 388.5px
+
 .dashboard-box
   margin-bottom: 1rem
   h3, h4, h5

--- a/app/views/supervisor/dashboard/index.html.slim
+++ b/app/views/supervisor/dashboard/index.html.slim
@@ -2,27 +2,29 @@ h2 Supervisor Dashboard
 p Alpha Version
 
 div.clearfix
-  - supervised_teams.each do |t|
-    div.dashboard-box
-      section.team-title
-        h3 = link_to "Team " + t.name, t
-      section.dashboard
-        h4 Checks
-        - if t.comments.any?
-          p = "You last checked on them #{ time_ago_in_words(t.comments.last.created_at) } ago."
-        - else
-          p You didn't check on them yet.
-        = simple_form_for Comment.new(team_id: t.id), url: supervisor_comments_path do |f|
-          == render 'supervisor/comments/form', f: f
-          - if t.comments.any?
-            p = render t.comments.recent
-            p = link_to 'Archive', supervisor_comments_path(team_id: t.id)
-      section.dashboard
-        h4 Activity
-        - if t.activities.any?
-          p = "Their latest update is from #{ time_ago_in_words(t.last_activity.created_at) } ago."
-          h5 = t.last_activity.title
-          p = render_markdown(t.last_activity.content).html_safe
-        - else
-          p Your team hasn't written any status updates yet.
-          
+  div.row
+    - supervised_teams.each do |t|
+      div.dashboard-box.col-sm-6 class=("col-lg-4" if supervised_teams.count > 2)
+        div.background-color
+          section.team-title
+            h3 = link_to "Team " + t.name, t
+          section.dashboard
+            h4 Checks
+            - if t.comments.any?
+              p = "Your latest check was #{ time_ago_in_words(t.comments.recent.first.created_at) } ago."
+            - else
+              p You didn't check upon them yet.
+            - if can?(:supervise, t)
+              = simple_form_for Comment.new(team_id: t.id), url: supervisor_comments_path do |f|
+                == render 'supervisor/comments/form', f: f
+              - if t.comments.any?
+                p = render t.comments.recent
+                p = link_to 'View history', supervisor_comments_path(team_id: t.id)
+          section.dashboard
+            - if t.activities.any?
+              h4 Activity
+              p = "Their latest update is from #{ time_ago_in_words(t.last_activity.created_at) } ago."
+              h5 = t.last_activity.title
+              p = render_markdown(t.last_activity.content).html_safe
+            - else
+              p Your team hasn't written any status updates yet

--- a/app/views/supervisor/dashboard/index.html.slim
+++ b/app/views/supervisor/dashboard/index.html.slim
@@ -24,6 +24,6 @@ div.row
             h4 Activity
             p = "Their latest update is from #{ time_ago_in_words(t.last_activity.created_at) } ago."
             h5 = t.last_activity.title
-            p = render_markdown(t.last_activity.content).html_safe
+            p = truncate((t.last_activity.content).html_safe, length: 220) { link_to " Show all", activities_path(team_id: t.id)}
           - else
             p Your team hasn't written any status updates yet

--- a/app/views/supervisor/dashboard/index.html.slim
+++ b/app/views/supervisor/dashboard/index.html.slim
@@ -4,7 +4,7 @@ p Alpha Version
 div.row
   - supervised_teams.each do |t|
     div.dashboard-box.col-sm-6 class=("col-lg-4" if supervised_teams.count > 2)
-      div.background-color
+      div.background-color class=("min-height" if supervised_teams.count > 2)
         section.team-title
           h3 = link_to "Team " + t.name, t
         section.dashboard

--- a/app/views/supervisor/dashboard/index.html.slim
+++ b/app/views/supervisor/dashboard/index.html.slim
@@ -1,30 +1,29 @@
 h2 Supervisor Dashboard
 p Alpha Version
 
-div.clearfix
-  div.row
-    - supervised_teams.each do |t|
-      div.dashboard-box.col-sm-6 class=("col-lg-4" if supervised_teams.count > 2)
-        div.background-color
-          section.team-title
-            h3 = link_to "Team " + t.name, t
-          section.dashboard
-            h4 Checks
+div.row
+  - supervised_teams.each do |t|
+    div.dashboard-box.col-sm-6 class=("col-lg-4" if supervised_teams.count > 2)
+      div.background-color
+        section.team-title
+          h3 = link_to "Team " + t.name, t
+        section.dashboard
+          h4 Checks
+          - if t.comments.any?
+            p = "Your latest check was #{ time_ago_in_words(t.comments.recent.first.created_at) } ago."
+          - else
+            p You didn't check upon them yet.
+          - if can?(:supervise, t)
+            = simple_form_for Comment.new(team_id: t.id), url: supervisor_comments_path do |f|
+              == render 'supervisor/comments/form', f: f
             - if t.comments.any?
-              p = "Your latest check was #{ time_ago_in_words(t.comments.recent.first.created_at) } ago."
-            - else
-              p You didn't check upon them yet.
-            - if can?(:supervise, t)
-              = simple_form_for Comment.new(team_id: t.id), url: supervisor_comments_path do |f|
-                == render 'supervisor/comments/form', f: f
-              - if t.comments.any?
-                p = render t.comments.recent
-                p = link_to 'View history', supervisor_comments_path(team_id: t.id)
-          section.dashboard
-            - if t.activities.any?
-              h4 Activity
-              p = "Their latest update is from #{ time_ago_in_words(t.last_activity.created_at) } ago."
-              h5 = t.last_activity.title
-              p = render_markdown(t.last_activity.content).html_safe
-            - else
-              p Your team hasn't written any status updates yet
+              p = render t.comments.recent
+              p = link_to 'View history', supervisor_comments_path(team_id: t.id)
+        section.dashboard
+          - if t.activities.any?
+            h4 Activity
+            p = "Their latest update is from #{ time_ago_in_words(t.last_activity.created_at) } ago."
+            h5 = t.last_activity.title
+            p = render_markdown(t.last_activity.content).html_safe
+          - else
+            p Your team hasn't written any status updates yet


### PR DESCRIPTION
### Sprint 3: Add responsive styling to supervisor dashboard

- [x] Minimize status-update text
- [x] Link to all the activities from that team
- [x] Put teams-boxes next to each other
- [x] Make them responsive

@alicetragedy could you review?