### PR TITLE
only show contributors whose team is accepted

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -5,7 +5,7 @@ class ContributorsController < ApplicationController
 
   def index
     @contributors = User.with_role(Role::CONTRIBUTOR_ROLES).includes(roles: :team).
-      where("teams.season_id IS NULL OR teams.season_id = ?", Season.current).
+      where("teams.season_id IS NULL OR teams.season_id = ? and teams.kind IS NOT NULL", Season.current).
       references(:teams).uniq
     respond_with @contributors.as_json(json_params)
   end

--- a/spec/controllers/contributors_controller_spec.rb
+++ b/spec/controllers/contributors_controller_spec.rb
@@ -7,8 +7,14 @@ describe ContributorsController do
     let!(:user)      { create(:user) }
     let!(:coach)     { create(:coach) }
     let!(:organizer) { create(:organizer) }
-    
+
     it 'returns json representation of user with relevant roles' do
+      get :index, format: :json
+      expect(assigns(:contributors).sort).to eq [coach, organizer].sort
+    end
+
+    it 'includes teamless organizers' do
+      organizer.roles.each { |r| r.update! team: nil }
       get :index, format: :json
       expect(assigns(:contributors).sort).to eq [coach, organizer].sort
     end


### PR DESCRIPTION
contributors.json should only return contributors whose team is volunteer or sponsored (i.e. not nil). Hopefully closes https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/254!