### PR TITLE
Limiting the number of Conferences(Issue414)

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -1,6 +1,14 @@
 class ConferencesController < ApplicationController
   load_and_authorize_resource except: [:index, :show]
 
+  def new
+    if Conference.count == 3
+      redirect_to conferences_path, notice: 'The maximum number of conferences is 3.'
+    end
+  end
+  def index
+    @conference = Conference.count
+  end
   def create
     conference.save!
     redirect_to conference

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -9,6 +9,6 @@ class Conference < ActiveRecord::Base
 
   def tickets_left
     confirmed_attendances = attendances.select { |attendance| attendance.confirmed }
-    tickets - confirmed_attendances.size
+    tickets = confirmed_attendances.size
   end
 end


### PR DESCRIPTION
Hey @carpodaster ,I have put a condition check on number of conferences limiting it to a maximum number of 3. A note will be displayed if an applicant tries to add more than 3 conferences.
![conf3](https://cloud.githubusercontent.com/assets/13950129/14410554/487df9d6-ff50-11e5-9670-38064106c64f.png)
This image shows the instance when there are 3 conferences.
![2conf3](https://cloud.githubusercontent.com/assets/13950129/14410570/5ef27188-ff50-11e5-8257-5a4fe78e0530.png)
This image shows the instance when the new conference button is clicked when there are already 3 conferences, i.e a note is displayed and it is redirected to the same page.
