### PR TITLE
Show only selected teams in the /orga/teams

### DIFF
--- a/app/controllers/orga/teams_controller.rb
+++ b/app/controllers/orga/teams_controller.rb
@@ -10,6 +10,9 @@ class Orga::TeamsController < Orga::BaseController
     else
       @teams = Team.order(:kind, :name)
     end
+    if params[:filter] != 'all'
+      @teams = @teams.where(season: current_season).select { |team| team.sponsored? || team.voluntary? }
+    end
   end
 
   def show

--- a/app/views/orga/teams/index.html.slim
+++ b/app/views/orga/teams/index.html.slim
@@ -1,6 +1,8 @@
 nav.actions
   ul.list-inline
     li = link_to icon('plus', 'New Team'), new_orga_team_path, class: 'btn btn-default btn-sm'
+    li = link_to 'Show all teams', orga_teams_path(filter: :all)
+    li = link_to 'Show only selected teams', orga_teams_path
     li = link_to 'Teams organizers info &rarr;'.html_safe, teams_info_path
 
 = render 'teams/table', namespace: :orga

--- a/spec/controllers/orga/teams_controller_spec.rb
+++ b/spec/controllers/orga/teams_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Orga::TeamsController do
   render_views
 
   let(:user) { create(:user) }
-  let(:team) { create(:team) }
+  let(:team) { create(:team, :current_season, kind: nil) }
 
   let(:valid_attributes) { build(:team).attributes.merge(roles_attributes: [{ name: 'coach', github_handle: 'tobias' }]) }
 
@@ -17,12 +17,19 @@ RSpec.describe Orga::TeamsController do
   context 'with admin logged in' do
     include_context 'with admin logged in'
 
-    describe "GET index" do
-      it "assigns all teams as @teams" do
+    describe 'GET index' do
+      let!(:voluntary_team)  { create :team, :current_season, kind: 'voluntary' }
+      let!(:sponsored_team)  { create :team, :current_season, kind: 'sponsored' }
+
+      it 'assigns only selected teams as @teams' do
         get :index
-        expect(assigns(:teams).to_a).to be == [team]
+        expect(assigns(:teams)).to match_array [voluntary_team, sponsored_team]
       end
 
+      it 'assigns all teams as @teams when requested' do
+        get :index, filter: 'all' # or whatever param it will turn out to be
+        expect(assigns(:teams)).to match_array [voluntary_team, sponsored_team, team]
+      end
     end
 
     describe "GET show" do


### PR DESCRIPTION
This addresses #253, by showing only the selected teams and offering to show all teams.