### PR TITLE
Fix issue with Github ribbon overlapping Sign In

### DIFF
--- a/app/assets/stylesheets/partials/_github-ribbon.sass
+++ b/app/assets/stylesheets/partials/_github-ribbon.sass
@@ -1,13 +1,5 @@
 // Responsive GitHub Ribbon
 
-.wrapper
-  position: absolute
-  top: 0px
-  right: 0px
-  width: 150px
-  height: 150px
-  overflow: hidden
-
 .ribbon
   // Positioning
   position: absolute
@@ -31,7 +23,7 @@
   -o-transition: background-color .3s ease
   transition: background-color .3s ease
 
-.ribbon 
+.ribbon
   a
     display: block
     margin: 1px
@@ -49,7 +41,7 @@
   background-color: $gray
 
 @media (max-width:1313px)
-  .wrapper
+  .ribbon
     visibility: hidden
     opacity:  0
     -webkit-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
@@ -59,7 +51,7 @@
     transition: visibility 0s linear 0.2s,  opacity 0.2s linear
 
 @media (min-width:1314px) and (max-width: 1360px)
-  .wrapper
+  .ribbon
     visibility: visible
     opacity:  1
     -webkit-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
@@ -67,4 +59,4 @@
     -ms-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
     -o-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
     transition: opacity 0.2s linear
-    
+

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -19,9 +19,8 @@ html
     div#wrap
       = render 'layouts/header'
 
-      div.wrapper
-        div.ribbon
-          a href="//github.com/rails-girls-summer-of-code/rgsoc-teams" Fork me on GitHub
+      div.ribbon
+        a href="//github.com/rails-girls-summer-of-code/rgsoc-teams" Fork me on GitHub
 
       section.container#content
         div.row


### PR DESCRIPTION
Fixes #569. Removing the `div.wrapper` seemed to do the trick.

The media queries seem to work as before, but I may have missed something here...

Anyway, the result:

![github-login-fix](https://cloud.githubusercontent.com/assets/31735/21032325/b743c6ac-bda0-11e6-9671-c6be1ebf6ec0.gif)