### PR TITLE
FIX: performance evaluation should not change when called multiple times

### DIFF
--- a/app/models/team_performance.rb
+++ b/app/models/team_performance.rb
@@ -31,30 +31,34 @@ class TeamPerformance
 
   def comments_score
     latest_comment = @team.comments.ordered.first
-    if @team.comments.empty?
-      @score += 3 unless self.class.buffer_days?
-    elsif latest_comment.created_at <= Time.now-5.days
-      @score += 2
-    elsif latest_comment.created_at <= Time.now-2.days
-      @score += 1
-    elsif latest_comment.created_at > Time.now-2.days
-      @score += 0
-    else
-      @score += 1
+    if !self.class.buffer_days?
+      if @team.comments.empty?
+        @score += 3
+      elsif latest_comment.created_at <= Time.now-5.days
+        @score += 2
+      elsif latest_comment.created_at <= Time.now-2.days
+        @score += 1
+      elsif latest_comment.created_at > Time.now-2.days
+        @score += 0
+      else
+        @score += 1
+      end
     end
   end
 
   def activity_score
-    if @team.activities.empty?
-      @score += 3 unless self.class.buffer_days?
-    elsif @team.last_activity.created_at <= Time.now-5.days
-      @score += 2
-    elsif @team.last_activity.created_at <= Time.now-3.days
-      @score += 1
-    elsif @team.last_activity.created_at > Time.now-3.days
-      @score += 0
-    else
-      @score += 1
+    if !self.class.buffer_days?
+      if @team.activities.empty?
+        @score += 3
+      elsif @team.last_activity.created_at <= Time.now-5.days
+        @score += 2
+      elsif @team.last_activity.created_at <= Time.now-3.days
+        @score += 1
+      elsif @team.last_activity.created_at > Time.now-3.days
+        @score += 0
+      else
+        @score += 1
+      end
     end
   end
 

--- a/app/models/team_performance.rb
+++ b/app/models/team_performance.rb
@@ -6,11 +6,6 @@ class TeamPerformance
     @score = 0
   end
 
-  def buffer_days?
-    # the first few days, plus the days before and after the coding season
-    Time.now < Season.current.starts_at+2.days || !Season.current.started? || Time.now > Season.current.ends_at+2.days
-  end
-
   def evaluation
     comments_score
     activity_score
@@ -28,10 +23,15 @@ class TeamPerformance
 
   private
 
+  def self.buffer_days?
+    # the first few days, plus the days before and after the coding season
+    Time.now < Season.current.starts_at+2.days || !Season.current.started? || Time.now > Season.current.ends_at+2.days
+  end
+
   def comments_score
     latest_comment = @team.comments.ordered.first
     if @team.comments.empty?
-      @score += 3 unless buffer_days?
+      @score += 3 unless self.class.buffer_days?
     elsif latest_comment.created_at <= Time.now-5.days
       @score += 2
     elsif latest_comment.created_at <= Time.now-2.days
@@ -45,7 +45,7 @@ class TeamPerformance
 
   def activity_score
     if @team.activities.empty?
-      @score += 3 unless buffer_days?
+      @score += 3 unless self.class.buffer_days?
     elsif @team.last_activity.created_at <= Time.now-5.days
       @score += 2
     elsif @team.last_activity.created_at <= Time.now-3.days

--- a/app/models/team_performance.rb
+++ b/app/models/team_performance.rb
@@ -3,10 +3,11 @@ class TeamPerformance
 
   def initialize(team)
     @team = team
-    @score = 0
   end
 
   def evaluation
+    @score = 0
+
     comments_score
     activity_score
 

--- a/spec/models/team_performance_spec.rb
+++ b/spec/models/team_performance_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe TeamPerformance do
+  let(:future_season) { build_stubbed :season, starts_at: 10.days.from_now, ends_at: 3.months.from_now }
+  let(:current_season) { build_stubbed :season, starts_at: 10.days.ago, ends_at: 2.months.from_now }
+  let(:past_season) { build_stubbed :season, starts_at: 2.months.ago, ends_at: 10.days.ago }
+
+  context 'for a team without activites and feedback' do
+    let(:team) { build_stubbed :team }
+    subject { TeamPerformance.new(team) }
+
+    describe "#evaluation" do
+      it "signals green before the season starts" do
+        allow(Season).to receive(:current).and_return(future_season)
+
+        expect(subject.evaluation).to eq(:green)
+      end
+
+      it "signals red before the season starts" do
+        allow(Season).to receive(:current).and_return(current_season)
+
+        expect(subject.evaluation).to eq(:red)
+      end
+
+      it "signals green after the season ends" do
+        allow(Season).to receive(:current).and_return(past_season)
+
+        expect(subject.evaluation).to eq(:green)
+      end
+    end
+  end
+
+  context 'for a team without activites but with recent feedback' do
+    let(:team) { create :team }
+    before { create :comment, team: team }
+    subject { TeamPerformance.new(team) }
+
+    it "signals green before the season starts" do
+      allow(Season).to receive(:current).and_return(future_season)
+
+      expect(subject.evaluation).to eq(:green)
+    end
+
+    it "signals orange during the season" do
+      allow(Season).to receive(:current).and_return(current_season)
+
+      expect(subject.evaluation).to eq(:orange)
+    end
+
+    it "signals orange after evaluation was called multiple times" do
+      allow(Season).to receive(:current).and_return(current_season)
+
+      10.times { subject.evaluation }
+      expect(subject.evaluation).to eq(:orange)
+    end
+
+    it "signals green after the season" do
+      allow(Season).to receive(:current).and_return(past_season)
+
+      expect(subject.evaluation).to eq(:green)
+    end
+  end
+
+  context 'for a team with recent activities but without feedback' do
+    let(:team) { create :team }
+    before { create :activity, team: team }
+    subject { TeamPerformance.new(team) }
+
+    it "signals green before the season starts" do
+      allow(Season).to receive(:current).and_return(future_season)
+
+      expect(subject.evaluation).to eq(:green)
+    end
+
+    it "signals orange during the season" do
+      allow(Season).to receive(:current).and_return(current_season)
+
+      expect(subject.evaluation).to eq(:orange)
+    end
+
+    it "signals green after the season" do
+      allow(Season).to receive(:current).and_return(past_season)
+
+      expect(subject.evaluation).to eq(:green)
+    end
+  end
+
+  context 'for a team with older activities and older feedback' do
+    let(:team) { create :team }
+    before { create :comment, team: team, created_at: 4.days.ago }
+    before { create :activity, team: team, created_at: 4.days.ago }
+    subject { TeamPerformance.new(team) }
+
+    it "signals green before the season starts" do
+      allow(Season).to receive(:current).and_return(future_season)
+
+      expect(subject.evaluation).to eq(:green)
+    end
+
+    it "signals orange during the season" do
+      allow(Season).to receive(:current).and_return(current_season)
+
+      expect(subject.evaluation).to eq(:orange)
+    end
+
+    it "signals green after the season" do
+      allow(Season).to receive(:current).and_return(past_season)
+
+      expect(subject.evaluation).to eq(:green)
+    end
+  end
+
+  context 'for a team with recent activities and recent feedback' do
+    let(:team) { create :team }
+    before { create :comment, team: team }
+    before { create :activity, team: team }
+    subject { TeamPerformance.new(team) }
+
+    it "signals green before the season starts" do
+      allow(Season).to receive(:current).and_return(future_season)
+
+      expect(subject.evaluation).to eq(:green)
+    end
+
+    it "signals green during the season" do
+      allow(Season).to receive(:current).and_return(current_season)
+
+      expect(subject.evaluation).to eq(:green)
+    end
+
+    it "signals green after the season" do
+      allow(Season).to receive(:current).and_return(past_season)
+
+      expect(subject.evaluation).to eq(:green)
+    end
+  end
+end


### PR DESCRIPTION
This fixes a bug (that was probably not occurring in the app directly) where each time evaluation was called the resulting score would be added to the last score (so after a few calls it would be higher than it should be). Since it's mostly your code @F3PiX, does this look fine to you?

(I found this while building the log update reminder in #256 which I'll add to this class as well, that is the reason why I also moved the self.buffer_days? method to a class method.)