### PR TITLE
Mobile: Various margins, paddings, etc.

### DIFF
--- a/app/assets/stylesheets/controllers/activities.sass
+++ b/app/assets/stylesheets/controllers/activities.sass
@@ -1,5 +1,13 @@
 // Styles for the activities-controller.
 
+a.atom
+  float: right
+  font-size: .6em
+  color: $main
+  @include icon-after($rss)
+  span
+    display: none
+
 ul.activities
   padding-left: 0
   li.activity.feed_entry

--- a/app/assets/stylesheets/controllers/users.sass
+++ b/app/assets/stylesheets/controllers/users.sass
@@ -7,3 +7,11 @@
     font-weight: normal
   input[type=checkbox]
     margin-right: 10px !important
+
+// used on user#show
+ul.teams,
+ul.conferences
+  padding: 0px
+  list-style-position: inside
+  ul.actions
+    padding: 0px 0.9rem

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -41,6 +41,10 @@ html, body
 .btn
   margin: 0 0 0 0.6rem
 
+.btn-group
+  .btn
+    margin: 0.3rem 0
+
 // For sticky footer
 #wrap
   min-height: 100%
@@ -270,14 +274,6 @@ html, body
     ul
       padding-left: 0
 
-  a.atom
-    float: right
-    font-size: .6em
-    color: $main
-    @include icon-after($rss)
-    span
-      display: none
-
   .pagination-info
     color: $gray
 
@@ -320,12 +316,24 @@ form
     input
       margin-right: 5px
 
+@media (max-width: $screen-sm)
+  .form-inline
+    .radio
+      input[type=radio]
+        position: inherit
+        margin-left: 0
+
 .filter
-  .team_filter
-    margin-top: -5px
-    float: right
   .form-control
     margin-left: 5px
+
+@media (min-width: $screen-sm)
+  .filter
+    .team_filter
+      float: right
+      margin-top: -5px
+    .form-control
+      margin-left: 0
 
 .form-btn-group
   margin: 1em 0 2em

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -9,7 +9,7 @@ section#header
             = icon('reorder')
 
     div.row
-      div.col-xs-offset-7.col-xs-5.col-md-offset-4.col-md-8
+      div.col-xs-offset-7.col-xs-5.col-md-offset-3.col-md-9.col-lrg-8
         nav class="top navbar-default" role="navigation"
           div class="collapse navbar-collapse" id="menu"
             ul

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -50,11 +50,10 @@ nav.actions
     ul.conferences
       - @user.attendances.includes(:conference).order('conferences.starts_on').each do |a|
         li
-          p
-            ' #{link_to a.conference.name, a.conference}
-            ' (#{a.conference.location}, #{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
-            - if @user == current_user
-              ' #{link_to "Tweet About It!", conference_tweet_link(a.conference), class: 'btn btn-default'}
+          ' #{link_to a.conference.name, a.conference}
+          ' (#{a.conference.location}, #{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
+          - if @user == current_user
+            ' #{link_to "Tweet About It!", conference_tweet_link(a.conference), class: 'btn btn-default'}
           - if can?(:crud, a) and admin?
             ul.actions
               - if a.confirmed?


### PR DESCRIPTION
This solves minor dis-arrangements:
- On teams#show, the stacked action buttons have now margins
- The filter / selection-box on Activities + Community are now neatly left-aligned in mobile
- The navigation had one size where the "Home" link would line-break -> solved.
- On user#show the list of teams and conferences had unpretty indents -> aligned.

Pic for team#show
![mobile_action-buttons](https://cloud.githubusercontent.com/assets/2246045/18227018/c2a4309c-7217-11e6-9dec-96c7f1317119.png)

Pic for selection box/ filter. 
![mobile_selection-box](https://cloud.githubusercontent.com/assets/2246045/18227019/c2a9615c-7217-11e6-972d-eb151ed8d7b5.png)
