### PR TITLE
render team filter dropdown in activities properly

### DIFF
--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -366,9 +366,6 @@ form
         margin-left: 0
 
 .filter
-  .team_filter
-    margin-top: -5px
-    float: right
   .form-control
     margin-left: 5px
 


### PR DESCRIPTION
For some reason the CSS in the last merged PR conflicted with a previous fix from @katrin-k to render the team dropdown in the activities page properly when on mobile. This should fix it :)