### PR TITLE
352 team/show on smaller viewports

### DIFF
--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -309,10 +309,6 @@ html, body
     white-space: nowrap
 
 .teams
-  td:first-child
-    padding-left: 2em
-  .team:before
-    margin-left: -1.5em
   .user
     white-space: nowrap
 

--- a/app/views/users_info/index.html.slim
+++ b/app/views/users_info/index.html.slim
@@ -1,17 +1,18 @@
 h1.header User info
 
-form.filter action=request.url
-  h5 Role
-  - (['all'] + Role::ROLES).each do |role|
-    label.radio
-      = radio_button_tag :role, role == 'all' ? '' : role, params[:role] == role
-      = role.capitalize
+.selection-box
+  form.filter.form-inline action=request.url
+    h5 Role
+    - (['all'] + Role::ROLES).each do |role|
+      label.radio
+        = radio_button_tag :role, role == 'all' ? '' : role, params[:role] == role
+        = role.capitalize
 
-  h5 Type
-  - %w(all sponsored voluntary).each do |kind|
-    label.radio
-      = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
-      = kind.capitalize
+    h5 Type
+    - %w(all sponsored voluntary).each do |kind|
+      label.radio
+        = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
+        = kind.capitalize
 
 table.table.table-striped.table-bordered.table-condensed.table-hover
   thead
@@ -33,4 +34,3 @@ table.table.table-striped.table-bordered.table-condensed.table-hover
         td = user.email
         td = user.tshirt_size        
         td = simple_format user.postal_address
-


### PR DESCRIPTION
On the team/show page, the star left of the team name was at certain points overflowing. The inital problem showed up on a larger screen, but it basically always shows up around the media breakpoints. The star-icon was positioned outside of the main container. 
My proposal: The star is now part of the container and thus follows the overall breakpoints. 

Screenshot:
![352-reposition-star](https://cloud.githubusercontent.com/assets/2246045/17512401/ec248db2-5e27-11e6-9a72-cdcd473288fd.png)


Resolves issue #352. 