### PR TITLE
Fix error caused by teams deleted post-application

### DIFF
--- a/app/controllers/rating/applications_controller.rb
+++ b/app/controllers/rating/applications_controller.rb
@@ -73,7 +73,7 @@ class Rating::ApplicationsController < Rating::BaseController
   end
 
   def applications
-    Application.includes(:ratings).where(season: current_season)
+    Application.includes(:ratings).where(season: current_season).where.not(team: nil)
   end
 
   def applications_table

--- a/spec/controllers/rating/applications_controller_spec.rb
+++ b/spec/controllers/rating/applications_controller_spec.rb
@@ -25,14 +25,26 @@ describe Rating::ApplicationsController do
           CreatesApplicationFromDraft.new(application_draft).tap { |c| c.save }.application
         end
 
-        before { get :index }
-
         it 'initializes @applications as a new Application::Table' do
+          get :index
           expect(assigns :applications).to be_a Rating::Table
         end
 
         it 'lists all available applications' do
+          get :index
           expect(response).to be_success
+        end
+
+        context 'team deletes their profile' do
+
+          before do
+            application.team.destroy
+          end
+
+          it 'does not list their application' do
+            get :index
+            expect(assigns(:applications).rows).to be_empty
+          end
         end
       end
     end


### PR DESCRIPTION
Fingers crossed, this should eliminate the error caused by trying to list the rating section's applications