### PR TITLE
Add coach role confirmation

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -56,13 +56,18 @@ class ApplicationDraftsController < ApplicationController
   end
 
   def apply
-    if application_draft.ready? && application_draft.submit_application!
-      flash[:notice] = 'Your application has been submitted!'
-      ApplicationFormMailer.new_application(application_draft.application).deliver_later
+    if current_team.coaches_confirmed?
+      if application_draft.ready? && application_draft.submit_application!
+        flash[:notice] = 'Your application has been submitted!'
+        ApplicationFormMailer.new_application(application_draft.application).deliver_later
+      else
+        flash[:alert]  = 'An error has occured. Please contact us.'
+      end
+      redirect_to application_drafts_path
     else
-      flash[:alert]  = 'An error has occured. Please contact us.'
+      flash[:alert]  = 'Your coaches have not all confirmed their membership.'
+      redirect_to current_team
     end
-    redirect_to application_drafts_path
   end
 
   protected

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -23,6 +23,32 @@ class RolesController < ApplicationController
     end
   end
 
+  def update
+    user = @role.user
+    respond_to do |format|
+      if user == current_user
+        if params[:confirm]
+          if @role.pending?
+            @role.confirm!
+            if @role.save
+              format.html { redirect_to @team, notice: "You're now confirmed!" }
+              format.json { render action: :show, status: :updated, location: @team }
+            else
+              format.html { redirect_to @team }
+              format.json { render json: @role.errors, status: :unprocessable_entity }
+            end
+          else
+            format.html { redirect_to @team, notice: 'Already confirmed!' }
+            format.json { render action: :show, status: :updated, location: @team }
+          end
+        end
+      else
+        format.html { redirect_to @team, notice: "Can't confirm for others!" }
+        format.json { render json: @role.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
   def destroy
     @role.destroy
     redirect_to @team
@@ -45,7 +71,7 @@ class RolesController < ApplicationController
 
     def role_params
       params[:role] ||= { name: params[:name] }
-      params.require(:role).permit(:user_id, :team_id, :name, :github_handle)
+      params.require(:role).permit(:user_id, :team_id, :name, :github_handle, :confirm)
     end
 
 end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -32,11 +32,11 @@ class RolesController < ApplicationController
           format.html { redirect_to @team, notice: "You're now confirmed!" }
           format.json { render action: :show, status: :updated, location: @team }
         else
-          format.html { redirect_to @team }
+          format.html { redirect_to @team, alert: "We encountered an error confirming your role." }
           format.json { render json: @role.errors, status: :unprocessable_entity }
         end
       else
-        format.html { redirect_to @team, notice: 'Already confirmed!' }
+        format.html { redirect_to @team, alert: 'Already confirmed!' }
         format.json { render action: :show, status: :updated, location: @team }
       end
     end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,6 +15,7 @@ class TeamsController < ApplicationController
   end
 
   def show
+    flash.notice = "Please note: Not all of your coaches have confirmed their membership. You won't be able to submit your application unless they've all confirmed!" unless @team.coaches_confirmed?
   end
 
   def new

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,6 @@ class TeamsController < ApplicationController
   end
 
   def show
-    flash.notice = "Please note: Not all of your coaches have confirmed their membership. You won't be able to submit your application unless they've all confirmed!" unless @team.coaches_confirmed?
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -182,8 +182,19 @@ module ApplicationHelper
 
   def link_to_team_members(team, role = :member)
     team.send(role.to_s.pluralize).sort_by(&:name_or_handle).map do |student|
-      link_to_team_member(student)
+      link_to_team_member(student) + status_for(team, student, role)
     end.join.html_safe
+  end
+
+  def status_for(team, member, role_name)
+    if role_name == :coach
+      role = team.roles.find { |role| role.user == member}
+      if role && role.confirmed?
+        'Confirmed'
+      else
+        current_user == member ? link_to('Confirm', team_role_path(team, role, confirm: true), method: :put) : 'Not Confirmed Yet'
+      end
+    end
   end
 
   def link_to_team_member(member)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -193,7 +193,7 @@ module ApplicationHelper
         content_tag :span, 'Confirmed', class: 'label label-default'
       else
         if current_user == member
-          link_to 'Confirm', team_role_path(team, role, confirm: true), method: :put, class: 'btn btn-sm btn-success'
+          link_to 'Confirm', confirm_role_path((role.confirmation_token || 'confirmation-token-missing')), method: :put, class: 'btn btn-sm btn-success'
         else
           content_tag :span, 'Not confirmed yet', class: 'label label-default'
         end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -190,9 +190,13 @@ module ApplicationHelper
     if role_name == :coach
       role = team.roles.find { |role| role.user == member}
       if role && role.confirmed?
-        'Confirmed'
+        content_tag :span, 'Confirmed', class: 'label label-default'
       else
-        current_user == member ? link_to('Confirm', team_role_path(team, role, confirm: true), method: :put, class: 'btn btn-sm btn-success') : 'Not Confirmed Yet'
+        if current_user == member
+          link_to 'Confirm', team_role_path(team, role, confirm: true), method: :put, class: 'btn btn-sm btn-success'
+        else
+          content_tag :span, 'Not confirmed yet', class: 'label label-default'
+        end
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -192,7 +192,7 @@ module ApplicationHelper
       if role && role.confirmed?
         'Confirmed'
       else
-        current_user == member ? link_to('Confirm', team_role_path(team, role, confirm: true), method: :put) : 'Not Confirmed Yet'
+        current_user == member ? link_to('Confirm', team_role_path(team, role, confirm: true), method: :put, class: 'btn btn-sm btn-success') : 'Not Confirmed Yet'
       end
     end
   end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -17,6 +17,7 @@ class Role < ActiveRecord::Base
   validates :name, inclusion: { in: ROLES }, presence: true
   validates :user_id, uniqueness: { scope: [:name, :team_id] }
 
+  before_create :set_confirmation_token
   after_create :send_notification, if: Proc.new { GUIDE_ROLES.include?(self.name) }
 
   after_create do |role|
@@ -46,5 +47,9 @@ class Role < ActiveRecord::Base
 
   def send_notification
     RoleMailer.user_added_to_team(self).deliver_later
+  end
+
+  def set_confirmation_token
+    self.confirmation_token = SecureRandom.hex(8)
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -133,7 +133,15 @@ class Team < ActiveRecord::Base
     User.find(user_id) if user_id
   end
 
+  def coaches_confirmed?
+    coach_roles.all? { |role| role.confirmed? }
+  end
+
   private
+
+  def coach_roles
+    roles.select { |role| role.name == 'coach' }
+  end
 
   def set_last_checked
     self.last_checked_at = Time.now.utc

--- a/app/views/application_drafts/new.html.slim
+++ b/app/views/application_drafts/new.html.slim
@@ -1,5 +1,8 @@
 h1 Student Application for Rails Girls Summer of Code #{Season.current.name}
 
+- unless application_draft.team.coaches_confirmed?
+  p.alert.alert-warning Please note: Not all of your coaches have confirmed their membership. You won't be able to submit your application unless they've all confirmed!
+
 p.attention
   | Please read our
     #{link_to "Student Application Guide", "http://railsgirlssummerofcode.org/students/application/"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ RgsocTeams::Application.routes.draw do
   end
 
   concern :has_roles do
-    resources :roles, only: [:new, :create, :destroy]
+    resources :roles, only: [:new, :create, :destroy, :update]
   end
 
   get 'users/info', to: 'users_info#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ RgsocTeams::Application.routes.draw do
   end
 
   concern :has_roles do
-    resources :roles, only: [:new, :create, :destroy, :update]
+    resources :roles, only: [:new, :create, :destroy]
   end
 
   get 'users/info', to: 'users_info#index'
@@ -49,9 +49,14 @@ RgsocTeams::Application.routes.draw do
   get 'apply', to: 'application_drafts#new', as: :apply
 
   get 'teams/info', to: 'teams_info#index'
-  resources :teams, concerns: :has_roles do
+  resources :teams do
     resources :join, only: [:new, :create]
     resources :sources
+    resources :roles, only: [:new, :create, :destroy]
+  end
+
+  resources :roles, only: [] do
+    put :confirm, on: :member
   end
 
   get 'calendar/index', as: :calendar

--- a/db/migrate/20160306133317_add_aasm_state_to_role.rb
+++ b/db/migrate/20160306133317_add_aasm_state_to_role.rb
@@ -1,0 +1,9 @@
+class AddAasmStateToRole < ActiveRecord::Migration
+  def up
+    add_column :roles, :state, :text, :default => 'pending', :null => false
+  end
+
+  def down
+    remove_column :roles, :state
+  end
+end

--- a/db/migrate/20160309121328_add_confirmation_token_to_roles.rb
+++ b/db/migrate/20160309121328_add_confirmation_token_to_roles.rb
@@ -1,0 +1,5 @@
+class AddConfirmationTokenToRoles < ActiveRecord::Migration
+  def change
+    add_column :roles, :confirmation_token, :string
+  end
+end

--- a/db/migrate/20160309121328_add_confirmation_token_to_roles.rb
+++ b/db/migrate/20160309121328_add_confirmation_token_to_roles.rb
@@ -1,5 +1,11 @@
 class AddConfirmationTokenToRoles < ActiveRecord::Migration
-  def change
+  def up
     add_column :roles, :confirmation_token, :string
+    Role.joins(team: :season).where("seasons.name IN (?)", %w(2014 2015)).
+      where(name: 'coach').references(:seasons).update_all(state: 'confirmed')
+  end
+
+  def down
+    remove_column :roles, :confirmation_token
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160217141602) do
+ActiveRecord::Schema.define(version: 20160306133317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -183,8 +183,9 @@ ActiveRecord::Schema.define(version: 20160217141602) do
     t.integer  "team_id"
     t.integer  "user_id"
     t.string   "name",       limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+    t.text     "state",                  default: "pending", null: false
   end
 
   create_table "seasons", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160306133317) do
+ActiveRecord::Schema.define(version: 20160309121328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,10 +182,11 @@ ActiveRecord::Schema.define(version: 20160306133317) do
   create_table "roles", force: :cascade do |t|
     t.integer  "team_id"
     t.integer  "user_id"
-    t.string   "name",       limit: 255
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
-    t.text     "state",                  default: "pending", null: false
+    t.string   "name",               limit: 255
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
+    t.text     "state",                          default: "pending", null: false
+    t.string   "confirmation_token"
   end
 
   create_table "seasons", force: :cascade do |t|

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -18,6 +18,20 @@ describe RolesController do
     end
   end
 
+  describe "PUT update" do
+    let(:team)    { create(:team) }
+
+    context 'as a coach confirming my role' do
+      let!(:role) { create(:role, name: 'coach', team: team, user: user) }
+      let!(:params) { { team_id: team.to_param, id: role.to_param, confirm: true } }
+
+      it 'allows the role to be confirmed' do
+        put :update, params, valid_session
+        expect(response).to redirect_to(assigns(:team))
+      end
+    end
+  end
+
   describe "POST create" do
     let(:team)    { create(:team) }
     let!(:params) { { team_id: team.to_param, role: valid_attributes.merge(github_handle: 'steve') } }

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -18,15 +18,16 @@ describe RolesController do
     end
   end
 
-  describe "PUT update" do
+  describe "PUT confirm" do
     let(:team)    { create(:team) }
 
     context 'as a coach confirming my role' do
       let!(:role) { create(:role, name: 'coach', team: team, user: user) }
-      let!(:params) { { team_id: team.to_param, id: role.to_param, confirm: true } }
 
       it 'allows the role to be confirmed' do
-        put :update, params, valid_session
+        expect {
+          put :confirm, { id: role.confirmation_token }, valid_session
+        }.to change { role.reload.state }.from('pending').to('confirmed')
         expect(response).to redirect_to(assigns(:team))
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -62,12 +62,13 @@ describe ApplicationHelper do
       @role1 = create(:student_role, user: @user1, team: @team)
       @role2 = create(:coach_role,   user: @user2, team: @team)
       @role3 = create(:mentor_role,  user: @user3, team: @team)
+      allow(self).to receive(:current_user).and_return(@user1)
     end
 
     it 'should return link_to student based on role type' do
       expect(link_to_team_members(@team)).to           eq(link_to_team_member(@user2) + link_to_team_member(@user3) + link_to_team_member(@user1))
       expect(link_to_team_members(@team, :student)).to eq(link_to_team_member(@user1))
-      expect(link_to_team_members(@team, :coach)).to   eq(link_to_team_member(@user2))
+      expect(link_to_team_members(@team, :coach)).to   eq(link_to_team_member(@user2) + "Not Confirmed Yet")
       expect(link_to_team_members(@team, :mentor)).to  eq(link_to_team_member(@user3))
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -68,8 +68,10 @@ describe ApplicationHelper do
     it 'should return link_to student based on role type' do
       expect(link_to_team_members(@team)).to           eq(link_to_team_member(@user2) + link_to_team_member(@user3) + link_to_team_member(@user1))
       expect(link_to_team_members(@team, :student)).to eq(link_to_team_member(@user1))
-      expect(link_to_team_members(@team, :coach)).to   eq(link_to_team_member(@user2) + "Not Confirmed Yet")
       expect(link_to_team_members(@team, :mentor)).to  eq(link_to_team_member(@user3))
+
+      expect(link_to_team_members(@team, :coach)).to   start_with link_to_team_member(@user2)
+      expect(link_to_team_members(@team, :coach)).to   match "Not confirmed yet"
     end
   end
 

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -15,6 +15,51 @@ describe Role do
     end
   end
 
+  describe '#state' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:team) { FactoryGirl.create(:team) }
+
+    before do
+      subject
+    end
+
+    subject do
+      user.roles.create team: team, name: role_name
+    end
+
+    context 'when the user is added as a coach' do
+      let(:role_name) { 'coach' }
+
+      it 'has the pending state' do
+        expect(subject).to be_pending
+      end
+    end
+
+    context 'when the user is added as a student' do
+      let(:role_name) { 'student' }
+
+      it 'has the confirmed state' do
+        expect(subject).to be_confirmed
+      end
+    end
+
+    context 'when the user is added as a mentor' do
+      let(:role_name) { 'mentor' }
+
+      it 'has the confirmed state' do
+        expect(subject).to be_confirmed
+      end
+    end
+
+    context 'when the user is added as a supervisor' do
+      let(:role_name) { 'supervisor' }
+
+      it 'has the confirmed state' do
+        expect(subject).to be_confirmed
+      end
+    end
+  end
+
   describe 'create' do
     let(:user) { FactoryGirl.create(:user) }
     let(:team) { FactoryGirl.create(:team) }

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -51,7 +51,7 @@ describe Role do
       it_behaves_like 'a guide role'
     end
 
-    context 'when the user is added as a coach' do
+    context 'when the user is added as a mentor' do
       let(:role_name) { 'mentor' }
 
       it_behaves_like 'a guide role'

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Role do
+RSpec.describe Role do
   it { is_expected.to belong_to(:team) }
   it { is_expected.to belong_to(:user) }
   it { is_expected.to validate_presence_of(:user) }
@@ -12,6 +12,17 @@ describe Role do
     it 'includes role name' do
       FactoryGirl.create(:student_role)
       expect(Role.includes?('student')).to eq true
+    end
+  end
+
+  context 'with callbacks' do
+    context 'before save' do
+      before { allow(subject).to receive(:valid?) { true } }
+
+      it 'creates a confirmation token' do
+        expect { subject.save }.to \
+          change { subject.confirmation_token }.from nil
+      end
     end
   end
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -60,6 +60,28 @@ describe Team do
     end
   end
 
+  describe '#coaches_confirmed?' do
+    let(:role)   { FactoryGirl.create "#{role_name}_role" }
+    let(:role_name)   { 'coach' }
+    let(:member) { role.user }
+    let(:user) { create(:user) }
+    let(:team) { FactoryGirl.create(:team) }
+    let(:roles_attributes) { [{ name: role_name, team_id: team.id, user_id: member.id }] }
+
+    it 'says its coaches are confirmed when all coaches are confirmed' do
+      team.attributes = { roles_attributes: roles_attributes }
+      team.roles.each { |role| role.confirm! unless role.confirmed? }
+      team.save!
+      expect(team).to be_coaches_confirmed
+    end
+
+    it 'says its coaches are not confirmed when not all coaches are confirmed' do
+      team.attributes = { roles_attributes: roles_attributes }
+      team.save!
+      expect(team).to_not be_coaches_confirmed
+    end
+  end
+
   describe '#state' do
     let(:first_student) { create(:user) }
     let(:second_student) { create(:user) }


### PR DESCRIPTION
This is the next in steps toward resolving #363

It adds the following:

- Displaying the confirmation status of coaches in the team's view
- Coaches can confirm their status in the team's view
- Adds the following line to the email: 'If you've been added as a coach, please note that you need to confirm your role as a coach.'