### PR TITLE
352-Optimize mobile view for team/show

### DIFF
--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -309,10 +309,6 @@ html, body
     white-space: nowrap
 
 .teams
-  td:first-child
-    padding-left: 2em
-  .team:before
-    margin-left: -1.5em
   .user
     white-space: nowrap
 


### PR DESCRIPTION
(New, 2nd PR)

On the team/show page, the star left of the team name was at certain points overflowing. The inital problem showed up on a larger screen, but it basically always shows up around the media breakpoints. The star-icon was positioned outside of the main container. 
My proposal: The star is now part of the container and thus follows the overall breakpoints. 

Screenshot:
![352-reposition-star](https://cloud.githubusercontent.com/assets/2246045/17512401/ec248db2-5e27-11e6-9a72-cdcd473288fd.png)


Resolves issue #352. 