### PR TITLE
Fix date formats in conference views

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -136,7 +136,7 @@ module ApplicationHelper
   def links_to_conferences(conferences, extra_info = false)
     conferences.map do |conference|
       text = conference.name
-      text += " (#{conference.location}, #{format_conference_date(conference.starts_on, conference.ends_on)})" if extra_info
+      text += " (#{conference.location}#{format_conference_date(conference.starts_on, conference.ends_on)})" if extra_info
       link_to(text, conference)
     end
   end

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -51,7 +51,7 @@ nav.actions
       - @user.attendances.includes(:conference).order('conferences.starts_on').each do |a|
         li
           ' #{link_to a.conference.name, a.conference}
-          ' (#{a.conference.location}, #{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
+          ' (#{a.conference.location}#{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
           - if @user == current_user
             ' #{link_to "Tweet About It!", conference_tweet_link(a.conference), class: 'btn btn-default'}
           - if can?(:crud, a) and admin?


### PR DESCRIPTION
(#503, [comment](https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/503#issuecomment-235365223))
  
This  date format with a comma:
![image](https://cloud.githubusercontent.com/assets/6314687/20650453/024aaaf6-b4cf-11e6-9db8-78de0369573f.png)

.. is now without the comma.

![schermafbeelding 2016-11-27 om 18 31 35](https://cloud.githubusercontent.com/assets/6314687/20650484/cb983ea0-b4cf-11e6-8b97-44f5505f5f53.png)

Checked all other usages of the conference_date_formatter, everything is fine. 🏎 


