### PR TITLE
add new application fields to edit profile section

### DIFF
--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -73,11 +73,17 @@
   .collapse#collapseApplicationSpecificInfo
     h3#application_specific.page-header Application-specific information
     p.help-block This information will be included in your #{link_to 'application', apply_path, target: :blank} and is visible to your team and to organizers.
-    = f.input :application_about, as: :text, label: 'About you', input_html: { rows: '5' }, hint: 'Please tell us a little bit about yourself and your background.'
-    = f.input :application_motivation, label: 'Tell us a little about why you are applying for Rails Girls Summer of Code'
     = f.input :application_gender_identification, as: :string, label: 'Your gender self-identification', hint: 'No-one is excluded from applying on the basis of gender, but people who self-identify as female, or have experiences being socialized as female, are given preference during selection.'
-    h4 Please rate your level of programming experience (1 being the 'lowest' and 5 the 'highest').
-    p.help-block Some of our skill level guidelines are specific to ruby, but most are language-agnostic. For each level, assume that the guidelines of the level(s) below it are also true, meaning that if you see yourself as a Level 2, you should be able to do most of Level 1, too.
+    .form-inline
+      = f.input :application_age, :collection => User::AGE, :include_blank => false, label: 'Your age'
+    = f.input :application_location, as: :string, label: 'Where do you plan to live July-September? (Please write as "City, Country")'
+    = f.input :application_about, as: :text, label: 'Please tell us a little bit about yourself. What is your background?', input_html: { rows: '5' }, hint: 'Only share what you feel comfortable with.'
+    = f.input :application_code_background, label: 'How did you get into programming?', input_html: {rows: '5' }
+
+    = f.input :application_skills, label: 'Please give us a short summary of your programming skills', hint: 'What languages, frameworks, and tech tools did you learn? What did you build?'
+    
+    h4 According to these guidelines, what is your programming level (where 1 is the 'lowest')?
+    p.help-block For each level, assume that the guidelines of the level(s) below it are also true, meaning that if you see yourself as a Level 2, you should be able to do most of Level 1, too.
     .form-inline
       - SkillLevel.each do |level, explanations|
         .radio
@@ -88,22 +94,23 @@
          - explanations.each do |l|
           li #{l}
 
-    = f.input :application_community_engagement, label: 'Tell us about your community involvement!', hint: 'When did you attend your first Rails Girls, Railsbridge, Black Girls Code, PyLadies, or similar workshop? Have you been involved in organization/coaching/study groups since then? Tell us all about it!'
-    label For how many months have you actively been learning after your first workshop?
+    = f.input :application_community_engagement, label: 'Tell us about your community involvement.', hint: 'When did you attend your first Rails Girls, Railsbridge, Black Girls Code, PyLadies, or similar workshop? Have you been involved in organization/coaching/study groups since then? Tell us all about it!'
     .form-inline
-      - User::MONTHS_LEARNING.each do |months|
-        .radio
-          = f.radio_button :application_learning_period, months
-          | #{months} months
-        <br>
-      <br>
+      = f.input :application_learning_period, :collection => User::MONTHS_LEARNING, :include_blank => false, label: 'For how many months have you actively been learning after your first workshop?'
+    .form-inline
+      = f.input :application_language_learning_period, :collection => User::MONTHS_LEARNING, :include_blank => false, label: 'For how many months have you been learning the language of your primary project?'
 
-    = f.input :application_learning_history, label: 'Please summarize what you have been doing to learn programming since your first workshop', hint: '.g. entered a study Group, learning Rails by doing exercises etc.'
-    = f.input :application_skills, label: 'Please give us a short summary of your programming skills', hint: 'What languages, frameworks, and tech tools did you learn? What did you build?'
+    = f.input :application_learning_history, label: 'Please summarize what you have been doing to learn programming since your first workshop', hint: 'e.g. entered a study group, learning Rails by doing exercises etc.'
+    
     = f.input :application_code_samples, as: :text, label: 'Please link to pull requests you have done or other examples of your coding on GitHub or elsewhere.', input_html: { rows: '5' }
-    = f.input :application_location, as: :string, label: 'Where do you plan to live July-September? (Please write as "City, Country")'
-    = f.input :banking_info, label: 'Money transfer information', hint: "Please provide the following information so we can send money to you.<br>For EU: your name, your IBAN and BIC.<br>For US: your name, bank account number, and bank routing number. OR if you cannot receive bank transfers: your address for sending a check (bank transfers are preferred).<br>For all others: name and address, your bank account number, the SWIFT code of your bank and the bank's address.".html_safe
-    = f.input :application_minimum_money, as: :text, label: 'How much money do you need at the very minimum per month to sustain yourself while working fulltime on an Open Source project? Please give a short summary of your costs including rent, living costs, special circumstances.', hint: 'The total of the stipend will be decided on case-by-case basis, taking into consideration data from the world bank plus individual living situations.', input_html: { rows: 4 }
+
+    = f.input :application_goals, label: "What do you want to achieve by the end of the summer?", input_html: { rows: 4 }
+
+    = f.input :application_motivation, label: 'Why are you applying to this program, and what do you think you can give back?', hint: "Write a short essay (750-1000 words) explaining your motivation. Please don't mention your name, age, or current location.", input_html: { rows: 10 }
+
+    = f.input :application_money, :collection => (200..1500).step(50), label: 'How much money, in USD, do you need per month to sustain yourself while working fulltime on an Open Source project?', hint: "Double-check your selection by using #{link_to 'this cost of living calculator', 'http://www.numbeo.com/cost-of-living/', target: :blank}. If you need more than $1500/month, select 1500 and let us know so below.".html_safe
+
+    = f.input :application_minimum_money, as: :text, label: "If needed, you can use this field to break down your costs for us, or point out any special circumstances which require a higher budget than what you've selected above or than what is usual for your city.", hint: 'The total of the stipend will be decided on case-by-case basis, taking into consideration data from the world bank plus individual living situations.', input_html: { rows: 4 }
 
   - if admin?
     h3.page-header Roles


### PR DESCRIPTION
This updates the "Edit Profile" section with all the new (student-specific) fields we've added to the application, as described in https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/412. As it's quite a bit of information, improvements to the styling of the page (at least adding some subheadings) would still need to be made.