### PR TITLE
add special announcement styling for navbar

### DIFF
--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -79,6 +79,18 @@ html, body
           margin: 0 0.6rem 0 0.6rem
         &:last-child:after
           content: none
+      li.announcement
+        a
+          padding: 4px
+          -webkit-border-radius: 5px
+          -moz-border-radius: 5px
+          border-radius: 5px
+          background-color: white
+          color: $railsred
+        a:hover
+          color: white
+          background-color: $railsred
+
       a
         color: white
         text-decoration: none

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -20,7 +20,8 @@ section#header
         nav.top
           ul class="collapse navbar-collapse" id="menu"
             - if Season.projects_proposable?
-              li = link_to 'Submit your Project', new_project_path
+              li class="announcement"
+                = link_to 'Submit your Project', new_project_path
             - if show_application_link?
               li = application_disambiguation_link
             - if current_user.try :current_student?


### PR DESCRIPTION
this adds some extra styling on `announcement` items in the navbar as discussed in https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/322
ideally we can re-use this class for time- or season-based announcements ie. application submissions.

<img width="1178" alt="screen shot 2015-12-06 at 16 17 20" src="https://cloud.githubusercontent.com/assets/3143348/11614010/db41d320-9c34-11e5-95e2-c0c435ee6d86.png">
