### PR TITLE
small styling fixes

### DIFF
--- a/app/assets/stylesheets/controllers/projects.sass
+++ b/app/assets/stylesheets/controllers/projects.sass
@@ -1,3 +1,3 @@
 
-.edit-project
+.project-actions
   float: right

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -376,7 +376,7 @@ form
 
 // page-header
 
-h1.header
+h1.header, h2.header
   i, span
     display: inline-block
   span

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -16,6 +16,12 @@ html, body
   a, a:hover
     color: $railsred
     color: $railsred
+
+  a:hover
+    i
+      text-decoration: none
+      color: $darkgray
+
   li
     list-style-type: none
   .text-right

--- a/app/views/orga/projects/index.html.slim
+++ b/app/views/orga/projects/index.html.slim
@@ -23,7 +23,7 @@ table.table.table-striped.table-bordered.table-condensed
             = link_to 'Accept', [:accept, :orga, project], method: :put, class: 'btn btn-sm btn-success'
         td
           - if project.may_reject?
-            = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
+            = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger'
 
 br
 

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -17,9 +17,10 @@ table.table.table-striped.table-bordered.table-condensed
       td
         = link_to project.name, project
         - if current_user == project.submitter
-          = link_to [:edit, project], class: 'edit-project' do
-            = icon('edit')
-          = link_to project, data: { confirm: 'This action cannot be undone. Are you sure?' }, method: :delete, class: 'edit-project' do
-            = icon('minus-sign')
+          .project-actions
+            = link_to [:edit, project] do
+              = icon('edit')
+            = link_to project, data: { confirm: 'This action cannot be undone. Are you sure?' }, method: :delete do
+              = icon('minus-sign')
       td = l project.created_at, format: :short
       td = project_status project

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -24,17 +24,23 @@ table.table.table-striped.table-bordered
     th State
     td = project_status(@project)
 
-h2 Project Description
+h2.header
+  = icon('file') 
+  span Project Description
 - if @project.description
   .projects
     p = render_markdown(@project.description).html_safe
 
-h2 Issues, Features, and Milestones
+h2.header
+  = icon('list') 
+  span Issues, Features, and Milestones
 - if @project.issues_and_features
   .projects
     p = render_markdown(@project.issues_and_features).html_safe
 
-h2 Comments
+h2.header 
+  = icon('comments')
+  span Comments
 - if current_user
   = simple_form_for Comment.new(project: @project), url: comments_path do |f|
     .checks


### PR DESCRIPTION
Minor improvements to the styling:
- change color of "Reject" button from orange to red to be consistent with the "rejected" tag
- fix a 'wrong' float on edit/delete actions in project list
- change styling of hover on icon-links (grey on hover and remove underline)

<img width="252" alt="screen shot 2015-12-06 at 20 33 36" src="https://cloud.githubusercontent.com/assets/3143348/11615142/1aceac60-9c59-11e5-94fa-a9664b665340.png">

<img width="1003" alt="screen shot 2015-12-06 at 20 34 10" src="https://cloud.githubusercontent.com/assets/3143348/11615145/20408632-9c59-11e5-8588-81a2b0931f94.png">
