### PR TITLE
extend session validity

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_rgsoc-teams_session'
+Rails.application.config.session_store(:cookie_store, {
+  key: '_rgsoc-teams_session',
+  expire_after: 1.week
+})


### PR DESCRIPTION
as mentioned in #372. you get logged out after you close your browser. this extends the validity of the session to 1 week (just picked something random) and will also extend the session every time you visit.
if you visit the site, say, every day. it will never expire. if you are on vacation for 2 weeks, your session will time out and you have to login again.