### PR TITLE
Add option to show all public acitivities

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -27,7 +27,7 @@ class ActivitiesController < ApplicationController
     helper_method :teams
 
     def normalize_params
-      params[:kind] = '' if params[:kind] == 'all'
+      params[:kind] = 'all' if params[:kind].blank?
     end
 
     def whitelisted_kind

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -7,7 +7,7 @@ div.row
 
     div.selection-box
       form.filter.form-inline action=request.url
-        - public_activities.each do |kind|
+        - (['all'] + public_activities).each do |kind|
           label.radio
             = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
             = " " + kind == 'feed_entry' ? 'Blog Post' : kind.titleize


### PR DESCRIPTION
<img width="633" alt="screen shot 2016-07-19 at 21 31 32" src="https://cloud.githubusercontent.com/assets/656318/16963741/407e3c86-4df8-11e6-9899-03bc5b570606.png">

This adds a default option to show all public acitivity on the landing page. This way, one can also revert their choice if one of the two non-"All" options are selected.