### PR TITLE
Remove the fields to be filled in by coaches from the application process

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -91,7 +91,7 @@ class ApplicationDraftsController < ApplicationController
         permit(:project_name, :project_url, :project_plan, :misc_info, :heard_about_it, :voluntary, :voluntary_hours_per_week)
     elsif application_draft.as_coach?
       params.require(:application_draft).
-        permit(:coaches_contact_info, :coaches_hours_per_week, :coaches_why_team_successful)
+        permit(:coaches_contact_info)
     end
   end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -15,7 +15,7 @@ class Application < ActiveRecord::Base
       :student0_application_about, :student1_application_about,
       :student0_application_community_engagement, :student1_application_community_engagement,
 
-      :coaches_hours_per_week, :coaches_why_team_successful, :voluntary, :voluntary_hours_per_week, :heard_about_it,
+      :voluntary, :voluntary_hours_per_week, :heard_about_it,
 
       :project_name, :project_url, :project_plan,
     ]
@@ -135,7 +135,7 @@ class Application < ActiveRecord::Base
   end
 
   def rating_defaults
-    keys = [:women_priority, :skill_level, :practice_time, :project_time, :support]
+    keys = [:women_priority, :skill_level, :practice_time, :project_time]
     keys.inject({}) { |defaults, key| defaults.merge(key => send("estimated_#{key}")) }
   end
 
@@ -176,17 +176,6 @@ class Application < ActiveRecord::Base
 
   def estimated_project_time
     10
-  end
-
-  def estimated_support
-    value = application_data['coaches_hours_per_week']
-    return unless value =~ /^\d+$/
-
-    case value.to_i
-    when 5 then 8
-    when 3 then 5
-    when 1 then 1
-    end
   end
 
   def seems_to_have_pair?

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -17,7 +17,7 @@ class ApplicationDraft < ActiveRecord::Base
   scope :current, -> { where(season: Season.current) }
 
   validates :team, presence: true
-  validates :coaches_hours_per_week, :coaches_why_team_successful, :project_name, :project_url, :project_plan, presence: true, on: :apply
+  validates :project_name, :project_url, :project_plan, presence: true, on: :apply
   validates :heard_about_it, presence: true, on: :apply
   validates :voluntary_hours_per_week, presence: true, on: :apply, if: :voluntary?
   validate :only_two_application_drafts_allowed, if: :team, on: :create

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -14,7 +14,7 @@ class ApplicationForm
             :location, :attended_rg_workshop,
             :coding_level, :coding_level_pair,
             :skills, :learing_summary, :learning_since_workshop, :learning_since_workshop_pair,
-            :code_samples, :coaches, :hours_per_coach, :why_team_successful, :projects, :project_period,
+            :code_samples, :coaches, :projects, :project_period,
             :minimum_money, :misc_info]
 
   MUST_FIELDS = FIELDS - [:misc_info, :minimum_money]

--- a/app/models/creates_application_from_draft.rb
+++ b/app/models/creates_application_from_draft.rb
@@ -35,13 +35,7 @@ class CreatesApplicationFromDraft
       voluntary_hours_per_week: application_draft.voluntary_hours_per_week,
       heard_about_it: application_draft.heard_about_it,
       misc_info: application_draft.misc_info,
-    }.merge(student_attributes).merge(coaches_attributes).merge(project_attributes)
-  end
-
-  def coaches_attributes
-    %w(coaches_hours_per_week coaches_why_team_successful).each_with_object({}) do |attribute, hash|
-      hash[attribute] = application_draft.send(attribute)
-    end
+    }.merge(student_attributes).merge(project_attributes)
   end
 
   def project_attributes

--- a/app/views/application_drafts/new.html.slim
+++ b/app/views/application_drafts/new.html.slim
@@ -38,11 +38,6 @@ p.attention
     = f.input :project_plan, label: 'Your project plan', hint: "Please describe issues and features that you want to work on this summer, as discussed with your project mentor(s). See #{link_to 'Project Plan Section in Application Guide', 'http://railsgirlssummerofcode.org/students/application/#projectplan', target: :blank} for details.".html_safe, input_html: { rows: 6, disabled: !application_draft.as_student? || application_draft.applied? }
 
   fieldset
-    legend Filled in by coach(es)
-    = f.input :coaches_hours_per_week, label: 'Coach(es): How much time can your coaches put into (being available for) support, in total?', hint: 'Rough estimate, e.g. x hours per day', input_html: { disabled: !application_draft.as_coach? }
-    = f.input :coaches_why_team_successful, label: 'Coach(es): Why do you think this team will be successful with their project?', input_html: { disabled: !application_draft.as_coach? }
-
-  fieldset
     legend Miscellaneous
     = f.input :voluntary, as: :boolean, hint: 'This will not exclude you from being in the running for a sponsored seat.', label: 'We could join the RGSoC as a voluntary team', input_html: { disabled: !application_draft.as_student? || application_draft.applied? }
     = f.input :voluntary_hours_per_week, as: :integer, label: 'As a voluntary team, how many hours per week would you be able to work in the project? (please enter a full number only! eg. 15)', input_html: { disabled: !application_draft.as_student? || application_draft.applied? }

--- a/app/views/applications/new.html.slim
+++ b/app/views/applications/new.html.slim
@@ -44,12 +44,6 @@ p.attention
     = f.input :projects, as: :text, label: 'What project are you planning to work on?', hint: "What project are you planning to work on? If you don't know yet, you'll have time to still sort this out. The earlier you know your project the better :)", input_html: { rows: '5' }
 
   fieldset
-    legend Filled in by coach(es)
-    = f.input :coaches, as: :text, label: 'Coach(es): Who is going to coach you?', hint: 'Please provide contact information. If you have a team of coaches please describe how they are going to team up/split work.', input_html: { rows: '5', disabled: !@application_form.as_coach? }
-    = f.input :hours_per_coach, label: 'Coach(es): How much time can your coaches put into (being available for) support, in total?', hint: 'Rough estimate, e.g. x hours per day', input_html: { disabled: !@application_form.as_coach? }
-    = f.input :why_team_successful, label: 'Coach(es): Why do you think this team is going to be successfully working on their projects?', input_html: { disabled: !@application_form.as_coach? }
-
-  fieldset
     legend Miscellaneous
     -# = f.input :project_period, as: :text, label: 'When do you plan to work on this?', hint: 'We are aiming at July 1st to September 30th for most students, but you can be flexible. Please discuss this with your team.', input_html: { rows: '5' }
     = f.input :minimum_money, label: 'Where you live, how much money do you need at the very minimum per month to sustain yourself while working fulltime on an Open Source project?', hint: 'This question is optional'

--- a/db/migrate/20160210124328_remove_coach_fields_from_application_drafts.rb
+++ b/db/migrate/20160210124328_remove_coach_fields_from_application_drafts.rb
@@ -1,0 +1,11 @@
+class RemoveCoachFieldsFromApplicationDrafts < ActiveRecord::Migration
+  def up
+    remove_column :application_drafts, :coaches_why_team_successful
+    remove_column :application_drafts, :coaches_hours_per_week
+  end
+
+  def down
+    add_column :application_drafts, :coaches_why_team_successful, :text
+    add_column :application_drafts, :coaches_hours_per_week, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151207195550) do
+ActiveRecord::Schema.define(version: 20160210124328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,8 +33,6 @@ ActiveRecord::Schema.define(version: 20151207195550) do
 
   create_table "application_drafts", force: :cascade do |t|
     t.text     "coaches_contact_info"
-    t.text     "coaches_hours_per_week"
-    t.text     "coaches_why_team_successful"
     t.text     "project_name"
     t.text     "project_url"
     t.text     "misc_info"
@@ -48,7 +46,7 @@ ActiveRecord::Schema.define(version: 20151207195550) do
     t.datetime "updated_at"
     t.datetime "applied_at"
     t.integer  "updater_id"
-    t.text     "state",                       default: "draft", null: false
+    t.text     "state",                    default: "draft", null: false
     t.text     "project_plan"
     t.integer  "position"
     t.integer  "signed_off_by"
@@ -159,7 +157,7 @@ ActiveRecord::Schema.define(version: 20151207195550) do
     t.text     "issues_and_features"
     t.boolean  "beginner_friendly"
     t.string   "aasm_state"
-    t.text     "tags",                             default: [], array: true
+    t.text     "tags",                             default: [],    array: true
     t.string   "source_url"
     t.boolean  "comments_locked",                  default: false
   end
@@ -259,7 +257,7 @@ ActiveRecord::Schema.define(version: 20151207195550) do
     t.text     "banking_info"
     t.text     "postal_address"
     t.string   "timezone",                          limit: 255
-    t.string   "interested_in",                                 default: [],                 array: true
+    t.string   "interested_in",                     limit: 255, default: [],                 array: true
     t.boolean  "hide_email"
     t.boolean  "is_company",                                    default: false
     t.string   "company_name",                      limit: 255

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -8,7 +8,6 @@ FactoryGirl.define do
       student_name: FFaker::Name.name,
       location: FFaker::Address.city,
       minimum_money: rand(100),
-      coaches_hours_per_week: 3
     }}
   end
 end

--- a/spec/factories/application_drafts.rb
+++ b/spec/factories/application_drafts.rb
@@ -5,8 +5,6 @@ FactoryGirl.define do
     trait :appliable do
       team { create :team, :applying_team }
 
-      coaches_hours_per_week '15'
-      coaches_why_team_successful { FFaker::Lorem.paragraph }
       project_name { FFaker::Movie.title }
       project_url { FFaker::Internet.http_url }
       project_plan { FFaker::Lorem.paragraph }

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -153,18 +153,6 @@ RSpec.describe ApplicationDraft do
         end
       end
     end
-
-    context 'for coaches\' attributes' do
-      before { allow(subject).to receive(:students).and_return [] }
-
-      it { is_expected.not_to validate_presence_of :coaches_hours_per_week }
-      it { is_expected.not_to validate_presence_of :coaches_why_team_successful }
-
-      context 'when applying' do
-        it { is_expected.to validate_presence_of(:coaches_hours_per_week).on(:apply) }
-        it { is_expected.to validate_presence_of(:coaches_why_team_successful).on(:apply) }
-      end
-    end
   end
 
   context 'with callbacks' do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -109,26 +109,12 @@ describe Application do
       it { is_expected.to be_present }
     end
 
-    default_methods = %w(women_priority skill_level practice_time project_time support)
+    default_methods = %w(women_priority skill_level practice_time project_time)
 
     default_methods.each do |key|
       describe "estimated_#{key}" do
         subject { super().send("estimated_#{key}") }
         it { is_expected.to be_present }
-      end
-    end
-
-    describe '.estimated_support' do
-      it 'returns the a estimated value depending on coach-hours' do
-        hours = {
-          5 => 8,
-          3 => 5,
-          1 => 1
-        }
-        hours.each do |key, value|
-          allow(subject).to receive(:application_data).and_return('coaches_hours_per_week' => key.to_s)
-          expect(subject.estimated_support).to eq(value)
-        end
       end
     end
   end

--- a/spec/models/creates_application_from_draft_spec.rb
+++ b/spec/models/creates_application_from_draft_spec.rb
@@ -66,12 +66,6 @@ RSpec.describe CreatesApplicationFromDraft do
         end
       end
 
-      context 'carrying over the coaches\' statements' do
-        %w(coaches_hours_per_week coaches_why_team_successful).each do |coaches_attribute|
-          it_behaves_like 'matches corresponding attribute', coaches_attribute
-        end
-      end
-
       context 'carrying over the project related information' do
         %w(project_name project_url project_plan).each do |project_attribute|
           it_behaves_like 'matches corresponding attribute', project_attribute


### PR DESCRIPTION
This addresses #365.

The coach fields 'How many hours are you available for?" and "Why do you think this team will be successful?" Are removed with this.