### PR TITLE
Add delete functionality for projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -15,6 +15,14 @@ class ProjectsController < ApplicationController
     @projects = Project.all
   end
 
+  def destroy
+    respond_to do |format|
+      return unless project.submitter == current_user
+      @project.destroy
+      format.html { redirect_to projects_path, notice: 'Project was successfully deleted' }
+    end
+  end
+
   def create
     @project = Project.new(project_params)
 

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -19,4 +19,6 @@ table.table.table-striped.table-bordered.table-condensed
         - if current_user == project.submitter
           = link_to [:edit, project], class: 'edit-project' do
             = icon('edit')
+          = link_to project, data: { confirm: 'This action cannot be undone. Are you sure?' }, method: :delete, class: 'edit-project' do
+            = icon('minus-sign')
       td = l project.created_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ RgsocTeams::Application.routes.draw do
   resources :attendances
   resources :contributors, only: :index
   resources :status_updates, only: :show
-  resources :projects, except: [:destroy]
+  resources :projects
 
   namespace :applications do
     get 'students/:id', to: 'students#show', as: 'student'

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -91,4 +91,22 @@ RSpec.describe ProjectsController do
 
   end
 
+  describe 'DELETE destroy' do
+    let(:user) { create(:user) }
+    let(:project) { create(:project, submitter: user) }
+
+    before do
+      sign_in user
+      project # Boop it to life
+    end
+
+    it 'deletes the project' do
+      expect { delete :destroy, id: project.to_param }.to \
+        change { Project.count }.by -1
+      expect(flash[:notice]).not_to be_nil
+      expect(response).to redirect_to(projects_path)
+    end
+
+  end
+
 end


### PR DESCRIPTION
Finally, the `D` part of the `CRUD`. :)

Users are prompted to confirm.

As always, submitters can only delete their own projects.