### PR TITLE
Hide rejected projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -22,7 +22,7 @@ class ProjectsController < ApplicationController
   end
 
   def index
-    @projects = Project.current
+    @projects = Project.current.where(aasm_state: %w(accepted proposed))
   end
 
   def destroy

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe ProjectsController do
     let!(:accepted) { create :project, :accepted, season: Season.succ, name: 'accepted project' }
     let!(:rejected) { create :project, :rejected, season: Season.succ, name: 'rejected project' }
 
-    it 'displays all projects by default' do
+    it 'hides rejected projects' do
       get :index
       expect(response).to be_success
       expect(response.body).to include 'proposed project'
       expect(response.body).to include 'accepted project'
-      expect(response.body).to include 'rejected project'
+      expect(response.body).not_to include 'rejected project'
     end
   end
 


### PR DESCRIPTION
This is my proposal to to fix #435. Instead of only displaying accepted projects, it only hides rejected ones, allowing students to follow the discussion on proposed projects that may end up being accepted later on.