### PR TITLE
conference fixes

### DIFF
--- a/app/views/conferences/show.html.slim
+++ b/app/views/conferences/show.html.slim
@@ -1,14 +1,16 @@
 nav.page
-  ul
-    li = link_to 'All conferences', conferences_path, class: 'back'
-
-- if can?(:crud, Conference)
-  nav.actions
+  .back-nav
     ul
-      li = link_to 'Edit', edit_conference_path(conference), class: 'edit'
-      li = link_to 'Delete', conference_path(conference), method: :delete, class: 'edit', data: { confirm: 'Are you sure?' }
+      li = icon('chevron-left')
+      li = link_to 'All conferences', conferences_path, class: 'back'
 
 h1 class="conference" = conference.name
+
+- if can?(:crud, Conference)
+  nav.btn-group
+    = link_to 'Edit', edit_conference_path(conference), class: 'edit btn btn-default'
+    = link_to 'Delete', conference_path(conference), method: :delete, class: 'edit btn btn-default', data: { confirm: 'Are you sure?' }
+  p
 
 .conference
   dl

--- a/app/views/teams/_table.html.slim
+++ b/app/views/teams/_table.html.slim
@@ -7,7 +7,8 @@ table.table.table-striped.table-bordered.table-condensed
     th Name
     - @display_roles.each do |role|
       th = role.capitalize
-    th Conferences
+    / quick fix, hiding conferences in teams view
+    / th Conferences
     th Location
     - if current_user.try :admin?
       th Last checked
@@ -23,7 +24,8 @@ table.table.table-striped.table-bordered.table-condensed
               li.user
                 = avatar_url(user, size: 20)
                 = link_to(user.name_or_handle, user)
-      td = links_to_conferences(team.members.map(&:conferences).flatten.uniq).join(', ').html_safe
+      / quick fix, hiding conferences in teams view
+      / td = links_to_conferences(team.members.map(&:conferences).flatten.uniq).join(', ').html_safe
       td = team.students_location
       - if current_user.try :admin?
         td = format_date(team.last_checked_at)

--- a/app/views/teams/_table.html.slim
+++ b/app/views/teams/_table.html.slim
@@ -7,7 +7,7 @@ table.table.table-striped.table-bordered.table-condensed
     th Name
     - @display_roles.each do |role|
       th = role.capitalize
-    / quick fix, hiding conferences in teams view
+    / TODO quick fix, hiding conferences in teams view until program kick-off
     / th Conferences
     th Location
     - if current_user.try :admin?
@@ -24,7 +24,7 @@ table.table.table-striped.table-bordered.table-condensed
               li.user
                 = avatar_url(user, size: 20)
                 = link_to(user.name_or_handle, user)
-      / quick fix, hiding conferences in teams view
+      / TODO quick fix, hiding conferences in teams view until program kick-off
       / td = links_to_conferences(team.members.map(&:conferences).flatten.uniq).join(', ').html_safe
       td = team.students_location
       - if current_user.try :admin?


### PR DESCRIPTION
I know this is a stupid quick fix, but the conferences in the teams overview are quite confusing for students — especially if past attendees of conferences belong to a team, as the conferences are not "seasoned" yet — so I'm commenting them out until we find a better way to show them based on the current season (see https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/399)

This also adds consistent styling to the back navigation and all the buttons in a conference show view. 🎉