### PR TITLE
Style filter on users_info/index

### DIFF
--- a/app/views/users_info/index.html.slim
+++ b/app/views/users_info/index.html.slim
@@ -1,17 +1,18 @@
 h1.header User info
 
-form.filter action=request.url
-  h5 Role
-  - (['all'] + Role::ROLES).each do |role|
-    label.radio
-      = radio_button_tag :role, role == 'all' ? '' : role, params[:role] == role
-      = role.capitalize
+.selection-box
+  form.filter.form-inline action=request.url
+    h5 Role
+    - (['all'] + Role::ROLES).each do |role|
+      label.radio
+        = radio_button_tag :role, role == 'all' ? '' : role, params[:role] == role
+        = role.capitalize
 
-  h5 Type
-  - %w(all sponsored voluntary).each do |kind|
-    label.radio
-      = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
-      = kind.capitalize
+    h5 Type
+    - %w(all sponsored voluntary).each do |kind|
+      label.radio
+        = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
+        = kind.capitalize
 
 table.table.table-striped.table-bordered.table-condensed.table-hover
   thead
@@ -33,4 +34,3 @@ table.table.table-striped.table-bordered.table-condensed.table-hover
         td = user.email
         td = user.tshirt_size        
         td = simple_format user.postal_address
-


### PR DESCRIPTION
Just a minor thing, but a bit annoying whenever I looked at this page. 

Screenshot: (It now looks the same as on users/index)
![pr selection box on users-info](https://cloud.githubusercontent.com/assets/2246045/17510143/f09ef9c2-5e1d-11e6-96d6-f5c064593993.png)

I also wanted to add the search input, but failed. 
- Adding `= render partial: 'users/search'` won't help since it requests the wrong page.
- Pasting the code snippet and adjusting the paths to `users_info_path` did help, but the search results would still show all entries. 
Any ideas?