### PR TITLE
Small frontend fixes

### DIFF
--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -20,7 +20,6 @@ html, body
   a:hover
     i
       text-decoration: none
-      color: $darkgray
 
   li
     list-style-type: none

--- a/app/assets/stylesheets/vendor/bootstrap/autocomplete.scss
+++ b/app/assets/stylesheets/vendor/bootstrap/autocomplete.scss
@@ -28,6 +28,10 @@
   *border-right-width: 2px;
   *border-bottom-width: 2px;
 
+  .ui-menu-item {
+    margin-left: 10px;
+  }
+
   .ui-menu-item > a.ui-corner-all {
     display: block;
     padding: 3px 15px;

--- a/app/views/join/new.html.slim
+++ b/app/views/join/new.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'Back', teams_path, class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', teams_path, class: 'back'
 
 h1 Join team: #{@team.name}
 

--- a/app/views/mailings/edit.html.slim
+++ b/app/views/mailings/edit.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'Back', mailings_path, class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', mailings_path, class: 'back'
 
 h1 Edit Mailing
 

--- a/app/views/mailings/new.html.slim
+++ b/app/views/mailings/new.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'Back', mailings_path, class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', mailings_path, class: 'back'
 
 h1 New Mailing
 

--- a/app/views/mailings/show.html.slim
+++ b/app/views/mailings/show.html.slim
@@ -6,9 +6,9 @@ nav.page
 
 - if can?(:crud, Submission)
   nav.actions
-    ul
-      li = link_to 'Edit', edit_mailing_path(@mailing), class: 'edit'
-      li = link_to 'Delete', mailing_path(@mailing), method: :delete, class: 'edit', data: { confirm: 'Are you sure?' }
+    ul.list-inline
+      li = link_to 'Edit', edit_mailing_path(@mailing), class: 'btn btn-default btn-sm edit'
+      li = link_to 'Delete', mailing_path(@mailing), method: :delete, class: 'btn btn-default btn-sm destroy', data: { confirm: 'This action cannot be undone. Are you sure?' }
 
 h1 class="mailing" = @mailing.subject
 

--- a/app/views/mailings/show.html.slim
+++ b/app/views/mailings/show.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'All mailings', mailings_path, class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'All mailings', mailings_path, class: 'back'
 
 - if can?(:crud, Submission)
   nav.actions

--- a/app/views/orga/conferences/edit.html.slim
+++ b/app/views/orga/conferences/edit.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'Back', orga_conferences_path, class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', orga_conferences_path, class: 'back'
 
 nav.actions
   ul

--- a/app/views/orga/conferences/new.html.slim
+++ b/app/views/orga/conferences/new.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'Back', orga_conferences_path, class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', orga_conferences_path, class: 'back'
 
 h1 New conference
 

--- a/app/views/orga/teams/new.html.slim
+++ b/app/views/orga/teams/new.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'Back', orga_teams_path, class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', orga_teams_path, class: 'back'
 
 h1 New team
 

--- a/app/views/sources/edit.html.slim
+++ b/app/views/sources/edit.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'Back', sources_path(@team), class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', sources_path(@team), class: 'back'
 nav.actions
   ul
     li = link_to 'Show', @source, class: 'show'

--- a/app/views/sources/show.html.slim
+++ b/app/views/sources/show.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'Back', sources_path(@team), class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', sources_path(@team), class: 'back'
 nav.actions
   ul
     li = link_to 'Edit', edit_source_path(@source), class: 'edit'

--- a/app/views/submissions/new.html.slim
+++ b/app/views/submissions/new.html.slim
@@ -1,6 +1,8 @@
 nav.page
-  ul
-    li = link_to 'Back', @mailing, class: 'back'
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', @mailing, class: 'back'
 
 h1 Submit mailing
 


### PR DESCRIPTION
This fixes some minor UI details, such as:

- [x] better margin on the autocomplete for the project submission
- [x] finally remove the hover effect on icons (didn't look very good)
- [x] make all back navigation finally consistent

See screenshots!

improved margin
<img width="654" alt="screen shot 2016-11-28 at 12 27 27" src="https://cloud.githubusercontent.com/assets/3143348/20670157/f4880ae0-b577-11e6-8875-47dfe28cfb72.png">

old hover effect
<img width="568" alt="screen shot 2016-11-28 at 12 41 02" src="https://cloud.githubusercontent.com/assets/3143348/20670285/8e03cce0-b578-11e6-8e7f-42d21412b4d3.png">

new hover effect
<img width="578" alt="screen shot 2016-11-28 at 14 39 43" src="https://cloud.githubusercontent.com/assets/3143348/20670301/988ba188-b578-11e6-809b-bb8991360f04.png">

old back navigation in some pages
<img width="425" alt="screen shot 2016-10-13 at 16 58 52" src="https://cloud.githubusercontent.com/assets/3143348/20670364/d8eddce6-b578-11e6-92cf-1d263a5ee8c7.png">

new back navigation
<img width="1040" alt="screen shot 2016-11-28 at 14 09 29" src="https://cloud.githubusercontent.com/assets/3143348/20670369/e172c598-b578-11e6-898c-a09f59f8d4af.png">

ugly edit and delete links
<img width="517" alt="screen shot 2016-10-13 at 16 58 36" src="https://cloud.githubusercontent.com/assets/3143348/20670564/b26b9ab2-b579-11e6-99ad-0e86d715dc29.png">

improved edit and delete buttons
<img width="224" alt="screen shot 2016-11-28 at 14 47 32" src="https://cloud.githubusercontent.com/assets/3143348/20670575/ba2ebafe-b579-11e6-9684-836b65d62b37.png">




