### PR TITLE
Fix IRB context warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ end
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0'
-  gem 'rspec-activemodel-mocks'
   gem 'factory_girl_rails'
   gem 'database_cleaner'
   gem 'byebug', require: !ENV['RM_INFO'] #require parameter is workaround for RubyMine with Rails ~> 4.1
@@ -73,4 +72,5 @@ group :test do
   gem "codeclimate-test-reporter", require: false
   gem 'rspec-collection_matchers'
   gem 'rspec-html-matchers'
+  gem 'rspec-activemodel-mocks'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
     rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
-    rspec-rails (3.5.0)
+    rspec-rails (3.5.2)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)


### PR DESCRIPTION
Hello! 👋

Running `rails console`, I noticed a warning I had never seen before:

```
$ rails c
Loading development environment (Rails 4.2.7.1)
irb: warn: can't alias context from irb_context. <----- this
irb(main):001:0>
```

The reason for the warning seems to be a mix of two things: `rspec-activemodel-mocks` and the `rspec-rails` version we're using.

The issue with `rspec-activemodel-mocks` seems to be fixed by not including the gem in the `development` group - [see this issue](https://github.com/rspec/rspec-activemodel-mocks/issues/9).

This was also addressed in `rspec-rails` 3.5.2 as you can [see here](https://github.com/rspec/rspec-rails/blob/master/Changelog.md#352--2016-08-26).

So, this PR does just that - move `rspec-activemodel-mocks` out of the `development` group and bump `rspec-rails` to 3.5.2.

Let me know what you think! 🙌 