### PR TITLE
Add validation to limit the max. number of students per team

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then install all dependencies:
 
 ```bash
 bundle install
-bundle exec rake db:drop db:create db:migrate
+bundle exec rake db:drop db:setup
 ```
 
 ### Mailtrap (optional)
@@ -75,7 +75,7 @@ E.g. `foreman run rails server` or `foreman run rails console`.
 ## Quick Start 
 ###Beginner Friendly Tips for New Contributors
 - After forking the repo, follow the steps described above under 'Bootstrap'. Mailtrap is optional.
-- (Install and) connect to Postgres server  
+- (Install and) connect to Postgres server 
 - With everything properly installed, open the browser in development environment
 - The app should be available, with the database loaded with fake data.
 - To access all the functionality of the teams app, add yourself as an organizer.

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -13,7 +13,7 @@ class RolesController < ApplicationController
     @role.user = User.where(github_handle: params[:role][:github_handle]).first_or_create
 
     respond_to do |format|
-      if @role.save
+      if @team.save
         format.html { redirect_to @team, notice: 'Team was successfully created.' }
         format.json { render action: :show, status: :created, location: @team }
       else

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -15,6 +15,7 @@ class Role < ActiveRecord::Base
   validates :user, presence: true
   validates :name, inclusion: { in: ROLES }, presence: true
   validates :user_id, uniqueness: { scope: [:name, :team_id] }
+  validates_associated :team
 
   after_create :send_notification, if: Proc.new { GUIDE_ROLES.include?(self.name) }
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -15,7 +15,6 @@ class Role < ActiveRecord::Base
   validates :user, presence: true
   validates :name, inclusion: { in: ROLES }, presence: true
   validates :user_id, uniqueness: { scope: [:name, :team_id] }
-  validates_associated :team
 
   after_create :send_notification, if: Proc.new { GUIDE_ROLES.include?(self.name) }
 

--- a/app/views/roles/_form.html.slim
+++ b/app/views/roles/_form.html.slim
@@ -5,6 +5,12 @@
       ul
         - @role.errors.full_messages.each do |message|
           li = message
+  - if @team.errors.any?
+    #error_explanation
+      h2 = "#{pluralize(@team.errors.count, "error")} prohibited this team from being saved:"
+      ul
+        - @team.errors.full_messages.each do |message|
+          li = message
 
   = f.input :github_handle, required: true
   = f.input :name, collection: accessible_roles.map { |r| [r.capitalize, r] }, label: 'Role'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,4 +8,4 @@ FactoryGirl.create(:supervisor)
 # NB These are not listed in the Community listing
 FactoryGirl.create_list(:user, 6)
 
-FactoryGirl.create_list(:status_update, 5)
+FactoryGirl.create_list(:status_update, 5, published_at: Time.now)


### PR DESCRIPTION
Validation for the teams model to limit the max. number of students to two. Editing and deleting roles, etc. are taken into account, the validation process takes place in memory, not relying on data yet to be persisted.

ace624f adds the validation for the team model.

dda1f8f adds the classic behavior of firing the team's validations when saving a role, which will add the default Rails error message to the role: **`Team is invalid`**. I personally don't like this behavior, as I think it doesn't provide meaningful insights to the user. It rather adds complexity for her to understand what went wrong (*"2 errors prohibited this role from being saved ... Team is invalid"*).

Therefore 50812f9 undos firing the team model's validations when saving a role and instead displays the team's own error message in the role's form, if adding/editing a role does not suit the constraints of the team the role is connected to. As the **`Add a member`** button in the team's show view is just a shortcut duplicating the behavior of the normal **`Edit`**, the team-context is obvious anyways, so I consider showing the team errors more useful here.

If you don't like this approach, you can either just discard the last commit (50812f9) or tell me to rework it. If you like it, I would further suggest to fully ditch the **`Add a member`** button as it is available in an approachable way within the team's form anyways.

9c349da fixes some minor problems I ran into when bootstrapping the project.

