### PR TITLE
show number of applications per project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,6 +5,9 @@ class Project < ActiveRecord::Base
   belongs_to :submitter, class_name: 'User'
   has_many :comments, -> { order('created_at DESC') }, dependent: :destroy
 
+  has_many :first_choice_application_drafts,  class_name: 'ApplicationDraft', foreign_key: 'project1_id'
+  has_many :second_choice_application_drafts, class_name: 'ApplicationDraft', foreign_key: 'project2_id'
+
   validates :name, :submitter, :mentor_email, presence: true
 
   scope :current, -> do

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -16,9 +16,11 @@ section#header
               - if Season.projects_proposable?
                 li class="announcement"
                   = link_to 'Submit your Project', new_project_path
+              - if current_season.application_period?
+                li = link_to 'Projects', projects_path
               - if show_application_link?
                 li = application_disambiguation_link
-              - if current_user.try :current_student? 
+              - if current_user.try :current_student?
                 - if current_season.started?
                   li = link_to 'Status Updates', [:students, :status_updates], class: params[:controller] == 'students/status_updates' ? 'active' : ''
               - if current_user.try :supervisor?

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -11,6 +11,8 @@ table.table.table-striped.table-bordered.table-condensed
     th Name
     th Submitted
     th Comments
+    th Applications (1st Choice)
+    th Applications (2nd Choice)
     th Status
 
   - @projects.each do |project|
@@ -27,4 +29,6 @@ table.table.table-striped.table-bordered.table-condensed
       td
         - if project.comments.any?
           = link_to project.comments.count, project_path(project, anchor: 'comments'), class: 'label label-default'
+      td = project.first_choice_application_drafts.count
+      td = project.second_choice_application_drafts.count
       td = project_status project

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -41,16 +41,22 @@ table.table.table-striped.table-bordered
   tr
     th State
     td = project_status(@project)
+  tr
+    th Applications (1st Choice)
+    td = @project.first_choice_application_drafts.count
+  tr
+    th Applications (2nd Choice)
+    td = @project.second_choice_application_drafts.count
 
 h2.header
-  = icon('file') 
+  = icon('file')
   span Project Description
 - if @project.description
   .projects
     p = render_markdown(@project.description).html_safe
 
 h2.header
-  = icon('list') 
+  = icon('list')
   span Issues, Features, and Milestones
 - if @project.issues_and_features
   .projects

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Project do
   context 'with associations' do
     it { is_expected.to belong_to(:submitter).class_name(User) }
     it { is_expected.to have_many(:comments).dependent(:destroy) }
+    it { is_expected.to have_many(:first_choice_application_drafts).class_name(ApplicationDraft) }
+    it { is_expected.to have_many(:second_choice_application_drafts).class_name(ApplicationDraft) }
   end
 
   context 'with validations' do


### PR DESCRIPTION
As discussed in #397 this adds counts for ApplicationDrafts that reference a project in the Projects index and in the Project show. Currently the state of the ApplicationDraft is not taken into account (should it be considered?).