### PR TITLE
DRY-up CSS for error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -2,27 +2,8 @@
 <html>
 <head>
   <title>Page doesn't exist (404) | Rails Girls Summer of Code - Teams App</title>
-
-  <style type="text/css">
-    body { background-color: #fff; color: #666; text-align: center; font-family: Arial, sans-serif; }
-    div.container {
-      margin: 4rem auto;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      max-width: 400px;
-      background-color: #d82222;
-      border: 1px solid #ccc;
-      border-right-color: #999;
-      border-bottom-color: #999;
-    }
-    .dialog { padding: 2rem 0; background-color: white; }
-    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
-    a { color: #d82222; text-decoration: none; }
-  </style>
+  <link rel='stylesheet' type='text/css' href="css/style.css">
 </head>
-
 <body>
   <!-- This file lives in public/404.html -->
   <div class="container">

--- a/public/422.html
+++ b/public/422.html
@@ -2,26 +2,8 @@
 <html>
 <head>
   <title>Rejected Change (422) | Rails Girls Summer of Code - Teams App</title>
-  <style type="text/css">
-    body { background-color: #fff; color: #666; text-align: center; font-family: Arial, sans-serif; }
-    div.container {
-      margin: 4rem auto;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      max-width: 400px;
-      background-color: #d82222;
-      border: 1px solid #ccc;
-      border-right-color: #999;
-      border-bottom-color: #999;
-    }
-    .dialog { padding: 2rem 0; background-color: white; }
-    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
-    a { color: #d82222; text-decoration: none; }
-  </style>
+  <link rel='stylesheet' type='text/css' href="css/style.css">
 </head>
-
 <body>
   <!-- This file lives in public/422.html -->
   <div class="container">

--- a/public/500.html
+++ b/public/500.html
@@ -2,24 +2,7 @@
 <html>
 <head>
   <title>Something went wrong (500) | Rails Girls Summer of Code - Teams App</title>
-  <style type="text/css">
-    body { background-color: #fff; color: #666; text-align: center; font-family: Arial, sans-serif; }
-    div.container {
-      margin: 4rem auto;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      max-width: 400px;
-      background-color: #d82222;
-      border: 1px solid #ccc;
-      border-right-color: #999;
-      border-bottom-color: #999;
-    }
-    .dialog { padding: 2rem 0; background-color: white; }
-    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
-    a { color: #d82222; text-decoration: none; }
-  </style>
+  <link rel='stylesheet' type='text/css' href="css/style.css">
 </head>
 <body>
   <!-- This file lives in public/500.html -->

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,31 @@
+body {
+  background-color: #fff;
+  color: #666;
+  text-align: center;
+  font-family: Arial, sans-serif;
+}
+div.container {
+  margin: 4rem auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  max-width: 400px;
+  background-color: #d82222;
+  border: 1px solid #ccc;
+  border-right-color: #999;
+  border-bottom-color: #999;
+}
+.dialog {
+  padding: 2rem 0;
+  background-color: white;
+}
+h1 {
+  font-size: 100%;
+  color: #f00;
+  line-height: 1.5em;
+}
+a {
+  color: #d82222;
+  text-decoration: none;
+}


### PR DESCRIPTION
This DRYs up the CSS for the error pages in the public/ folder. Belongs to issue #506 and is an addition to PR #521.