### PR TITLE
Add ability rule to prevent students from creating a second team

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,6 +16,10 @@ class Ability
       user.admin? or signed_in?(user) && team.new_record? or on_team?(user, team)
     end
 
+    cannot :create, Team do |team|
+      on_team_for_season?(user, team.season)
+    end
+
     can :join, Team do |team|
       team.helpdesk_team? and signed_in?(user) and not on_team?(user, team)
     end
@@ -64,6 +68,10 @@ class Ability
 
   def on_team?(user, team)
     user.teams.include?(team)
+  end
+
+  def on_team_for_season?(user, season)
+    season && user.roles.student.joins(:team).pluck(:season_id).include?(season.id)
   end
 
 end

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -1,6 +1,6 @@
 nav.actions
   ul.list-inline
     li = link_to 'My Team', current_student.current_team, class: 'btn btn-default btn-sm' if current_student.current_team
-    li = link_to icon('plus', 'New Team'), new_team_path, class: 'btn btn-primary btn-sm' if can? :create, Team.new
+    li = link_to icon('plus', 'New Team'), new_team_path, class: 'btn btn-primary btn-sm' if can? :create, Team.new(season: Season.current)
 
 = render 'table', namespace: nil

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -105,6 +105,62 @@ describe Ability do
         end
       end
 
+      describe 'operations on teams' do
+        let(:team) { create :team }
+
+        context 'when user admin' do
+          let(:user) { create :organizer }
+
+          it 'allows crud' do
+            expect(subject).to be_able_to :crud, team
+          end
+        end
+        context 'when user student' do
+          let!(:user) { create :student }
+
+          it 'allows crud on new team' do
+            expect(subject).to be_able_to :crud, Team.new
+          end
+
+          it 'allows crud on own team' do
+            create :student_role, team: team, user: user
+            expect(subject).to be_able_to :crud, team
+          end
+
+          it 'does not allow crud on other team' do
+            expect(subject).not_to be_able_to :crud, team
+          end
+
+          context 'when in team for season' do
+            before { create :student_role, team: student_team, user: user }
+            let(:student_team) { create(:team, :current_season) }
+
+            it 'allows crud on own team' do
+              expect(subject).to be_able_to :crud, student_team
+            end
+
+            it 'allows to create team for different season' do
+              expect(subject).to be_able_to :create, Team.new
+            end
+
+            it 'does not allow to create team for same season' do
+              expect(subject).not_to be_able_to :create, Team.new(season: student_team.season)
+            end
+          end
+        end
+        context 'when user guest (not persisted)' do
+          let(:user) { build :user }
+
+          it 'does not allow crud on existing team' do
+            expect(subject).not_to be_able_to :crud, team
+          end
+          
+          it 'does not allow to create team' do
+            expect(subject).not_to be_able_to :create, Team.new
+          end
+        end
+      end
+
       context 'permitting activities' do
         context 'for feed_entries' do
           it 'allows anyone to read' do


### PR DESCRIPTION
Ability rule to prevent students from creating two teams for the same season.

I did not yet include anything on rules to prevent students from editing roles / edit their own rule when creating a team. Defining CanCan abilities with blocks is kind of a hassle when combined with `simple_form` and `nested_form`, making either the view or the rules incredibly ugly 🙈

But I'm sure there's a solution for it - I'll dig deeper. Until then, here's the team-rule first.
