### PR TITLE
fix oauth redirect issues

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,12 +18,8 @@ class ApplicationController < ActionController::Base
     params[resource] &&= send(method) if respond_to?(method, true)
   end
 
-  def after_sign_in_path_for(user)
-    if user.just_created?
-      edit_user_path(user, welcome: true, redirect_to: session.delete(:redirect_to))
-    else
-      session.delete(:previous_url_login_required) || session.delete(:previous_url) || user_path(current_user)
-    end
+  def after_sign_in_path_for(user)  
+    request.env['omniauth.origin'] || session.delete(:previous_url_login_required) || session.delete(:previous_url) || user_path(current_user)
   end
 
   rescue_from CanCan::AccessDenied do |exception|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,8 +18,12 @@ class ApplicationController < ActionController::Base
     params[resource] &&= send(method) if respond_to?(method, true)
   end
 
-  def after_sign_in_path_for(user)  
-    request.env['omniauth.origin'] || session.delete(:previous_url_login_required) || session.delete(:previous_url) || user_path(current_user)
+  def after_sign_in_path_for(user)
+    if user.just_created?
+      request.env['omniauth.origin'] || edit_user_path(user, welcome: true)
+    else
+      request.env['omniauth.origin'] || session.delete(:previous_url_login_required) || session.delete(:previous_url) || user_path(current_user)
+    end
   end
 
   rescue_from CanCan::AccessDenied do |exception|


### PR DESCRIPTION
This should finally fix the oauth redirect issue for realz now! :tada: :sparkles: (see part 2 in https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/372)
I've not removed all of the new user-specific stuff, because we can fall back on forcing a new user to fill out their profile right away if they don't come to the app from a link (rather than end up on the index, which might be a little confusing actually) — but all of the info required for a user to exist is already pulled in from the GitHub profile. In the context of the applications, it's obviously much better for the students to access the application right away (or whichever link they clicked on). Would love someone to take a quick look, and I'd like to merge to the staging branch first to see if it works as intended. :cat: 
