### PR TITLE
Styling fixes in activities view and header

### DIFF
--- a/app/assets/stylesheets/controllers/activities.css.sass
+++ b/app/assets/stylesheets/controllers/activities.css.sass
@@ -1,35 +1,49 @@
-// Styles for the activities-controller.
+// // Styles for the activities-controller.
 
+// .activities
+//   margin: 0 0 1rem 0
+//   padding: 0
+//   .activity
+//     @include clearfix
+//     padding: 3rem
+//     border: 1px solid $lightgray
+//     &.mailing img
+//       height: 100px
+//       border-width: 0
+//     .images
+//       float: left
+//       width: 75+75+10+10+10px
+//       .avatar
+//         width: 75px
+//         height: 75px
+//       .avatar:nth-child(3)
+//         margin-top: 1rem
+//     .text
+//       display: inline-block
+//       // for readability
+//       max-width: 75rem
+//       h4
+//         margin: 0 0 0.5rem 0
+//         font-size: 2rem
+//       .info
+//         margin-bottom: 0
+//         font-style: italic
+//       .content
+//         margin-top: 1rem
+//       // fixes bullet points indentation
+//       ul
+//         padding-left: 1.5rem
 .activities
-  margin: 0 0 1rem 0
-  padding: 0
+  ul
+    padding-left: 0
   .activity
-    @include clearfix
-    padding: 3rem
     border: 1px solid $lightgray
-    &.mailing img
-      height: 100px
-      border-width: 0
-    .images
-      float: left
-      width: 75+75+10+10+10px
+    .avatars
+      padding: 1rem 1rem 1rem 2rem
       .avatar
-        width: 75px
-        height: 75px
-      .avatar:nth-child(3)
-        margin-top: 1rem
+        width: 50%
+        display: inline-block
+        float: left
+        padding-right: 1rem
     .text
-      display: inline-block
-      // for readability
-      max-width: 75rem
-      h4
-        margin: 0 0 0.5rem 0
-        font-size: 2rem
-      .info
-        margin-bottom: 0
-        font-style: italic
-      .content
-        margin-top: 1rem
-      // fixes bullet points indentation
-      ul
-        padding-left: 1.5rem
+      padding: 1.666rem 3rem 1rem 1rem

--- a/app/assets/stylesheets/controllers/activities.css.sass
+++ b/app/assets/stylesheets/controllers/activities.css.sass
@@ -38,12 +38,16 @@
     padding-left: 0
   .activity
     border: 1px solid $lightgray
+    margin-bottom: 1.6rem
     .avatars
-      padding: 1rem 1rem 1rem 2rem
+      padding: 1.6rem 0.5rem 0 2rem
       .avatar
         width: 50%
         display: inline-block
         float: left
-        padding-right: 1rem
+        padding-left: 0.9rem
     .text
-      padding: 1.666rem 3rem 1rem 1rem
+      padding: 0.4rem 2.2rem
+    @media screen and (min-width: $screen-sm)
+      .text
+        padding: 0.8rem 2.6rem 0.4rem 1.3rem

--- a/app/assets/stylesheets/controllers/activities.css.sass
+++ b/app/assets/stylesheets/controllers/activities.css.sass
@@ -1,38 +1,5 @@
 // // Styles for the activities-controller.
 
-// .activities
-//   margin: 0 0 1rem 0
-//   padding: 0
-//   .activity
-//     @include clearfix
-//     padding: 3rem
-//     border: 1px solid $lightgray
-//     &.mailing img
-//       height: 100px
-//       border-width: 0
-//     .images
-//       float: left
-//       width: 75+75+10+10+10px
-//       .avatar
-//         width: 75px
-//         height: 75px
-//       .avatar:nth-child(3)
-//         margin-top: 1rem
-//     .text
-//       display: inline-block
-//       // for readability
-//       max-width: 75rem
-//       h4
-//         margin: 0 0 0.5rem 0
-//         font-size: 2rem
-//       .info
-//         margin-bottom: 0
-//         font-style: italic
-//       .content
-//         margin-top: 1rem
-//       // fixes bullet points indentation
-//       ul
-//         padding-left: 1.5rem
 .activities
   ul
     padding-left: 0

--- a/app/assets/stylesheets/global.css.sass
+++ b/app/assets/stylesheets/global.css.sass
@@ -112,7 +112,6 @@ html, body
 
 #content
   margin-top: 3rem
-  overflow-x: scroll
 
   h1
     font-size: 2rem

--- a/app/assets/stylesheets/global.css.sass
+++ b/app/assets/stylesheets/global.css.sass
@@ -48,12 +48,13 @@ html, body
     border-radius: 50%
     overflow: hidden
     margin-top: 12px
+    outline: none
+    text-align: center
     @media screen and (min-width: $screen-md)
       display: none
     i
       position: relative
       top: 5px
-      right: 7px
   ul
     padding: 0
     text-align: right
@@ -83,7 +84,7 @@ html, body
         text-decoration: none
 
     // Changes bootstraps default collapsing breakpoint
-    @media (min-width: $screen-sm) and (max-width: $screen-sm-max)
+    @media (min-width: $screen-xs) and (max-width: $screen-sm-max)
       .navbar-collapse.collapse
         display: none !important
 
@@ -111,6 +112,7 @@ html, body
 
 #content
   margin-top: 3rem
+  overflow-x: scroll
 
   h1
     font-size: 2rem

--- a/app/assets/stylesheets/global.css.sass
+++ b/app/assets/stylesheets/global.css.sass
@@ -245,10 +245,10 @@ html, body
       font-size: 1.3rem
 
   .status_updates, .activities
-    img
-      max-width: 75+75+10px
-      float: left
-      margin-right: 1rem
+    // img
+    //   max-width: 75+75+10px
+    //   float: left
+    //   padding-right: 1rem
 
   a.atom
     float: right

--- a/app/assets/stylesheets/global.css.sass
+++ b/app/assets/stylesheets/global.css.sass
@@ -244,12 +244,6 @@ html, body
     p
       font-size: 1.3rem
 
-  .status_updates, .activities
-    // img
-    //   max-width: 75+75+10px
-    //   float: left
-    //   padding-right: 1rem
-
   a.atom
     float: right
     font-size: .6em
@@ -429,3 +423,15 @@ h1.header
   h5
     font-style: italic
     margin-bottom: 0
+
+// Images in status updates and activity stream
+
+.status_updates, .activities
+  p
+    img
+      max-width: 100%
+      float: left
+      padding: 1rem 0
+      @media screen and (min-width: $screen-md)
+        max-width: 50%
+        padding: 0 1rem 1rem 0

--- a/app/views/activities/_feed_entry.html.slim
+++ b/app/views/activities/_feed_entry.html.slim
@@ -1,17 +1,18 @@
 li class="activity #{activity.kind}"
-  div.images
-    = link_to activity.source_url
-      - if activity.img_url.present?
-        = image_tag(activity.img_url)
-      - else
-        - activity.students.each do |student| 
-          = image_tag(student.avatar_url, class: "avatar")
-  div.text
-    h4.title
-      = link_to(activity.title, activity.source_url)
-    p.info
-      = link_to activity.team.display_name, activity.team
-      ' &nbsp;&mdash;
-      span.published_at = "at #{activity.published_at.to_formatted_s(:time)}".html_safe if activity.published_at
-    p.content
-      = format_activity_content(activity, length: 300)
+  div.row
+    div.avatars.hidden-xs.col-sm-4.col-md-3
+      = link_to activity.source_url
+        - if activity.img_url.present?
+          = image_tag(activity.img_url)
+        - else
+          - activity.students.each do |student| 
+            = image_tag(student.avatar_url, class: "avatar")
+    div.text.col-sm-8.col-md-9
+      h4.title
+        = link_to(activity.title, activity.source_url)
+      p.info
+        = link_to activity.team.display_name, activity.team
+        ' &nbsp;&mdash;
+        span.published_at = "at #{activity.published_at.to_formatted_s(:time)}".html_safe if activity.published_at
+      p.content
+        = format_activity_content(activity, length: 300)

--- a/app/views/activities/_mailing.html.slim
+++ b/app/views/activities/_mailing.html.slim
@@ -1,17 +1,18 @@
 li class="activity #{activity.kind}"
-  div.images
-    - activity.students.each do |student|
-      = image_tag(student.avatar_url, class: "avatar")
+  div.row
+    div.avatars.hidden-xs.col-sm-4.col-md-3
+      - activity.students.each do |student|
+        = image_tag(student.avatar_url, class: "avatar")
 
-  div.text
-    h4.title
-      = link_to(activity.title, mailing_url(activity.guid))
-    p.info
-      = link_to activity.team.display_name, activity.team
-      ' &nbsp;&mdash; 
-      span.published_at = "at #{activity.published_at.to_formatted_s(:time)}".html_safe if activity.published_at
-    p.content
-      = format_activity_content(activity, length: 300)
+    div.text.col-sm-8.col-md-9
+      h4.title
+        = link_to(activity.title, mailing_url(activity.guid))
+      p.info
+        = link_to activity.team.display_name, activity.team
+        ' &nbsp;&mdash; 
+        span.published_at = "at #{activity.published_at.to_formatted_s(:time)}".html_safe if activity.published_at
+      p.content
+        = format_activity_content(activity, length: 300)
 
 
 

--- a/app/views/activities/_status_update.html.slim
+++ b/app/views/activities/_status_update.html.slim
@@ -1,14 +1,15 @@
 li class="activity #{activity.kind}"
-  div.images
-    - activity.students.each do |student|
-      = image_tag(student.avatar_url, class: "avatar")
-  
-  div.text
-    h4.title
-      = link_to(activity.title, status_update_path(activity))
-    p.info
-      = link_to activity.team.display_name, activity.team
-      ' &nbsp;&mdash; 
-      span.published_at = "at #{activity.published_at.to_formatted_s(:time)}".html_safe if activity.published_at
-    p
-      = render_markdown(activity.content).html_safe
+  div.row
+    div.avatars.col-xs-3
+      - activity.students.each do |student|
+        = image_tag(student.avatar_url, class: "avatar")
+    
+    div.text.col-xs-9
+      h4.title
+        = link_to(activity.title, status_update_path(activity))
+      p.info
+        = link_to activity.team.display_name, activity.team
+        ' &nbsp;&mdash; 
+        span.published_at = "at #{activity.published_at.to_formatted_s(:time)}".html_safe if activity.published_at
+      p
+        = render_markdown(activity.content).html_safe

--- a/app/views/activities/_status_update.html.slim
+++ b/app/views/activities/_status_update.html.slim
@@ -1,10 +1,10 @@
 li class="activity #{activity.kind}"
   div.row
-    div.avatars.col-xs-3
+    div.avatars.hidden-xs.col-sm-4.col-md-3
       - activity.students.each do |student|
         = image_tag(student.avatar_url, class: "avatar")
     
-    div.text.col-xs-9
+    div.text.col-sm-8.col-md-9
       h4.title
         = link_to(activity.title, status_update_path(activity))
       p.info

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -1,28 +1,32 @@
-h1.header
-  = icon('comments-alt')
-  span Activities
-  = link_to '<span>Atom Feed</span>'.html_safe, activities_path(format: :atom), class: 'atom'
+div.row
+  div.col-sm-12
+    h1.header
+      = icon('comments-alt')
+      span Activities
+      = link_to '<span>Atom Feed</span>'.html_safe, activities_path(format: :atom), class: 'atom'
 
-- if current_user.try(:supervisor?)
-  .alert.alert-success
-    'Hey Supervisor. We loved working on your Dashboard! Team Cheesy says: Bye!
+    - if current_user.try(:supervisor?)
+      .alert.alert-success
+        'Hey Supervisor. We loved working on your Dashboard! Team Cheesy says: Bye!
 
-div.selection-box
-  form.filter.form-inline action=request.url
-    - public_activities.each do |kind|
-      label.radio
-        = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
-        = " " + kind == 'feed_entry' ? 'Blog Post' : kind.titleize
-    label.team_filter
-      ' Team:
-      = select_tag :team_id, options_for_select(teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: true, class: 'form-control'
+    div.selection-box
+      form.filter.form-inline action=request.url
+        - public_activities.each do |kind|
+          label.radio
+            = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
+            = " " + kind == 'feed_entry' ? 'Blog Post' : kind.titleize
+        label.team_filter
+          ' Team:
+          = select_tag :team_id, options_for_select(teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: true, class: 'form-control'
 
-p.pagination-info
-  = page_entries_info @activities
+    p.pagination-info
+      = page_entries_info @activities
 
-= render 'activities', object: @activities
+div.row
+  div.col-sm-12
+    = render 'activities', object: @activities
 
-= paginate @activities, theme: 'twitter-bootstrap-3', pagination_class: 'pagination-sm'
+    = paginate @activities, theme: 'twitter-bootstrap-3', pagination_class: 'pagination-sm'
 
-- content_for :head do
-  = auto_discovery_link_tag(:atom, {action: "index", format: "atom" }, {title: "Atom Feed"})
+    - content_for :head do
+      = auto_discovery_link_tag(:atom, {action: "index", format: "atom" }, {title: "Atom Feed"})


### PR DESCRIPTION
Fixes the activities view for all screen sizes after introduction of bootstrap grid.

Laptop:

![screen shot 2015-09-29 at 15 35 49](https://cloud.githubusercontent.com/assets/11146524/10165850/92887de4-66c1-11e5-9a92-62a957c63142.png)

Mobile:

![screen shot 2015-09-29 at 15 45 54](https://cloud.githubusercontent.com/assets/11146524/10165855/9a306750-66c1-11e5-9ccc-b7133e071ed5.png)