### PR TITLE
Transition to state machine for teams and add requirement for team to have two students

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -13,7 +13,11 @@ class ApplicationDraftsController < ApplicationController
   end
 
   def new
-    redirect_to new_team_path, alert: 'You need to be in a team as a student' unless current_user.student?
+    if current_user.student?
+      redirect_to root_path, alert: 'You need to have a partner in your team' unless current_team.confirmed?
+    else
+      redirect_to new_team_path, alert: 'You need to be in a team as a student'
+    end
   end
 
   def create

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -33,6 +33,7 @@ class TeamsController < ApplicationController
 
     respond_to do |format|
       if @team.save
+        @team.confirm! if @team.two_students_present?
         format.html { redirect_to @team, notice: 'Team was successfully created.' }
         format.json { render action: :show, status: :created, location: @team }
       else

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -17,6 +17,9 @@ class Role < ActiveRecord::Base
   validates :user_id, uniqueness: { scope: [:name, :team_id] }
 
   after_create :send_notification, if: Proc.new { GUIDE_ROLES.include?(self.name) }
+  after_create do |role|
+    role.team.confirm! if role.team && role.team.pending? && role.team.two_students_present?
+  end
 
   class << self
     def includes?(role_name)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,5 +1,6 @@
 class Team < ActiveRecord::Base
   include ProfilesHelper, HasSeason
+  include AASM
 
   delegate :sponsored?, :voluntary?, to: :kind
 
@@ -68,6 +69,19 @@ class Team < ActiveRecord::Base
 
   def rating(type = :mean, options = { bonus_points: true })
     Rating::Calc.new(self, type, options).calc
+  end
+
+  aasm :column => :state, :no_direct_assignment => true do
+    state :pending, :initial => true
+    state :confirmed
+
+    event :confirm do
+      transitions from: :pending, to:  :confirmed, guard: :two_students_present?
+    end
+  end
+
+  def two_students_present?
+    students.size > 1
   end
 
   def combined_ratings

--- a/db/migrate/20160217141602_add_aasm_state_to_team.rb
+++ b/db/migrate/20160217141602_add_aasm_state_to_team.rb
@@ -1,0 +1,9 @@
+class AddAasmStateToTeam < ActiveRecord::Migration
+  def up
+    add_column :teams, :state, :text, :default => 'pending', :null => false
+  end
+
+  def down
+    remove_column :teams, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160210124328) do
+ActiveRecord::Schema.define(version: 20160217141602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -217,8 +217,8 @@ ActiveRecord::Schema.define(version: 20160210124328) do
 
   create_table "teams", force: :cascade do |t|
     t.string   "name",               limit: 255
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
     t.string   "log_url",            limit: 255
     t.text     "description"
     t.integer  "number"
@@ -232,8 +232,9 @@ ActiveRecord::Schema.define(version: 20160210124328) do
     t.integer  "last_checked_by"
     t.integer  "season_id"
     t.boolean  "invisible",                      default: false
-    t.integer  "applications_count",             default: 0,     null: false
+    t.integer  "applications_count",             default: 0,         null: false
     t.string   "project_name"
+    t.text     "state",                          default: "pending", null: false
   end
 
   add_index "teams", ["applications_count"], name: "index_teams_on_applications_count", using: :btree

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -71,12 +71,11 @@ RSpec.describe ApplicationDraftsController do
         expect(flash[:alert]).to be_present
       end
 
-      it 'renders the "new" template for a single team member' do
+      it 'redirects for a single team member' do
         create :student_role, user: user
         get :new
-        expect(response).to render_template 'new'
-        expect(response.body).to \
-          match "You haven't got a second student on your team."
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to be_present
       end
 
       it 'renders the "new" template for a tean with two students' do

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -120,6 +120,25 @@ RSpec.describe TeamsController do
         post :create, { team_id: team.to_param, team: valid_attributes }
         expect(assigns(:team).season.name).to eql Date.today.year.to_s
       end
+
+      it 'sets the state as pending' do
+        post :create, { team_id: team.to_param, team: valid_attributes }
+        expect(assigns(:team)).to be_pending
+      end
+
+      context 'given the team is comprised of two students' do
+        let(:first_student) { FactoryGirl.create(:user) }
+        let(:second_student) { FactoryGirl.create(:user) }
+        let(:team) { FactoryGirl.create(:team) }
+        let(:current_user) { first_student }
+
+        let(:valid_attributes) { build(:team).attributes.merge(roles_attributes: [{ name: 'student', github_handle: first_student.github_handle }, { name: 'student', github_handle: second_student.github_handle }]) }
+
+        it 'sets the state as confirmed' do
+          post :create, { team_id: team.to_param, team: valid_attributes }
+          expect(assigns(:team)).to be_confirmed
+        end
+      end
     end
   end
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -60,6 +60,35 @@ describe Team do
     end
   end
 
+  describe '#state' do
+    let(:first_student) { create(:user) }
+    let(:second_student) { create(:user) }
+    let(:team) { FactoryGirl.create(:team) }
+    let(:role_name) { 'student' }
+    it 'returns "pending" when only one student present' do
+      team.attributes = { roles_attributes: [{ name: role_name, user_id: first_student.id }] }
+      team.save!
+      expect(team).to be_pending
+    end
+
+    it 'returns "confirmed" when second student present' do
+      team.attributes = { roles_attributes: [{ name: role_name, user_id: first_student.id }, { name: role_name, user_id: second_student.id }] }
+      team.save!
+      team.confirm!
+      expect(team).to be_confirmed
+    end
+  end
+
+  describe '#confirm' do
+
+    let(:team) { FactoryGirl.create(:team) }
+
+    it 'will not confirm the team if two students are not present' do
+      expect { team.confirm! }.to raise_error AASM::InvalidTransition
+    end
+
+  end
+
   it_behaves_like 'HasSeason'
 
   context 'with scopes' do


### PR DESCRIPTION
Apologies for the long title!

What this does is start to address #363, by doing two things:

- Turn the team model object into a state machine with two states:
   - `pending`: This is when there's only one student in the team.
   - `confirmed`: This is when there's two students in the team.
- Add the requirement for a team to be confirmed before students can create one.