### PR TITLE
Max 3 conferences added in User Profile

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,11 @@ class UsersController < ApplicationController
 
   load_and_authorize_resource except: [:index, :show]
 
+  # limit is currently set on conference attendances only
+  rescue_from ActiveRecord::NestedAttributes::TooManyRecords do |error|
+    redirect_to edit_user_path(@user), alert: error.message
+  end
+
   def index
     @filters = {
       all:        'All',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,7 +80,7 @@ class User < ActiveRecord::Base
   validates :homepage, format: { with: URL_PREFIX_PATTERN }, allow_blank: true
   validate :immutable_github_handle
 
-  accepts_nested_attributes_for :attendances, allow_destroy: true
+  accepts_nested_attributes_for :attendances, allow_destroy: true, limit: 3
   accepts_nested_attributes_for :roles
 
   before_save :sanitize_location

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -60,7 +60,8 @@
           = s.input :conference_id, as: :select, collection: conferences, required: false, label: false, default: 1
 
           = s.link_to_remove 'Remove'
-        = f.link_to_add 'I want to add another conference!', :attendances, class: 'btn btn-primary form-btn-group'
+        - if current_user.attendances.count < 3
+          = f.link_to_add 'I want to add another conference!', :attendances, class: 'btn btn-primary form-btn-group'
 
   h3.page-header Private information
   p.help-block This information will only be visible to yourself and organizers.


### PR DESCRIPTION
Solves #414
- Add limit to number of permitted attendances
- Hide 'add conference' button if User has 3 attendances: 
- Add flash alert when user wants to save their profile with more than 3 conferences.

One problem left:
The count of the attendances is updated only when the parent is saved. This means an user is able to add 4 conferences in the Edit Profile form, and will not be notified that 3 = max until after submit.
This is not super user friendly

Todo's
- [ ] Make limit for attendances only, no other attributes
- [ ] Add tests
