### PR TITLE
Solve Season Switch error

### DIFF
--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -57,7 +57,7 @@ class Orga::SeasonsController < Orga::BaseController
       when 'CodingSummer'
         @season.fake_coding_phase
       when 'RealTime'
-        @season.destroy
+        @season.back_to_reality
       end
     redirect_to orga_seasons_path, notice: "We time travelled into the #{params[:option]} phase"
   end

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -80,6 +80,18 @@ class Season < ActiveRecord::Base
     })
   end
 
+  def back_to_reality
+    update({
+       name: Date.today.year,
+       starts_at: Time.utc(Date.today.year, 7, 1),
+       ends_at: Time.utc(Date.today.year, 9, 30),
+       applications_open_at: Time.utc(Date.today.year, 3, 1),
+       applications_close_at: Time.utc(Date.today.year, 3, 31),
+       acceptance_notification_at: Time.utc(Date.today.year, 5, 1)
+           })
+
+  end
+
   def transition?
     year == Date.today.year.to_s and ended?
   end

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -88,8 +88,7 @@ class Season < ActiveRecord::Base
        applications_open_at: Time.utc(Date.today.year, 3, 1),
        applications_close_at: Time.utc(Date.today.year, 3, 31),
        acceptance_notification_at: Time.utc(Date.today.year, 5, 1)
-           })
-
+     })
   end
 
   def transition?


### PR DESCRIPTION
Solves #491
Before, the season switch to real time did season.destroy. This broke the references, especially from the seeds (only in dev env). Now the season switch updates the current season, and the references from the seeds work again.