### PR TITLE
Worked on Lightning Talk Slots checkbox in conferences display page and form (Issue #294)

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -32,7 +32,7 @@ class ConferencesController < ApplicationController
       params[:conference] ? params.require(:conference).permit(
         :name, :url, :location, :twitter, :tickets, :flights, :accomodation,
         :'starts_on(1i)', :'starts_on(2i)', :'starts_on(3i)', :round,
-        :'ends_on(1i)', :'ends_on(2i)', :'ends_on(3i)',
+        :'ends_on(1i)', :'ends_on(2i)', :'ends_on(3i)', :lightningtalkslots,
         attendances_attributes: [:id, :github_handle, :_destroy]
       ) : {}
     end

--- a/app/views/conferences/_form.html.slim
+++ b/app/views/conferences/_form.html.slim
@@ -16,7 +16,7 @@
   = f.input :flights
   = f.input :round
   = f.input :accomodation
-  = f.input :lightningtalkslots, input_html: {value: nil}, label: "Lightning Talk Slots"
+  = f.input :lightningtalkslots, label: "Lightning Talk Slots"
 
   h3 Attendees
   fieldset.attendees

--- a/app/views/conferences/_form.html.slim
+++ b/app/views/conferences/_form.html.slim
@@ -16,7 +16,7 @@
   = f.input :flights
   = f.input :round
   = f.input :accomodation
-  = f.input :lightningtalkslots, input_html: {value: false}, label: "Lightning Talk Slots"
+  = f.input :lightningtalkslots, input_html: {value: nil}, label: "Lightning Talk Slots"
 
   h3 Attendees
   fieldset.attendees

--- a/app/views/conferences/_form.html.slim
+++ b/app/views/conferences/_form.html.slim
@@ -16,6 +16,7 @@
   = f.input :flights
   = f.input :round
   = f.input :accomodation
+  = f.input :lightningtalkslots, input_html: {value: false}, label: "Lightning Talk Slots"
 
   h3 Attendees
   fieldset.attendees
@@ -28,5 +29,3 @@
 
   .actions
     = f.submit 'Save', class: 'btn btn-success'
-
-

--- a/app/views/conferences/index.html.slim
+++ b/app/views/conferences/index.html.slim
@@ -13,6 +13,7 @@ table.table.table-striped.table-bordered.table-condensed.conferences
     th = sortable 'starts_on', 'Date'
     th Attendees
     th Tickets left
+    th Lightning Talk Slots
 
   - Conference.where(round: 2).each do |conference|
     tr
@@ -21,6 +22,7 @@ table.table.table-striped.table-bordered.table-condensed.conferences
       td = format_conference_date(conference.starts_on, conference.ends_on)
       td = conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-'
       td = conference.tickets_left
+      td = conference.lightningtalkslots
 
 p = link_to "View as Calendar", calendar_path
 p = link_to "Show/Hide First Round Conferences", "#", onclick: "$('.first-conferences').toggle()"
@@ -36,6 +38,7 @@ p = link_to "Show/Hide First Round Conferences", "#", onclick: "$('.first-confer
       th = sortable 'starts_on', 'Date'
       th Attendees
       th Tickets left
+      th Lightning Talk Slots
 
     - Conference.where(round: 1).each do |conference|
       tr
@@ -44,3 +47,4 @@ p = link_to "Show/Hide First Round Conferences", "#", onclick: "$('.first-confer
         td = format_conference_date(conference.starts_on, conference.ends_on)
         td = conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-'
         td = conference.tickets_left
+        td = conference.lightningtalkslots

--- a/app/views/conferences/index.html.slim
+++ b/app/views/conferences/index.html.slim
@@ -22,7 +22,10 @@ table.table.table-striped.table-bordered.table-condensed.conferences
       td = format_conference_date(conference.starts_on, conference.ends_on)
       td = conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-'
       td = conference.tickets_left
-      td = conference.lightningtalkslots
+      - if conference.lightningtalkslots?
+      		td = "yes"
+      - else
+      		td = "no"
 
 p = link_to "View as Calendar", calendar_path
 p = link_to "Show/Hide First Round Conferences", "#", onclick: "$('.first-conferences').toggle()"
@@ -47,4 +50,7 @@ p = link_to "Show/Hide First Round Conferences", "#", onclick: "$('.first-confer
         td = format_conference_date(conference.starts_on, conference.ends_on)
         td = conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-'
         td = conference.tickets_left
-        td = conference.lightningtalkslots
+        - if conference.lightningtalkslots?
+      		td = "yes"
+        - else
+      		td = "no"

--- a/app/views/conferences/show.html.slim
+++ b/app/views/conferences/show.html.slim
@@ -26,6 +26,8 @@ h1 class="conference" = conference.name
     dd = format_conference_scholarships(conference.tickets, conference.flights, conference.accomodation)
     dt Tickets left
     dd = conference.tickets_left
+    dt Lightning Talk Slots
+    dd = conference.lightningtalkslots
 
   h4 Attendees
   ul.attendees

--- a/app/views/conferences/show.html.slim
+++ b/app/views/conferences/show.html.slim
@@ -27,7 +27,10 @@ h1 class="conference" = conference.name
     dt Tickets left
     dd = conference.tickets_left
     dt Lightning Talk Slots
-    dd = conference.lightningtalkslots
+    - if conference.lightningtalkslots?
+      		dd = "yes"
+    - else
+      		dd = "no"
 
   h4 Attendees
   ul.attendees

--- a/db/migrate/20160410084420_add_lightningtalkslots_to_conferences.rb
+++ b/db/migrate/20160410084420_add_lightningtalkslots_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddLightningtalkslotsToConferences < ActiveRecord::Migration
+  def change
+    add_column :conferences, :lightningtalkslots, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160409202420) do
+ActiveRecord::Schema.define(version: 20160410084420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,18 +111,19 @@ ActiveRecord::Schema.define(version: 20160409202420) do
   add_index "comments", ["project_id"], name: "index_comments_on_project_id", using: :btree
 
   create_table "conferences", force: :cascade do |t|
-    t.string   "name",         limit: 255
-    t.string   "location",     limit: 255
-    t.string   "twitter",      limit: 255
-    t.string   "url",          limit: 255
+    t.string   "name",               limit: 255
+    t.string   "location",           limit: 255
+    t.string   "twitter",            limit: 255
+    t.string   "url",                limit: 255
     t.date     "starts_on"
     t.date     "ends_on"
     t.integer  "tickets"
     t.integer  "accomodation"
     t.integer  "flights"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
-    t.integer  "round",                    default: 1
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+    t.integer  "round",                          default: 1
+    t.boolean  "lightningtalkslots"
   end
 
   create_table "mailings", force: :cascade do |t|


### PR DESCRIPTION
@carpodaster 
I have added Lightning Talk Slots checkbox to new conference form and also a field for displaying the same in the list of conferences page.
![new_conference_form](https://cloud.githubusercontent.com/assets/18331427/14409065/8845463a-ff2a-11e5-9925-3dc8002909e8.png)
![conferences_display](https://cloud.githubusercontent.com/assets/18331427/14409066/8bff3a24-ff2a-11e5-9d6b-86436b9435da.png)
![display_individual_conference](https://cloud.githubusercontent.com/assets/18331427/14409067/8df2364c-ff2a-11e5-8e64-4f6099a17da4.png)
Made changes in the following files:
1. db/schema.rb
2. conferences_controller.rb
3. views/conferences/_form.html.slim
4. views/conferences/show.html.slim
5. views/conferences/index.html.slim