### PR TITLE
Remove redundant strong params for conferences

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -16,18 +16,9 @@ class ConferencesController < ApplicationController
     helper_method :conferences
 
     def conference
-       @conference ||= params[:id] ? Conference.find(params[:id]) : Conference.new(conference_params)
+       @conference ||= Conference.find(params[:id])
     end
     helper_method :conference
-
-    def conference_params
-     params[:conference] ? params.require(:conference).permit(
-         :name, :url, :location, :twitter, :tickets, :flights, :accomodation,
-         :'starts_on(1i)', :'starts_on(2i)', :'starts_on(3i)', :round,
-         :'ends_on(1i)', :'ends_on(2i)', :'ends_on(3i)', :lightningtalkslots,
-         attendances_attributes: [:id, :github_handle, :_destroy]
-     ) : {}
-    end
 
     def sort_params
       {


### PR DESCRIPTION
The permitted params are set in the orga/conferences_controller. In the non-orga controller, they are never called.

Leftover from #546 