### PR TITLE
Ability-restriction to prohibit students from creating a second team

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -15,6 +15,7 @@ class Ability
     can :crud, Team do |team|
       user.admin? or signed_in?(user) && team.new_record? or on_team?(user, team)
     end
+    cannot :create, Team if user.roles.student.exists?
 
     can :join, Team do |team|
       team.helpdesk_team? and signed_in?(user) and not on_team?(user, team)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -105,6 +105,49 @@ describe Ability do
         end
       end
 
+      describe 'operations on teams' do
+        let(:team) { create :team }
+
+        context 'when user admin' do
+          let(:user) { create :organizer }
+
+          it 'allows crud' do
+            expect(subject).to be_able_to :crud, team
+          end
+        end
+        context 'when user student' do
+          let!(:user) { create :student }
+
+          it 'allows crud on new Team' do
+            expect(subject).to be_able_to :crud, Team.new
+          end
+
+          it 'allows crud on own Team' do
+            create :student_role, team: team, user: user
+            expect(subject).to be_able_to :crud, team
+          end
+
+          it 'does not allow crud on other team' do
+            expect(subject).not_to be_able_to :crud, team
+          end
+
+          it 'does not allow to create team if already in another team' do
+            create :student_role, team: team, user: user
+            expect(subject).not_to be_able_to :create, Team.new
+          end
+        end
+        context 'when user guest (not persisted)' do
+          let(:user) { build :user }
+
+          it 'does not allow crud on existing team' do
+            expect(subject).not_to be_able_to :crud, team
+          end
+          it 'does not allow to create team' do
+            expect(subject).not_to be_able_to :create, Team.new
+          end
+        end
+      end
+
       context 'permitting activities' do
         context 'for feed_entries' do
           it 'allows anyone to read' do


### PR DESCRIPTION
Add ability restriction to prohibit students from creating a second team if they already got one. This also hides the `New Team` button on the team's index page if a logged in student-user already has a team (as discussed in #205).

From what I read out of the specs and other models, a user can only have one **`student`** role, so I took this as a basis to decide whether she can create a new team or not. Hope I am on the right mental model here.