### PR TITLE
More and better seeding

### DIFF
--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -1,0 +1,15 @@
+class ReminderMailer < ActionMailer::Base
+  include ActionView::Helpers::TextHelper
+
+  default from: ENV['EMAIL_FROM'] || 'summer-of-code@railsgirls.com'
+
+  def update_log(team)
+    @team = team
+    mail subject: subject, to: team.students.pluck(:email)
+  end
+
+  private
+    def subject
+      "[rgsoc-teams] Reminder: please update your team log"
+    end
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -19,7 +19,7 @@ class Role < ActiveRecord::Base
   validates :user_id, uniqueness: { scope: [:name, :team_id] }
 
   before_create :set_confirmation_token
-  after_create :send_notification, if: Proc.new { GUIDE_ROLES.include?(self.name) }
+  after_commit :send_notification, on: :create, if: -> { GUIDE_ROLES.include?(name) }
 
   after_create do |role|
     role.confirm! unless role.name == 'coach'

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -13,6 +13,10 @@ class Season < ActiveRecord::Base
       find_or_create_by(name: (Date.today.year+1).to_s)
     end
 
+    def prev
+      find_or_create_by(name: (Date.today.year-1).to_s)
+    end
+
     # Project proposals open early. This predicate tells us if
     # we are in the transition phase after the current season's
     # coding period but before the new year (i.d. 'Season') begun.

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -31,6 +31,10 @@ class Team < ActiveRecord::Base
   before_create :set_number
   before_save :set_last_checked, if: :checked
 
+  scope :without_recent_log_update, -> {
+    where.not(id: Activity.where(kind: 'status_update').where("created_at > ?", 26.hours.ago).pluck(:team_id))
+  }
+
   class << self
     def ordered(sort = {})
       order([sort[:order] || 'kind, name', sort[:direction] || 'asc'].join(' '))

--- a/app/models/team_performance.rb
+++ b/app/models/team_performance.rb
@@ -1,5 +1,13 @@
 class TeamPerformance
-# Memo: calculates Team's Performance Score for Supervisor's Dashboard
+# Internal: calculates a Team's performance score for supervisor's dashboard
+
+  def self.teams_to_remind
+    if buffer_days?
+      Team.none
+    else
+      Team.by_season_phase.without_recent_log_update
+    end
+  end
 
   def initialize(team)
     @team = team

--- a/app/views/reminder_mailer/update_log.text.erb
+++ b/app/views/reminder_mailer/update_log.text.erb
@@ -1,0 +1,11 @@
+Hey there!
+
+This is a reminder to please update your team log - since your last entry was created more than 24 hours ago! We require all teams of RGSoC to daily update their log (except weekends). Thank you.
+
+Cheers,
+your friendly RGSoC-Teams-App Robot
+
+
+
+P.S.:
+This email is triggered by an automated test. If you actually ​*did*​ update your log in the last 24 hours, please let us know: summer-of-code@railsgirls.com.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,7 @@
+FactoryGirl.create_list(:team, 5, :current_season, kind: "sponsored")
+FactoryGirl.create(:team, :current_season, kind: "voluntary")
+
+
 FactoryGirl.create_list(:student, 12)
 FactoryGirl.create_list(:coach, 3)
 FactoryGirl.create_list(:organizer, 2)
@@ -5,7 +9,17 @@ FactoryGirl.create(:mentor)
 FactoryGirl.create(:supervisor)
 
 # To explore use cases where user has no role yet
-# NB These are not listed in the Community listing
-FactoryGirl.create_list(:user, 6)
+FactoryGirl.create_list(:user, 3)
 
-FactoryGirl.create_list(:status_update, 5, published_at: Time.now)
+#Create status updates for different teams
+5.times do
+FactoryGirl.create(:status_update, published_at: Time.now, team_id: (0..Team.all.count).to_a.sample)
+end
+
+
+FactoryGirl.create(:application_draft)
+FactoryGirl.create(:application_draft, :appliable)
+
+FactoryGirl.create(:project) #proposed
+FactoryGirl.create(:project, :accepted)
+FactoryGirl.create(:project, :rejected)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,9 @@ FactoryGirl.create(:team, :last_season, kind: "sponsored")
 FactoryGirl.create(:team, :last_season, kind: "voluntary")
 
 # Users with different roles
+FactoryGirl.create_list(:team, 5, :current_season, kind: "sponsored")
+FactoryGirl.create(:team, :current_season, kind: "voluntary")
+
 FactoryGirl.create_list(:student, 12)
 FactoryGirl.create_list(:coach, 3)
 FactoryGirl.create_list(:organizer, 2)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,7 @@
 FactoryGirl.create_list(:team, 5, :current_season, kind: "sponsored")
 FactoryGirl.create(:team, :current_season, kind: "voluntary")
+FactoryGirl.create(:team, :last_season, kind: "sponsored")
+FactoryGirl.create(:team, :last_season, kind: "voluntary")
 
 FactoryGirl.create_list(:student, 12)
 FactoryGirl.create_list(:coach, 3)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,6 @@
 FactoryGirl.create_list(:team, 5, :current_season, kind: "sponsored")
 FactoryGirl.create(:team, :current_season, kind: "voluntary")
 
-
 FactoryGirl.create_list(:student, 12)
 FactoryGirl.create_list(:coach, 3)
 FactoryGirl.create_list(:organizer, 2)
@@ -13,7 +12,7 @@ FactoryGirl.create_list(:user, 3)
 
 #Create status updates for different teams
 5.times do
-FactoryGirl.create(:status_update, published_at: Time.now, team_id: (0..Team.all.count).to_a.sample)
+  FactoryGirl.create(:status_update, published_at: Time.now, team: Team.all.sample)
 end
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,6 @@ end
 FactoryGirl.create(:application_draft)
 FactoryGirl.create(:application_draft, :appliable)
 
-FactoryGirl.create(:project) #proposed
-FactoryGirl.create(:project, :accepted)
-FactoryGirl.create(:project, :rejected)
+FactoryGirl.create(:project, :current) #proposed
+FactoryGirl.create(:project, :accepted, :current)
+FactoryGirl.create(:project, :rejected, :current)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,12 @@
+# Teams
 FactoryGirl.create_list(:team, 5, :current_season, kind: "sponsored")
 FactoryGirl.create(:team, :current_season, kind: "voluntary")
+FactoryGirl.create (:team, :current_season) #not accepted
+
 FactoryGirl.create(:team, :last_season, kind: "sponsored")
 FactoryGirl.create(:team, :last_season, kind: "voluntary")
 
+# Users with different roles
 FactoryGirl.create_list(:student, 12)
 FactoryGirl.create_list(:coach, 3)
 FactoryGirl.create_list(:organizer, 2)
@@ -12,12 +16,13 @@ FactoryGirl.create(:supervisor)
 # To explore use cases where user has no role yet
 FactoryGirl.create_list(:user, 3)
 
-#Create status updates for different teams
+
+# Status updates for different teams
 5.times do
   FactoryGirl.create(:status_update, published_at: Time.now, team: Team.all.sample)
 end
 
-
+# Applications and their projects
 FactoryGirl.create(:application_draft)
 FactoryGirl.create(:application_draft, :appliable)
 

--- a/lib/mailer_previews/role_mailer_preview.rb
+++ b/lib/mailer_previews/role_mailer_preview.rb
@@ -1,3 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/role_mailer
 class RoleMailerPreview < ActionMailer::Preview
   def user_added_to_team
     RoleMailer.user_added_to_team(Role.first)
@@ -5,5 +6,10 @@ class RoleMailerPreview < ActionMailer::Preview
 
   def coach_added_to_team
     RoleMailer.user_added_to_team(Role.where(name: 'coach').first)
+  end
+
+  def supervisor_added_to_team
+    role = Role.where(name: 'supervisor').first
+    RoleMailer.user_added_to_team role
   end
 end

--- a/lib/tasks/teams.rake
+++ b/lib/tasks/teams.rake
@@ -1,0 +1,13 @@
+require 'feed'
+
+namespace :teams do
+  desc 'Notify teams to update their status log'
+  task notify_missing_log_updates: :environment do
+    # we do not send annoying emails on weekends:
+    if !(Date.today.saturday? || Date.today.sunday?)
+      TeamPerformance.teams_to_remind.each do |team|
+        ReminderMailer.update_log(team).deliver_later
+      end
+    end
+  end
+end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -11,6 +11,10 @@ FactoryGirl.define do
       season { Season.current }
     end
 
+    trait :last_season do
+      season { Season.prev }
+    end
+
     trait :supervise do
       name 'supervise'
     end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :team do
     kind 'sponsored'
-    sequence(:name) { |i| "#{i}-#{FFaker::CheesyLingo.word}" }
+    sequence(:name) { |i| "#{i}-#{FFaker::CheesyLingo.word.capitalize}" }
 
     trait :helpdesk do
       name 'helpdesk'

--- a/spec/mailers/previews/reminder_mailer_preview.rb
+++ b/spec/mailers/previews/reminder_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/reminder_mailer
+class ReminderMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe ReminderMailer, type: :mailer do
+  let(:student_1_email) { 'someone@nowhere.com' }
+  let(:student_2_email) { 'free@hat.com' }
+
+  let(:team) {
+    team = create :team, kind: 'sponsored'
+    create :student, team: team, email: student_1_email
+    create :student, team: team, email: student_2_email
+    team
+  }
+
+  describe '#update_log' do
+    let :mail do
+      ReminderMailer.update_log(team)
+    end
+
+    it 'should send to the students' do
+      expect(mail.to.count).to eq(2)
+      expect(mail.to).to include(student_1_email)
+      expect(mail.to).to include(student_2_email)
+    end
+
+    it 'contain a reference to the app in the subect' do
+      expect(mail.subject).to include('[rgsoc-teams]')
+    end
+  end
+end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -208,6 +208,40 @@ describe Team do
         end
       end
     end
+
+    describe '.without_recent_log_update' do
+      let(:team_without) do
+        create :team
+      end
+
+      let(:team_with_old) do
+        team_with_old = create :team
+        create :status_update, created_at: 2.days.ago, team: team_with_old
+        team_with_old
+      end
+
+      let(:team_with_recent) do
+        team_with_recent = create :team
+        create :status_update, created_at: 1.hour.ago, team: team_with_recent
+        team_with_recent
+      end
+
+      it 'includes the team without any status updates' do
+        team_without
+        expect(described_class.without_recent_log_update).to include(team_without)
+      end
+
+      it 'includes the team with only old updates' do
+        team_with_old
+        expect(described_class.without_recent_log_update).to include(team_with_old)
+      end
+
+      it 'does not include the team with recent updates' do
+        team_with_recent
+        expect(described_class.without_recent_log_update).not_to include(team_with_recent)
+      end
+    end
+
   end
 
   describe 'creating a new team' do


### PR DESCRIPTION
Issue #225 
Adds seeds for users, teams and status updates.
First try for Application Drafts and Projects.

- [x] An unaccepted team
- [x] An accepted team
- [x] An accepted, but voluntary team
- [x]  Teams from last season
- [x] Status updates per team  
- [x] An application draft, unsubmitted
- [x] An application draft, completed
- [x] A proposed project
- [x] An accepted project
- [x] A rejected project