### PR TITLE
Make student input fields' name and id attributes unique

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -86,10 +86,8 @@ class ApplicationDraftsController < ApplicationController
   end
 
   def student_params
-    # TODO make sure we are the student set to be updated
     if application_draft.as_student? and params[:student]
-      # TODO: Do we need an index? Maybe just compare id with current_student.id
-      params[:student].
+      params[:student].fetch(current_user.id.to_s, {}).
         permit(
           :name, :application_about, :application_motivation, :application_gender_identification, :application_age,
           :application_coding_level, :application_community_engagement, :application_learning_period, :application_language_learning_period,

--- a/app/views/application_drafts/_student_fields.html.slim
+++ b/app/views/application_drafts/_student_fields.html.slim
@@ -1,4 +1,4 @@
-= simple_fields_for (student || Student.new) do |s|
+= simple_fields_for (student || Student.new), index: student.id.to_i do |s|
 
   h2 Basics
   = s.input :name, label: 'Student Name', hint: 'Please provide your first and last name', input_html: { disabled: !may_edit?(s.object) }


### PR DESCRIPTION
This PR fixes long-timer #192 in my local setup. It's a simple patchset but I would appreciate an extra pair of eyes to double-check if this introduces a privilege escalation by means of url- or form input forging.

/cc @klappradla @cypher @ramonh @michaelem 

_Edit_: Some background, copied from yesterday's Slack:

> So, what I noticed yesterday: due to the fact that we render the `_student_fields` partial for both students, we get duplicate input names and DOM ids.
> 
> I’m guessing that’s why the form doesn’t preselect the skill level (remember: it ​_is_​ saved in the DB, it just doesn’t check the saved value in the form). And because the form fields are not named like the the corresponding attributes, the form helper doesn’t know which input field to highlight as erroneous.