### PR TITLE
Refactor current scope

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -22,7 +22,7 @@ class ActivitiesController < ApplicationController
     end
 
     def teams
-      Team.current.selected.order(:name)
+      Team.in_current_season.selected.order(:name)
     end
     helper_method :teams
 

--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -9,7 +9,7 @@ class ApplicationDraftsController < ApplicationController
   helper_method :application_draft
 
   def index
-    @application_drafts = current_user.application_drafts.current
+    @application_drafts = current_user.application_drafts.in_current_season
     redirect_to [:edit, @application_draft] and return if @application_draft = @application_drafts.first
   end
 
@@ -74,9 +74,9 @@ class ApplicationDraftsController < ApplicationController
 
   def application_draft
     @application_draft ||= if params[:id]
-                             current_team.application_drafts.current.find(params[:id])
+                             current_team.application_drafts.in_current_season.find(params[:id])
                            else
-                             current_team.application_drafts.current.new(team: current_team)
+                             current_team.application_drafts.in_current_season.new(team: current_team)
                            end.tap { |draft| draft.assign_attributes(current_user: current_user, updater: current_user) }
   end
 

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -20,7 +20,7 @@ class ConferencesController < ApplicationController
   private
 
     def conferences
-      @conferences ||= Conference.ordered(sort_params).current
+      @conferences ||= Conference.ordered(sort_params).in_current_season
     end
     helper_method :conferences
 

--- a/app/controllers/orga/projects_controller.rb
+++ b/app/controllers/orga/projects_controller.rb
@@ -2,7 +2,7 @@ class Orga::ProjectsController < Orga::BaseController
   before_action :find_resource, except: [:index]
 
   def index
-    @projects = Project.current
+    @projects = Project.in_current_season
   end
 
   def accept

--- a/app/controllers/orga/teams_controller.rb
+++ b/app/controllers/orga/teams_controller.rb
@@ -11,7 +11,7 @@ class Orga::TeamsController < Orga::BaseController
       @teams = Team.order(:kind, :name)
     end
     if params[:filter] != 'all'
-      @teams = Team.current.selected.ordered
+      @teams = Team.in_current_season.selected.ordered
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -22,7 +22,7 @@ class ProjectsController < ApplicationController
   end
 
   def index
-    @projects = Project.current.where(aasm_state: %w(accepted proposed))
+    @projects = Project.in_current_season.where(aasm_state: %w(accepted proposed))
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -82,7 +82,7 @@ class UsersController < ApplicationController
 
     def teams
       all_teams = Team.all.order(:name)
-      selected_teams = Team.current.selected.order(:name)
+      selected_teams = Team.in_current_season.selected.order(:name)
       current_season.active? ? selected_teams : all_teams
     end
     helper_method :teams

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,7 +76,7 @@ class UsersController < ApplicationController
     end
 
     def conferences
-      @conferences ||= Conference.current.order(:name)
+      @conferences ||= Conference.in_current_season.order(:name)
     end
     helper_method :conferences
 

--- a/app/exporters/projects.rb
+++ b/app/exporters/projects.rb
@@ -2,7 +2,7 @@ module Exporters
   class Projects < Base
 
     def current
-      projects = Project.current.includes(:submitter)
+      projects = Project.in_current_season.includes(:submitter)
 
       generate(projects, 'Project ID', 'Name', 'Submitter GH Handle', 'Mentor Name', 'Mentor GH Handle', 'Mentor Email', 'Website', 'Status', 'Tags') do |p|
         [p.id, p.name, p.submitter&.github_handle, p.mentor_name, p.mentor_github_handle, p.mentor_email, p.url, p.aasm_state, p.tags.sort.join(', ')]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,7 +11,7 @@ module ApplicationHelper
   end
 
   def application_disambiguation_link
-    if current_user && current_user.application_drafts.current.any?
+    if current_user && current_user.application_drafts.in_current_season.any?
       link_to 'My Application', application_drafts_path
     else
       link_to 'Apply now', apply_path

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,7 +59,7 @@ class Ability
     can :read, :mailing if signed_in?(user)
 
     # applications
-    can :create, :application_draft if user.student? && user.application_drafts.current.none?
+    can :create, :application_draft if user.student? && user.application_drafts.in_current_season.none?
   end
 
   def signed_in?(user)

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -14,7 +14,7 @@ class ApplicationDraft < ActiveRecord::Base
   has_one    :application
   belongs_to :signatory, class_name: 'User', foreign_key: :signed_off_by
 
-  scope :current, -> { where(season: Season.current) }
+  scope :in_current_season, -> { where(season: Season.current) }
 
   validates :team, presence: true
   validates :project1, :project_plan, presence: true, on: :apply

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -9,7 +9,7 @@ class Conference < ActiveRecord::Base
   accepts_nested_attributes_for :attendances
 
   scope :ordered, ->(sort = {}) { order([sort[:order] || 'starts_on, name', sort[:direction] || 'asc'].join(' ')) }
-  scope :current, -> { where(season: Season.current) }
+  scope :in_current_season, -> { where(season: Season.current) }
 
   def tickets_left
     confirmed_attendances = attendances.select { |attendance| attendance.confirmed }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,7 +10,7 @@ class Project < ActiveRecord::Base
 
   validates :name, :submitter, :mentor_email, presence: true
 
-  scope :current, -> do
+  scope :in_current_season, -> do
     where(season: Season.transition? ? Season.succ : Season.current)
   end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -30,7 +30,7 @@ class Student < SimpleDelegator
 
   def current_drafts
     @current_drafts ||= if current_team
-      current_team.application_drafts.current
+      current_team.application_drafts.in_current_season
     else
       []
     end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -48,13 +48,13 @@ class Team < ActiveRecord::Base
     # phase of the running season we're currently in.
     def by_season_phase
       if Time.now.utc > Season.current.acceptance_notification_at
-        Team.current.selected
+        Team.in_current_season.selected
       else
-        Team.current.visible
+        Team.in_current_season.visible
       end
     end
 
-    def current
+    def in_current_season
       where(season: Season.current)
     end
 

--- a/app/views/orga/teams/show.html.slim
+++ b/app/views/orga/teams/show.html.slim
@@ -72,12 +72,13 @@ nav.btn-group
   h3 Supervisors
   p = @team.supervisors.any? ? link_to_team_members(@team, :supervisor) : content_tag(:em, 'Will be added by RGSoC Organizers')
 
-- if @team.members.any? { |user| user.conferences.current.any? }
+- if @team.members.any? { |user| user.conferences.in_current_season.any? }
   h4 Conferences
   ul.conferences
     - @team.members.each do |user|
-      - if user.conferences.current.any?
-        li = "#{link_to user.name, user}: #{links_to_conferences(user.conferences.current, true).join(', ')}".html_safe
+      - if user.conferences.in_current_season.any?
+        li = "#{link_to user.name, user}: #{links_to_conferences(user.conferences.in_current_seasaon, true).join(',
+')}".html_safe
 
 - if @team.activities.any?
   h3 Activities

--- a/app/views/rating/applications/edit.html.slim
+++ b/app/views/rating/applications/edit.html.slim
@@ -4,7 +4,7 @@ h1 = "Application: #{@application.name}"
 
 = simple_form_for @form_path do |a|
   = a.input :misc_info
-  = a.association :project, collection: Project.current.order(:name), include_blank: '- none -'
+  = a.association :project, collection: Project.in_current_season.order(:name), include_blank: '- none -'
   = a.input :project_visibility
   = a.input :coaching_company
   = a.input :city

--- a/app/views/teams/_table.html.slim
+++ b/app/views/teams/_table.html.slim
@@ -28,7 +28,8 @@ table.table.table-striped.table-bordered.table-condensed
                 = avatar_url(user, size: 20)
                 = link_to(user.name_or_handle, user)
       / TODO quick fix, hiding conferences in teams view until program kick-off
-      / td = links_to_conferences(team.members.map { |u| u.conferences.current }.flatten.uniq).join(', ').html_safe
+      / td = links_to_conferences(team.members.map { |u| u.conferences.in_current_season }.flatten.uniq).join(', ')
+      /.html_safe
       td = team.students_location
       - if current_user.try :admin?
         td = format_date(team.last_checked_at)

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -86,12 +86,13 @@ nav.page
     h3 Supervisors
     p = @team.supervisors.any? ? link_to_team_members(@team, :supervisor) : content_tag(:em, 'Will be added by RGSoC Organizers')
 
-- if @team.members.any? { |user| user.conferences.current.any? }
+- if @team.members.any? { |user| user.conferences.in_current_season.any? }
   h4 Conferences
   ul.conferences
     - @team.members.each do |user|
-      - if user.conferences.current.any?
-        li = "#{link_to user.name, user}: #{links_to_conferences(user.conferences.current, true).join(', ')}".html_safe
+      - if user.conferences.in_current_season.any?
+        li = "#{link_to user.name, user}: #{links_to_conferences(user.conferences.in_current_season, true).join(', ')}"
+        .html_safe
 
 - if @team.activities.any?
   h3

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -38,7 +38,7 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
         td = user.country
         td = user.location
         td = time_for_user(user)
-        / td = links_to_conferences(user.conferences.current).join(', ').html_safe
+        / td = links_to_conferences(user.conferences.in_current_season).join(', ').html_safe
 
 p.pagination-info
   = page_entries_info @users

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,14 +1,14 @@
 # Teams
 FactoryGirl.create_list(:team, 5, :current_season, kind: "sponsored")
-FactoryGirl.create(:team, :current_season, kind: "voluntary")
-FactoryGirl.create(:team, :current_season) #not accepted
+FactoryGirl.create(:team, :in_current_season, kind: "voluntary")
+FactoryGirl.create(:team, :in_current_season) #not accepted
 
 FactoryGirl.create(:team, :last_season, kind: "sponsored")
 FactoryGirl.create(:team, :last_season, kind: "voluntary")
 
 # Users with different roles
-FactoryGirl.create_list(:team, 5, :current_season, kind: "sponsored")
-FactoryGirl.create(:team, :current_season, kind: "voluntary")
+FactoryGirl.create_list(:team, 5, :in_current_season, kind: "sponsored")
+FactoryGirl.create(:team, :in_current_season, kind: "voluntary")
 
 FactoryGirl.create_list(:student, 12)
 FactoryGirl.create_list(:coach, 3)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
 # Teams
-FactoryGirl.create_list(:team, 5, :current_season, kind: "sponsored")
+FactoryGirl.create_list(:team, 5, :in_current_season, kind: "sponsored")
 FactoryGirl.create(:team, :in_current_season, kind: "voluntary")
 FactoryGirl.create(:team, :in_current_season) #not accepted
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,6 +29,6 @@ end
 FactoryGirl.create(:application_draft)
 FactoryGirl.create(:application_draft, :appliable)
 
-FactoryGirl.create(:project, :current) #proposed
-FactoryGirl.create(:project, :accepted, :current)
-FactoryGirl.create(:project, :rejected, :current)
+FactoryGirl.create(:project, :in_current_season) #proposed
+FactoryGirl.create(:project, :accepted, :in_current_season)
+FactoryGirl.create(:project, :rejected, :in_current_season)

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ConferencesController do
 
   describe 'GET index' do
     let(:last_season)            { Season.create name: Date.today.year-1 }
-    let!(:current_conference)    { create :conference, :current_season }
+    let!(:current_conference)    { create :conference, :in_current_season }
     let!(:last_years_conference) { create :conference, season: last_season }
 
     it 'displays all of this season\'s conferences' do

--- a/spec/controllers/orga/teams_controller_spec.rb
+++ b/spec/controllers/orga/teams_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Orga::TeamsController do
   render_views
 
   let(:user) { create(:user) }
-  let(:team) { create(:team, :current_season, kind: nil) }
+  let(:team) { create(:team, :in_current_season, kind: nil) }
 
   let(:valid_attributes) { build(:team).attributes.merge(roles_attributes: [{ name: 'coach', github_handle: 'tobias' }]) }
 
@@ -18,8 +18,8 @@ RSpec.describe Orga::TeamsController do
     include_context 'with admin logged in'
 
     describe 'GET index' do
-      let!(:voluntary_team)  { create :team, :current_season, kind: 'voluntary' }
-      let!(:sponsored_team)  { create :team, :current_season, kind: 'sponsored' }
+      let!(:voluntary_team)  { create :team, :in_current_season, kind: 'voluntary' }
+      let!(:sponsored_team)  { create :team, :in_current_season, kind: 'sponsored' }
 
       it 'assigns only selected teams as @teams' do
         get :index

--- a/spec/controllers/students/status_updates_controller_spec.rb
+++ b/spec/controllers/students/status_updates_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Students::StatusUpdatesController do
   context 'with student logged in' do
     include_context 'with student logged in'
 
-    let(:team) { create :team, :current_season }
+    let(:team) { create :team, :in_current_season }
 
     let(:status_update) { create :status_update, team: team }
 

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe TeamsController do
   describe "GET index" do
     context 'before acceptance letters are sent' do
       let(:last_season)      { Season.create name: Date.today.year-1 }
-      let!(:invisble_team)   { create :team, :current_season, kind: nil, invisible: true }
-      let!(:unaccepted_team) { create :team, :current_season, kind: nil}
+      let!(:invisble_team)   { create :team, :in_current_season, kind: nil, invisible: true }
+      let!(:unaccepted_team) { create :team, :in_current_season, kind: nil}
       let!(:last_years_team) { create :team, kind: 'sponsored', season: last_season }
 
       before do
@@ -43,9 +43,9 @@ RSpec.describe TeamsController do
 
     context 'after acceptance letters have been sent' do
       let(:last_season)      { Season.create name: Date.today.year-1 }
-      let!(:voluntary_team)  { create :team, :current_season, kind: 'voluntary' }
-      let!(:sponsored_team)  { create :team, :current_season, kind: 'sponsored' }
-      let!(:unaccepted_team) { create :team, :current_season, kind: nil}
+      let!(:voluntary_team)  { create :team, :in_current_season, kind: 'voluntary' }
+      let!(:sponsored_team)  { create :team, :in_current_season, kind: 'sponsored' }
+      let!(:unaccepted_team) { create :team, :in_current_season, kind: nil}
       let!(:last_years_team) { create :team, kind: 'sponsored', season: last_season }
 
       before do

--- a/spec/exporters/applications_spec.rb
+++ b/spec/exporters/applications_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Exporters::Applications do
 
     context 'for existing applications' do
       let!(:old_application) { create :application }
-      let!(:new_application) { create :application, :current }
+      let!(:new_application) { create :application, :in_current_season }
 
       it 'exports all applications of the current season' do
         csv_rows = subject.split("\n")

--- a/spec/exporters/projects_spec.rb
+++ b/spec/exporters/projects_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Exporters::Projects do
 
   describe '#current' do
     let!(:old_project) { create :project, name: "OLDPROJECT" }
-    let!(:new_project) { create :project, :current, name: "NEWPROJECT" }
+    let!(:new_project) { create :project, :in_current_season, name: "NEWPROJECT" }
 
     it 'exports all projects of the current season' do
       expect(described_class.current).to match 'NEWPROJECT'

--- a/spec/exporters/teams_spec.rb
+++ b/spec/exporters/teams_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Exporters::Teams do
 
   describe '#current' do
     let!(:old_team) { create :team, name: "OLDTEAM" }
-    let!(:new_team) { create :team, :current_season, name: "NEWTEAM" }
-    let!(:app_team) { create :team, :applying_team, :current_season, name: "APPLYINGTEAM" }
+    let!(:new_team) { create :team, :in_current_season, name: "NEWTEAM" }
+    let!(:app_team) { create :team, :applying_team, :in_current_season, name: "APPLYINGTEAM" }
 
     subject { described_class.current }
 

--- a/spec/exporters/users_spec.rb
+++ b/spec/exporters/users_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Exporters::Users do
 
   describe '#current_students' do
     let(:old_team) { create :team, season: nil }
-    let(:new_team) { create :team, :current_season }
+    let(:new_team) { create :team, :in_current_season }
 
     let!(:old_student) { create :user, name: "OLDSTUDENT" }
     let!(:new_student) { create :user, name: "NEWSTUDENT" }

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
       minimum_money: rand(100),
     }}
 
-    trait :current do
+    trait :in_current_season do
       season { Season.current }
     end
   end

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     name { [FFaker::CheesyLingo.title, 'Conf'].join ' ' }
     tickets 2
 
-    trait :current_season do
+    trait :in_current_season do
       season { Season.current }
     end
 

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
       after(:create) { |record| record.reject! }
     end
 
-    trait :current do
+    trait :in_current_season do
       season { Season.current }
     end
   end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :role do
-    association :team, :current_season
+    association :team, :in_current_season
     user
     name { Role::ROLES.sample }
 

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
       name 'helpdesk'
     end
 
-    trait :current_season do
+    trait :in_current_season do
       season { Season.current }
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -133,7 +133,7 @@ describe Ability do
 
           context 'when in team for season' do
             before { create :student_role, team: student_team, user: user }
-            let(:student_team) { create(:team, :current_season) }
+            let(:student_team) { create(:team, :in_current_season) }
 
             it 'allows crud on own team' do
               expect(subject).to be_able_to :crud, student_team

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -22,7 +22,7 @@ describe Team do
     let(:role)   { FactoryGirl.create "#{role_name}_role" }
     let(:member) { role.user }
     let(:user) { create(:user) }
-    let(:team) { create :team, :current_season }
+    let(:team) { create :team, :in_current_season }
     let(:roles_attributes) { [{ name: role_name, team_id: team.id, user_id: member.id }] }
 
     context 'for students' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -205,13 +205,13 @@ describe User do
     end
 
     it 'returns false if user\'s team has not been accepted' do
-      team    = FactoryGirl.create(:team, :current_season, kind: nil)
+      team    = FactoryGirl.create(:team, :in_current_season, kind: nil)
       student = FactoryGirl.create(:student, team: team)
       expect(student).not_to be_current_student
     end
 
     it 'returns true if user is among this season\'s accepted students' do
-      team    = FactoryGirl.create(:team, :current_season, kind: 'sponsored')
+      team    = FactoryGirl.create(:team, :in_current_season, kind: 'sponsored')
       student = FactoryGirl.create(:student, team: team)
       expect(student).to be_current_student
     end

--- a/spec/support/shared_examples/redirect_for_non_students.rb
+++ b/spec/support/shared_examples/redirect_for_non_students.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples 'redirects for non-users' do
   # OPTIMIZE test actions other than 'index'
 
-  let(:accepted_team) { create :team, :current_season, kind: 'sponsored' }
+  let(:accepted_team) { create :team, :in_current_season, kind: 'sponsored' }
 
   shared_examples_for 'disallows access to students namespace' do
     before do
@@ -37,7 +37,7 @@ RSpec.shared_examples 'redirects for non-users' do
 
   context 'as a student' do
     context 'who is not part of an accepted team' do
-      let(:unaccepted_team) { create :team, :current_season, kind: nil }
+      let(:unaccepted_team) { create :team, :in_current_season, kind: nil }
       let(:user) { create(:student_role, team: unaccepted_team).user }
       it_behaves_like 'disallows access to students namespace'
     end


### PR DESCRIPTION
Instead of  #500
- [x] Step 1: the Team.in_current_season scope
- [x] Refactor other models' current scope (application_draft,  conference, project, student)  
        - [x] Check what to do with the current scope in Exporters 
- [x] Refactor other references (in exporters, etc) 
- [x] Refactor traits in factories plus seeds.rb

Scope `:current` for current season refactored to `:in_current_season`
All associations now use `in_current_season`, like: @teams.in_current_season, @conferences.in_current_season.
`current_season` still exists for `Season.current` Okay? 
 