### PR TITLE
Fix conference styling #455

### DIFF
--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -184,8 +184,11 @@ html, body
       width: 100px
       font-weight: normal
   .conference
+    dl
+      width: 100%
     dt
-      width: 120px
+      width: 20%
+      text-align: left
 
   .status_update
     dl

--- a/app/views/conferences/show.html.slim
+++ b/app/views/conferences/show.html.slim
@@ -13,7 +13,7 @@ h1 class="conference" = conference.name
   p
 
 .conference
-  dl
+  dl.dl-horizontal
     dt Location
     dd = conference.location
     dt Date

--- a/app/views/orga/seasons/show.html.slim
+++ b/app/views/orga/seasons/show.html.slim
@@ -1,7 +1,7 @@
 h1 Season #{@season.name}
 
 .conference
-  dl
+  dl.dl-horizontal
     dt Year
     dd = @season.name
     dt Start Date


### PR DESCRIPTION
Files modified:

**app/assets/stylesheets/global.sass**

Deleted `.conference` from
  ```
.profile, .mailing,
    dl
      // margin-bottom: 1em
      @include clearfix
    dt
      float: left
      width: 100px
      font-weight: normal
```

Added
``` 
.conference-row, .season-row
    width: 100%
    dt, dd
      display: inline-block
    dt
      font-weight: 200%
  
 
.season-row
    dt
      width: 10%

  .conference-row
    dt
      width: 20%
```

**app/views/conferences/show.html.slim**

Added divs of class `.conference-row` like
```    
.conference-row
      dt Location
      dd = conference.location
```

**app/views/orga/seasons/show.html.slim**

Added divs of class `.season-row` like
```   
 .season-row
      dt Year
      dd = @season.name
```
due to distinguish seasons styling from conferences styling (both had `.conference` class before) and make the code compatible with above mentioned changes

Result:
![screenshot from 2016-07-14 14-59-20](https://cloud.githubusercontent.com/assets/12581810/16842144/a00a2a90-49dc-11e6-9f5c-1be1309661d2.png)
![screenshot from 2016-07-14 14-59-25](https://cloud.githubusercontent.com/assets/12581810/16842143/a0097a78-49dc-11e6-90c1-8211ec975519.png)
