### PR TITLE
fixed errors on starting of project

### DIFF
--- a/db/migrate/20150625085615_add_seasons_to_mailings.rb
+++ b/db/migrate/20150625085615_add_seasons_to_mailings.rb
@@ -1,6 +1,5 @@
 class AddSeasonsToMailings < ActiveRecord::Migration
   def change
     add_column :mailings, :seasons, :text, array: true, default: []
-    Mailing.update_all(seasons: [Season.current.name])
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,3 +9,5 @@ FactoryGirl.create(:supervisor)
 FactoryGirl.create_list(:user, 6)
 
 FactoryGirl.create_list(:status_update, 5)
+
+Mailing.update_all(seasons: [Season.current.name])

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -19,6 +19,7 @@ FactoryGirl.define do
 
     factory :status_update do
       kind 'status_update'
+      published
       title { FFaker::CheesyLingo.sentence }
       content { FFaker::CheesyLingo.paragraph }
     end


### PR DESCRIPTION
I cloned fresh code(master branch) and was setting up project. I was facing errors while configuring it by `rake db:create db:migrate`

This PR solves following issue :
1) `undefined method project_proposals_open_at `
- While doing `rake db:migrate` the migration `20150625085615_add_seasons_to_mailings.rb` was raising error of `project_proposals_open_at` is undefined because of validation callback called while creating Season object. I fixed by moving `Mailing.update_all(seasons: [Season.current.name])` to `db/seeds.rb`

2) `undefined method published_at of nil class `
- The factory of `status_update` do not contain published_at attributes. So when we render root page it was raising error. Which is fixed by adding published trait in factory.


