### PR TITLE
Replace AASM confirmation with dynamic #confirmed? method

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -25,10 +25,6 @@ class Role < ActiveRecord::Base
     role.confirm! unless role.name == 'coach'
   end
 
-  after_create do |role|
-    role.team.confirm! if role&.team&.may_confirm?
-  end
-
   class << self
     def includes?(role_name)
       !where(name: role_name).empty?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,5 @@
 class Team < ActiveRecord::Base
   include ProfilesHelper, HasSeason
-  include AASM
 
   delegate :sponsored?, :voluntary?, to: :kind
 
@@ -72,13 +71,8 @@ class Team < ActiveRecord::Base
     Rating::Calc.new(self, type, options).calc
   end
 
-  aasm :column => :state, :no_direct_assignment => true do
-    state :pending, :initial => true
-    state :confirmed
-
-    event :confirm do
-      transitions from: :pending, to:  :confirmed, guard: :two_students_present?
-    end
+  def confirmed?
+    two_students_present?
   end
 
   def combined_ratings

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -159,7 +159,7 @@ class Team < ActiveRecord::Base
   end
 
   def two_students_present?
-    students.size == 2
+    students(true).select(&:persisted?).size == 2
   end
 
   # def must_have_members

--- a/db/migrate/20160314195714_remove_state_from_teams.rb
+++ b/db/migrate/20160314195714_remove_state_from_teams.rb
@@ -1,0 +1,9 @@
+class RemoveStateFromTeams < ActiveRecord::Migration
+  def up
+    remove_column :teams, :state
+  end
+
+  def down
+    add_column :teams, :state, :text, :default => 'pending', :null => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160309200334) do
+ActiveRecord::Schema.define(version: 20160314195714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -241,7 +241,6 @@ ActiveRecord::Schema.define(version: 20160309200334) do
     t.boolean  "invisible",                      default: false
     t.integer  "applications_count",             default: 0,         null: false
     t.string   "project_name"
-    t.text     "state",                          default: "pending", null: false
   end
 
   add_index "teams", ["applications_count"], name: "index_teams_on_applications_count", using: :btree

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -121,11 +121,6 @@ RSpec.describe TeamsController do
         expect(assigns(:team).season.name).to eql Date.today.year.to_s
       end
 
-      it 'sets the state as pending' do
-        post :create, { team_id: team.to_param, team: valid_attributes }
-        expect(assigns(:team)).to be_pending
-      end
-
       context 'given the team is comprised of two students' do
         let(:first_student) { FactoryGirl.create(:user) }
         let(:second_student) { FactoryGirl.create(:user) }

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -155,14 +155,12 @@ describe Team do
     let(:role_name) { 'student' }
     it 'will not be confirmed if only one student present' do
       team.attributes = { roles_attributes: [{ name: role_name, user_id: first_student.id }] }
-      team.save!
-      expect(team).not_to be_confirmed
+      expect { team.save! }.not_to change { team.confirmed? }.from false
     end
 
     it 'will confirm team through role assignment when second student present' do
       team.attributes = { roles_attributes: [{ name: role_name, user_id: first_student.id }, { name: role_name, user_id: second_student.id }] }
-      team.save!
-      expect(team).to be_confirmed
+      expect { team.save! }.to change { team.confirmed? }.to true
     end
   end
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -148,31 +148,24 @@ describe Team do
     end
   end
 
-  describe '#state' do
+  describe '#confirmed?' do
     let(:first_student) { create(:user) }
     let(:second_student) { create(:user) }
     let(:team) { FactoryGirl.create(:team) }
     let(:role_name) { 'student' }
-    it 'returns "pending" when only one student present' do
+    it 'will not be confirmed if only one student present' do
       team.attributes = { roles_attributes: [{ name: role_name, user_id: first_student.id }] }
-      expect { team.save! }.not_to change { team.confirmed? }
+      team.save!
+      expect(team).not_to be_confirmed
     end
 
     it 'will confirm team through role assignment when second student present' do
       team.attributes = { roles_attributes: [{ name: role_name, user_id: first_student.id }, { name: role_name, user_id: second_student.id }] }
-      expect { team.save! }.to change { team.confirmed? }.to true
+      team.save!
+      expect(team).to be_confirmed
     end
   end
 
-  describe '#confirm' do
-
-    let(:team) { FactoryGirl.create(:team) }
-
-    it 'will not confirm the team if two students are not present' do
-      expect { team.confirm! }.to raise_error AASM::InvalidTransition
-    end
-
-  end
 
   it_behaves_like 'HasSeason'
 


### PR DESCRIPTION
This aims to address #403.

Instead of saving the state in the database, we'd instead dynamically check if a team is confirmed by checking if two students are present.

The API stays the same, however.