### PR TITLE
Show relevant teams only in dropdown menu

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -22,7 +22,7 @@ class ActivitiesController < ApplicationController
     end
 
     def teams
-      Team.where(season: Season.current, kind: %w(sponsored voluntary)).order(:name)
+      Team.in_current_season.selected.order(:name)
     end
     helper_method :teams
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -22,7 +22,7 @@ class ActivitiesController < ApplicationController
     end
 
     def teams
-      Team.in_current_season.selected.order(:name)
+      Team.current_season.selected.order(:name)
     end
     helper_method :teams
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -22,7 +22,7 @@ class ActivitiesController < ApplicationController
     end
 
     def teams
-      Team.current_season.selected.order(:name)
+      Team.current.selected.order(:name)
     end
     helper_method :teams
 

--- a/app/controllers/orga/teams_controller.rb
+++ b/app/controllers/orga/teams_controller.rb
@@ -11,7 +11,7 @@ class Orga::TeamsController < Orga::BaseController
       @teams = Team.order(:kind, :name)
     end
     if params[:filter] != 'all'
-      @teams = Team.current_season.selected.ordered
+      @teams = Team.current.selected.ordered
     end
   end
 

--- a/app/controllers/orga/teams_controller.rb
+++ b/app/controllers/orga/teams_controller.rb
@@ -11,7 +11,7 @@ class Orga::TeamsController < Orga::BaseController
       @teams = Team.order(:kind, :name)
     end
     if params[:filter] != 'all'
-      @teams = @teams.where(season: current_season).select { |team| team.sponsored? || team.voluntary? }
+      @teams = Team.in_current_season.selected.ordered
     end
   end
 

--- a/app/controllers/orga/teams_controller.rb
+++ b/app/controllers/orga/teams_controller.rb
@@ -11,7 +11,7 @@ class Orga::TeamsController < Orga::BaseController
       @teams = Team.order(:kind, :name)
     end
     if params[:filter] != 'all'
-      @teams = Team.in_current_season.selected.ordered
+      @teams = Team.current_season.selected.ordered
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -82,7 +82,7 @@ class UsersController < ApplicationController
 
     def teams
       all_teams = Team.all.order(:name)
-      selected_teams = Team.current_season.selected.order(:name)
+      selected_teams = Team.in_current_season.selected.order(:name)
       current_season.active? ? selected_teams : all_teams
     end
     helper_method :teams

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -82,7 +82,7 @@ class UsersController < ApplicationController
 
     def teams
       all_teams = Team.all.order(:name)
-      selected_teams = Team.active_teams.order(:name)
+      selected_teams = Team.current_season.selected.order(:name)
       current_season.active? ? selected_teams : all_teams
     end
     helper_method :teams

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -82,7 +82,7 @@ class UsersController < ApplicationController
 
     def teams
       all_teams = Team.all.order(:name)
-      selected_teams = Team.in_current_season.selected.order(:name)
+      selected_teams = Team.current_season.selected.order(:name)
       current_season.active? ? selected_teams : all_teams
     end
     helper_method :teams

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -82,7 +82,7 @@ class UsersController < ApplicationController
 
     def teams
       all_teams = Team.all.order(:name)
-      selected_teams = Team.current_season.selected.order(:name)
+      selected_teams = Team.current.selected.order(:name)
       current_season.active? ? selected_teams : all_teams
     end
     helper_method :teams

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -81,9 +81,9 @@ class UsersController < ApplicationController
     helper_method :conferences
 
     def teams
-      all_teams = Team.all
-      active_teams = Team.where(season: Season.current, kind: %w(sponsored voluntary)).order(:name)
-      current_season.active? ? active_teams : all_teams
+      all_teams = Team.all.order(:name)
+      selected_teams = Team.active_teams.order(:name)
+      current_season.active? ? selected_teams : all_teams
     end
     helper_method :teams
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,7 +31,6 @@ class UsersController < ApplicationController
   def edit
     if current_user.admin?
       @user.attendances.build unless @user.attendances.any?
-      @teams = Team.all
     end
   end
 
@@ -80,6 +79,13 @@ class UsersController < ApplicationController
       @conferences ||= Conference.order(:name)
     end
     helper_method :conferences
+
+    def teams
+      all_teams = Team.all
+      active_teams = Team.where(season: Season.current, kind: %w(sponsored voluntary)).order(:name)
+      current_season.active? ? active_teams : all_teams
+    end
+    helper_method :teams
 
     def user_params
       params.require(:user).permit(

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -36,6 +36,10 @@ class Season < ActiveRecord::Base
     Time.now.utc >= (applications_open_at || 1.week.from_now)
   end
 
+  def active?
+    Time.now.utc.between?(acceptance_notification_at, ends_at)
+  end
+
   def started?
     Time.now.utc >= (starts_at || 1.week.from_now)
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -54,9 +54,14 @@ class Team < ActiveRecord::Base
       end
     end
 
-    def active_teams
-      Team.where(season: Season.current, kind: %w(sponsored voluntary)).order(:name)
+    def current_season
+      where(season: Season.current)
     end
+
+    def selected
+      where(kind: %w(sponsored voluntary))
+    end
+
   end
 
   def application

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -48,13 +48,13 @@ class Team < ActiveRecord::Base
     # phase of the running season we're currently in.
     def by_season_phase
       if Time.now.utc > Season.current.acceptance_notification_at
-        Team.current_season.selected
+        Team.current.selected
       else
-        Team.current_season.visible
+        Team.current.visible
       end
     end
 
-    def current_season
+    def current
       where(season: Season.current)
     end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -45,16 +45,16 @@ class Team < ActiveRecord::Base
     end
 
     # Returns a base scope reflecting the relevant teams depending on what
-    # phase of the running season we're currently in.
+    # phase of the running season we're currentin_ly in.
     def by_season_phase
       if Time.now.utc > Season.current.acceptance_notification_at
-        Team.where season: Season.current, kind: %w(sponsored voluntary)
+        Team.in_current_season.selected
       else
-        Team.visible.where season: Season.current
+        Team.in_current_season.visible
       end
     end
 
-    def current_season
+    def in_current_season
       where(season: Season.current)
     end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -53,6 +53,10 @@ class Team < ActiveRecord::Base
         Team.visible.where season: Season.current
       end
     end
+
+    def active_teams
+      Team.where(season: Season.current, kind: %w(sponsored voluntary)).order(:name)
+    end
   end
 
   def application

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -45,16 +45,16 @@ class Team < ActiveRecord::Base
     end
 
     # Returns a base scope reflecting the relevant teams depending on what
-    # phase of the running season we're currentin_ly in.
+    # phase of the running season we're currently in.
     def by_season_phase
       if Time.now.utc > Season.current.acceptance_notification_at
-        Team.in_current_season.selected
+        Team.current_season.selected
       else
-        Team.in_current_season.visible
+        Team.current_season.visible
       end
     end
 
-    def in_current_season
+    def current_season
       where(season: Season.current)
     end
 

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -115,7 +115,7 @@
   - if admin?
     h3.page-header Roles
     = f.simple_fields_for :roles do |r|
-        = r.input :team_id, as: :select, collection: @teams, required: false
+        = r.input :team_id, as: :select, collection: teams, required: false
         = r.input :name, as: :select, collection: Role::ROLES
         = r.link_to_remove 'Remove', class: 'btn btn-default'
     = f.link_to_add 'Add another role', :roles, class: 'btn btn-primary form-btn-group'


### PR DESCRIPTION
Solves #485 

From the day the acceptance letters are sent through the coding summer, only selected teams will turn up in the user profile editor (for orga's only). 
Plus some refactored Team.scopes
