### PR TITLE
Fixes routing with `Season.current.started?`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,11 @@
 RgsocTeams::Application.routes.draw do
-
-
   get 'status_updates/show'
 
-  # FIXME Accessing season this early breaks `rake db:create RAILS_ENV=test` on CI
-  # if Season.current.started?
+  if ActiveRecord::Base.connection.table_exists?("seasons") && Season.current.started?
     root to: 'activities#index'
-  # else
-  #   root to: 'users#index'
-  # end
+  else
+    root to: 'users#index'
+  end
 
   devise_for :users, controllers: { omniauth_callbacks: 'omniauth_callbacks' }
 

--- a/spec/routing/root_routing_spec.rb
+++ b/spec/routing/root_routing_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'root routing' do
 
   before do
-    # expect(Season).to receive(:current).and_return(season)
+    expect(Season).to receive(:current).and_return(season)
     Rails.application.reload_routes!
   end
 
@@ -11,7 +11,6 @@ describe 'root routing' do
     let(:season) { double(:started? => false) }
 
     it 'routes to users#index' do
-      skip 'Define root path based on current season'
       expect(get('/')).to route_to('users#index')
     end
   end


### PR DESCRIPTION
## Problem:
Accessing `Season` in `routes.rb` breaks `rake db:create` on CI.

## Solution:
Access `Season` only after making sure the db table actually exists.