### PR TITLE
Link to team page instead of redirecting to it

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -65,8 +65,8 @@ class ApplicationDraftsController < ApplicationController
       end
       redirect_to application_drafts_path
     else
-      flash[:alert]  = 'Your coaches have not all confirmed their membership.'
-      redirect_to current_team
+      flash[:alert] = %Q[Your coaches have not all confirmed their membership. See <a href="#{team_path(current_team)}">your team</a> for more info.]
+      redirect_to application_drafts_path
     end
   end
 

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe ApplicationDraftsController do
           it "fails to apply" do
             expect { put :apply, id: draft.id }.not_to change { Application.count }
             expect(flash[:alert]).to be_present
-            expect(response).to redirect_to team
+            expect(response).to redirect_to application_drafts_path
           end
         end
       end


### PR DESCRIPTION
This addresses part of #419 by linking to the team page instead of redirecting to it (Thank you @alicetragedy for the suggestion!)