### PR TITLE
Improve confirmation email for non-coaches

### DIFF
--- a/app/views/role_mailer/user_added_to_team.html.slim
+++ b/app/views/role_mailer/user_added_to_team.html.slim
@@ -9,12 +9,12 @@ html
       | }
   body
     p
-      ' You have been added to the
+      ' You have been added to Team
       a>[href=team_url(@role.team)]= @role.team.name
       | as a #{@role.name}.
 
-    - if @role.name == 'coach'
-      p
-        ' Please confirm that you are indeed willing to join the team as their coach.
-        ' You can do so on the team's overview page listed above (make sure you are
-        ' logged in using your Github account).
+      - if @role.name == 'coach'
+        p
+          ' Please confirm that you are indeed willing to join the team as their coach.
+          ' You can do so on the team's overview page listed above (make sure you are
+          ' logged in using your Github account).

--- a/app/views/role_mailer/user_added_to_team.text.erb
+++ b/app/views/role_mailer/user_added_to_team.text.erb
@@ -1,7 +1,7 @@
-You have been added to the <%= @role.team.name %> as a <%= @role.name %>.
+You have been added to Team <%= @role.team.name %> as a <%= @role.name %>.
 
 Visit the team at <%= team_url(@role.team) %>
 
-Please confirm that you are indeed willing to join the team as their coach.
+For coaches only: Please confirm that you are indeed willing to join the team as their coach.
 You can do so on the team's overview page listed above (make sure you are
 logged in using your Github account).

--- a/app/views/role_mailer/user_added_to_team.text.erb
+++ b/app/views/role_mailer/user_added_to_team.text.erb
@@ -2,6 +2,8 @@ You have been added to Team <%= @role.team.name %> as a <%= @role.name %>.
 
 Visit the team at <%= team_url(@role.team) %>
 
-For coaches only: Please confirm that you are indeed willing to join the team as their coach.
+<% if @role.name == 'coach' %>
+Please confirm that you are indeed willing to join the team as their coach.
 You can do so on the team's overview page listed above (make sure you are
 logged in using your Github account).
+<% end %>


### PR DESCRIPTION
Supervisors and mentors were incorrectly adressed as a coach in the mailer that confirms their role.
  

Bug #476 