### PR TITLE
Fix voor Kaminari paging

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,11 +14,9 @@ class UsersController < ApplicationController
     }
     @users = User.ordered(params[:sort],params[:direction])
         .group('users.id').with_all_associations_joined
-       # .page(params[:page])
     @users = @users.with_assigned_roles if Time.now.utc > (current_season.starts_at || Date.new)
     @users = @users.with_role(params[:role]) if params[:role].present? && params[:role] != 'all'
     @users = @users.with_interest(params[:interest]) if params[:interest].present? && params[:interest] != 'all'
-    #@users = @users.search(params[:search]) if params[:search]
     @users = Kaminari.paginate_array(@users.search(params[:search])).page(params[:page])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,11 +14,12 @@ class UsersController < ApplicationController
     }
     @users = User.ordered(params[:sort],params[:direction])
         .group('users.id').with_all_associations_joined
-        .page(params[:page])
+       # .page(params[:page])
     @users = @users.with_assigned_roles if Time.now.utc > (current_season.starts_at || Date.new)
     @users = @users.with_role(params[:role]) if params[:role].present? && params[:role] != 'all'
     @users = @users.with_interest(params[:interest]) if params[:interest].present? && params[:interest] != 'all'
-    @users = @users.search(params[:search]) if params[:search]
+    #@users = @users.search(params[:search]) if params[:search]
+    @users = Kaminari.paginate_array(@users.search(params[:search])).page(params[:page])
   end
 
   def show

--- a/app/views/users/_search.html.slim
+++ b/app/views/users/_search.html.slim
@@ -1,5 +1,5 @@
 = form_tag users_path, method: :get, id: "search-form" do |f|
-  = text_field_tag :search, params[:search], placeholder: "Search by name"
+  = text_field_tag :search, params[:search], placeholder: "Search user or team"
   = submit_tag "Go", class: "btn btn-success"
   = link_to_if(params[:search].present?, "Clear search results", users_path, class: "btn btn-default")  do
    a

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -42,6 +42,4 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
 
 p.pagination-info
   = page_entries_info @users
-  /unless params[:search].present?
   = paginate @users, theme: 'twitter-bootstrap-3', pagination_class: 'pagination-sm'
-  /unless params[:search].present?

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -41,5 +41,7 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
         / td = links_to_conferences(user.conferences.current).join(', ').html_safe
 
 p.pagination-info
-  = page_entries_info @users unless params[:search].present?
-  = paginate @users, theme: 'twitter-bootstrap-3', pagination_class: 'pagination-sm' unless params[:search].present?
+  = page_entries_info @users
+  /unless params[:search].present?
+  = paginate @users, theme: 'twitter-bootstrap-3', pagination_class: 'pagination-sm'
+  /unless params[:search].present?


### PR DESCRIPTION
Kaminari provides an array wrapper. This solves 2 things: the ugly checks in views if search params are present, PLUS the empty pages at the end of the user list.

Before:
![before](https://cloud.githubusercontent.com/assets/6314687/17279518/f593fb70-5775-11e6-9d5d-4574fd370d46.png)
After
![after](https://cloud.githubusercontent.com/assets/6314687/17279524/0257edf8-5776-11e6-9b0d-ce9985f8626a.png)

Very happy that this longlasting issue is solved... (https://github.com/TeamCheesy/rgsoc-teams/issues/16) 
