### PR TITLE
User impersonation (development only)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'bootstrap-sass'
 gem 'font-awesome-sass-rails'
+gem 'pretender'
 
 gem 'sass-rails'
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,8 @@ GEM
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
     pg (0.19.0)
+    pretender (0.2.1)
+      actionpack
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -373,6 +375,7 @@ DEPENDENCIES
   newrelic_rpm
   omniauth-github
   pg
+  pretender
   pry
   rails (~> 5.0)
   rails-controller-testing

--- a/README.md
+++ b/README.md
@@ -126,10 +126,12 @@ E.g. `foreman run rails server` or `foreman run rails console`.
     ``` user = User.last``` #or ```user = User.find_by(github_handle: "yourgithubhandle") ```
     ``` user.roles.create(name: "organizer") ```
     You can assign yourself other roles in the same way. If however you assign
-    yourself a student role AND another role, that may lead to unexpected behavior in the app. In that case, remove the student role.    
+    yourself a student role AND another role, that may lead to unexpected behavior in the app. In that case, remove the student role. 
     - Refresh the browser to effectuate. You should see links for organizers. 
 - Once you are an `organizer`, you can add a season and switch between season's phases at
 http://localhost:3000/orga/seasons in your browser.
+- While in development, you are also able to impersonate other users to easily test the system
+as someone else. Go to http://localhost:3000/users while logged in to do that.
 - You are good to go now. Happy coding!
 
 ## Testing

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -201,6 +201,9 @@ html, body
   h3
     font-size: 1.25rem
     margin-bottom: 1rem
+    // Used by Bootstrap popovers (search data-toggle="popover")
+    &.popover-title
+      margin-bottom: 0
 
   h4
     font-size: 1.15rem

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,10 @@ class ApplicationController < ActionController::Base
 
   before_action :set_timezone
 
+  # Allow users to impersonate other uses in a non-production environment.
+  # See the `pretender` gem.
+  impersonates :user
+
   def after_sign_in_path_for(user)
     if user.just_created?
       request.env['omniauth.origin'] || edit_user_path(user, welcome: true)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :normalize_params, only: :index
   before_action :set_user, only: [:show, :edit, :update, :destroy, :impersonate]
 
-  load_and_authorize_resource except: [:index, :show, :impersonate]
+  load_and_authorize_resource except: [:index, :show, :impersonate, :stop_impersonating]
 
   def index
     @filters = {
@@ -69,7 +69,12 @@ class UsersController < ApplicationController
 
   def impersonate
     impersonate_user(@user)
-    redirect_to users_path, notice: "Now impersonating #{@user.name}!"
+    redirect_to users_path, notice: "Now impersonating #{@user.name}."
+  end
+
+  def stop_impersonating
+    stop_impersonating_user
+    redirect_to users_path, notice: "Impersonation stopped. You're back to being #{current_user.name}!"
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,8 @@
 class UsersController < ApplicationController
   before_action :normalize_params, only: :index
-  before_action :set_user, only: [:show, :edit, :update, :destroy]
+  before_action :set_user, only: [:show, :edit, :update, :destroy, :impersonate]
 
-  load_and_authorize_resource except: [:index, :show]
+  load_and_authorize_resource except: [:index, :show, :impersonate]
 
   def index
     @filters = {
@@ -65,6 +65,11 @@ class UsersController < ApplicationController
       format.html { redirect_to users_url }
       format.json { head :no_content }
     end
+  end
+
+  def impersonate
+    impersonate_user(@user)
+    redirect_to users_path, notice: "Now impersonating #{@user.name}!"
   end
 
   private

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -36,6 +36,9 @@ section#header
                 li class="divider"
                 - if signed_in?
                   li = "#{link_to 'Profile', current_user}".html_safe
-                  li = link_to "Sign out", sign_out_path, method: :delete
+                  - if current_user != true_user
+                    li.announcement = link_to icon('eye-close', 'Stop'), stop_impersonating_users_path, method: :post, title: 'Stop Impersonation'
+                  - else
+                    li = link_to "Sign out", sign_out_path, method: :delete
                 - else
                   li = link_to icon('github', 'Sign in'), user_github_omniauth_authorize_path

--- a/app/views/users/_impersonate.html.slim
+++ b/app/views/users/_impersonate.html.slim
@@ -1,0 +1,9 @@
+= link_to icon('eye-open'), impersonate_user_path(user), class: 'btn btn-warning btn-sm',
+  method: :post,
+  title: "Impersonate User (for development only)",
+  data: { \
+    toggle: :popover,
+    content: "By clicking this you'll experience the app as if you were #{user.name}. You can use this to locally test the entire application process, by becoming the second team member.",
+    trigger: :hover,
+    placement: 'right auto',
+  }

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -39,7 +39,7 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
         td = user.location
         td = time_for_user(user)
         / td = links_to_conferences(user.conferences.in_current_season).join(', ').html_safe
-        - unless Rails.env.production?
+        - if signed_in? && !Rails.env.production?
           td = render 'impersonate', user: user if user != current_user
 
 p.pagination-info

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -39,6 +39,8 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
         td = user.location
         td = time_for_user(user)
         / td = links_to_conferences(user.conferences.in_current_season).join(', ').html_safe
+        - unless Rails.env.production?
+          td = render 'impersonate', user: user if user != current_user
 
 p.pagination-info
   = page_entries_info @users

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -8,6 +8,8 @@ nav.actions
   ul.list-inline
     li = link_to 'Edit', edit_user_path(@user), class: 'btn btn-default btn-sm edit' if can? :edit, @user
     li = link_to 'Delete Profile', @user, data: { confirm: 'This action cannot be undone. Are you sure?' }, method: :delete, class: 'btn btn-default btn-sm destroy' if can? :destroy, @user
+    - unless Rails.env.production?
+      li = render 'impersonate', user: @user if @user != current_user
 
 .profile
   - if @user.avatar_url.present?

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -8,7 +8,7 @@ nav.actions
   ul.list-inline
     li = link_to 'Edit', edit_user_path(@user), class: 'btn btn-default btn-sm edit' if can? :edit, @user
     li = link_to 'Delete Profile', @user, data: { confirm: 'This action cannot be undone. Are you sure?' }, method: :delete, class: 'btn btn-default btn-sm destroy' if can? :destroy, @user
-    - unless Rails.env.production?
+    - if signed_in? && !Rails.env.production?
       li = render 'impersonate', user: @user if @user != current_user
 
 .profile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,12 @@ RgsocTeams::Application.routes.draw do
     resources :roles, only: [:new, :create, :destroy]
   end
 
+  concern :impersonatable do
+    post 'impersonate', on: :member
+  end
+
   get 'users/info', to: 'users_info#index'
-  resources :users, except: :new, concerns: :has_roles
+  resources :users, except: :new, concerns: [:has_roles, :impersonatable]
   resources :sources, only: :index
   resources :comments, only: :create
   resources :conferences

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ RgsocTeams::Application.routes.draw do
   end
 
   concern :impersonatable do
-    post 'impersonate', on: :member
+    post 'impersonate', on: :member unless Rails.env.production?
   end
 
   get 'users/info', to: 'users_info#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,10 @@ RgsocTeams::Application.routes.draw do
   end
 
   concern :impersonatable do
-    post 'impersonate', on: :member unless Rails.env.production?
+    unless Rails.env.production?
+      post 'impersonate', on: :member
+      post 'stop_impersonating', on: :collection
+    end
   end
 
   get 'users/info', to: 'users_info#index'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -37,6 +37,19 @@ describe UsersController do
         expect(response.body).not_to include user_opted_out.email
       end
     end
+
+    it 'shows user impersonation links when in development' do
+      user = create(:student)
+      get :index, { params: {} }, {}
+      expect(response.body).to include impersonate_user_path(user)
+    end
+
+    it 'does not show user impersonation links when in production' do
+      allow(Rails).to receive(:env).and_return('production'.inquiry)
+      user = create(:student)
+      get :index, { params: {} }, {}
+      expect(response.body).not_to include impersonate_user_path(user)
+    end
   end
 
   describe "GET show" do
@@ -44,6 +57,19 @@ describe UsersController do
       user = create(:user)
       get :show, { params: { id: user.to_param } }, valid_session
       expect(assigns(:user)).to eq(user)
+    end
+
+    it 'shows the user impersonation link when in development' do
+      user = create(:user)
+      get :show, { params: { id: user.to_param } }, {}
+      expect(response.body).to include impersonate_user_path(user)
+    end
+
+    it 'does not show the user impersonation link when in production' do
+      allow(Rails).to receive(:env).and_return('production'.inquiry)
+      user = create(:user)
+      get :show, { params: { id: user.to_param } }, {}
+      expect(response.body).not_to include impersonate_user_path(user)
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -28,27 +28,30 @@ describe UsersController do
     end
 
     context 'with user logged in' do
-      it 'will not show email addresses of those who opted out' do
+      before(:each) do
         sign_in create(:student)
+      end
+
+      it 'will not show email addresses of those who opted out' do
         user = FactoryGirl.create(:student, hide_email: false)
         user_opted_out = FactoryGirl.create(:user, hide_email: true)
         get :index, { params: {} }, valid_session
         expect(response.body).to include user.email
         expect(response.body).not_to include user_opted_out.email
       end
-    end
 
-    it 'shows user impersonation links when in development' do
-      user = create(:student)
-      get :index, { params: {} }, {}
-      expect(response.body).to include impersonate_user_path(user)
-    end
+      it 'shows user impersonation links when in development' do
+        other_user = create(:student)
+        get :index, { params: {} }, {}
+        expect(response.body).to include impersonate_user_path(other_user)
+      end
 
-    it 'does not show user impersonation links when in production' do
-      allow(Rails).to receive(:env).and_return('production'.inquiry)
-      user = create(:student)
-      get :index, { params: {} }, {}
-      expect(response.body).not_to include impersonate_user_path(user)
+      it 'does not show user impersonation links when in production' do
+        allow(Rails).to receive(:env).and_return('production'.inquiry)
+        other_user = create(:student)
+        get :index, { params: {} }, {}
+        expect(response.body).not_to include impersonate_user_path(other_user)
+      end
     end
   end
 
@@ -59,17 +62,23 @@ describe UsersController do
       expect(assigns(:user)).to eq(user)
     end
 
-    it 'shows the user impersonation link when in development' do
-      user = create(:user)
-      get :show, { params: { id: user.to_param } }, {}
-      expect(response.body).to include impersonate_user_path(user)
-    end
+    context 'with user logged in' do
+      before(:each) do
+        sign_in create(:student)
+      end
 
-    it 'does not show the user impersonation link when in production' do
-      allow(Rails).to receive(:env).and_return('production'.inquiry)
-      user = create(:user)
-      get :show, { params: { id: user.to_param } }, {}
-      expect(response.body).not_to include impersonate_user_path(user)
+      it 'shows the user impersonation link when in development' do
+        other_user = create(:user)
+        get :show, { params: { id: other_user.to_param } }, {}
+        expect(response.body).to include impersonate_user_path(other_user)
+      end
+
+      it 'does not show the user impersonation link when in production' do
+        allow(Rails).to receive(:env).and_return('production'.inquiry)
+        other_user = create(:user)
+        get :show, { params: { id: other_user.to_param } }, {}
+        expect(response.body).not_to include impersonate_user_path(other_user)
+      end
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -236,4 +236,24 @@ describe UsersController do
       expect(flash[:notice]).to include "Now impersonating #{impersonated_user.name}"
     end
   end
+
+  describe 'POST stop_impersonating' do
+    let(:user) { create(:user) }
+    let(:impersonated_user) { create(:user) }
+    before do
+      sign_in user
+      controller.impersonate_user(impersonated_user)
+    end
+
+    it 'changes the current_user' do
+      post :stop_impersonating, { params: {} }
+      expect(controller.current_user).to eq user
+    end
+
+    it 'redirects to users#index' do
+      post :stop_impersonating, { params: {} }
+      expect(response).to redirect_to users_path
+      expect(flash[:notice]).to include "Impersonation stopped"
+    end
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -53,6 +53,17 @@ describe UsersController do
         expect(response.body).not_to include impersonate_user_path(other_user)
       end
     end
+
+    context 'when impersonating' do
+      it 'shows a Stop Impersonation link instead of Sign out' do
+        sign_in create(:student)
+        other_user = create(:student)
+        controller.impersonate_user(other_user)
+        get :index, { params: {} }, {}
+        expect(response.body).not_to include sign_out_path
+        expect(response.body).to include stop_impersonating_users_path
+      end
+    end
   end
 
   describe "GET show" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -200,4 +200,20 @@ describe UsersController do
     end
   end
 
+  describe 'POST impersonate' do
+    let(:user) { create(:user) }
+    let(:impersonated_user) { create(:user) }
+    before { sign_in user }
+
+    it 'changes the current_user' do
+      post :impersonate, { params: { id: impersonated_user.id } }
+      expect(controller.current_user).to eq impersonated_user
+    end
+
+    it 'redirects to users#index' do
+      post :impersonate, { params: { id: impersonated_user.id } }
+      expect(response).to redirect_to users_path
+      expect(flash[:notice]).to include "Now impersonating #{impersonated_user.name}"
+    end
+  end
 end

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -25,5 +25,9 @@ describe UsersController do
     it 'routes to #destroy' do
       expect(delete('/users/1')).to route_to('users#destroy', id: '1')
     end
+
+    it 'routes to #impersonate' do
+      expect(post('/users/1/impersonate')).to route_to('users#impersonate', id: '1')
+    end
   end
 end

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -26,8 +26,16 @@ describe UsersController do
       expect(delete('/users/1')).to route_to('users#destroy', id: '1')
     end
 
-    it 'routes to #impersonate' do
+    it 'routes to #impersonate on development' do
       expect(post('/users/1/impersonate')).to route_to('users#impersonate', id: '1')
+    end
+  end
+
+  describe 'production-specific routing' do
+    include_context 'with production routing'
+
+    it 'does not route to #impersonate on production' do
+      expect(post('/users/1/impersonate')).not_to be_routable
     end
   end
 end

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -29,6 +29,10 @@ describe UsersController do
     it 'routes to #impersonate on development' do
       expect(post('/users/1/impersonate')).to route_to('users#impersonate', id: '1')
     end
+
+    it 'routes to #stop_impersonating on development' do
+      expect(post('/users/stop_impersonating')).to route_to('users#stop_impersonating')
+    end
   end
 
   describe 'production-specific routing' do
@@ -36,6 +40,10 @@ describe UsersController do
 
     it 'does not route to #impersonate on production' do
       expect(post('/users/1/impersonate')).not_to be_routable
+    end
+
+    it 'does not route to #stop_impersonating on production' do
+      expect(post('/users/stop_impersonating')).not_to be_routable
     end
   end
 end

--- a/spec/support/shared_contexts/with_production_routing.rb
+++ b/spec/support/shared_contexts/with_production_routing.rb
@@ -1,0 +1,13 @@
+RSpec.shared_context 'with production routing' do
+  before do
+    # Stub production environment and reload routes
+    allow(Rails).to receive(:env).and_return('production'.inquiry)
+    Rails.application.reload_routes!
+  end
+
+  after do
+    # Unstub environment and reload routes
+    allow(Rails).to receive(:env).and_call_original
+    Rails.application.reload_routes!
+  end
+end


### PR DESCRIPTION
This PR addresses and hopefully closes #548. It allows users to impersonate other users in development. This is useful for testing the entire application process as both team members.

## How it looks & works

In the public-facing Community page (`users#index`), you'll see an orange button for every user in the list, except yourself.

![impersonation](https://cloud.githubusercontent.com/assets/31735/21076964/dac45306-bf32-11e6-92ee-b6cacfe3b6a3.png)

As soon as you hover your mouse over one of these buttons, you get a [bootstrap popover](http://getbootstrap.com/javascript/#popovers) with a small explanation. (this may be a bit over the top 😅 let me know what you think).

<img width="865" alt="screen shot 2016-12-10 at 23 44 21" src="https://cloud.githubusercontent.com/assets/31735/21077001/b17a6476-bf33-11e6-8222-dc397db18438.png">

If you open a user's profile, you'll also see an orange "Impersonate" link. It also shows the same popover on hover.

<img width="988" alt="screen shot 2016-12-10 at 23 44 59" src="https://cloud.githubusercontent.com/assets/31735/21076995/8730348e-bf33-11e6-89f4-6eba97c0b9df.png">

Clicking any of these orange buttons will switch your `current_user` to be the impersonated user. I used a gem called [pretender](https://github.com/ankane/pretender) that also gives us a `true_user` method, which is the original user. This is how clicking the link looks like:

<img width="1183" alt="screen shot 2016-12-10 at 23 45 21" src="https://cloud.githubusercontent.com/assets/31735/21077026/218918f2-bf34-11e6-9270-83afc1177dcc.png">

You'll notice that when in "impersonation mode", the Sign out link is swapped by a "Stop impersonation" one.

<img width="1164" alt="screen shot 2016-12-10 at 21 19 40" src="https://cloud.githubusercontent.com/assets/31735/21077033/546b67ac-bf34-11e6-9063-ee0b991a8a67.png">

Clicking it will stop the impersonation make you _you_ again!

## Some details

### Keeping this out of production

As you'll see in the code, I'm checking for the production environment at the route level and at the view level. Let me know if you feel I should add some controller-level protection, like a guard clause which is what's being used on the Switch Season Phase feature.

### Tests

I wanted to explore testing the route-level production protections and I (eventually) got it working 🙌 . At the end of it I had a feeling that this may be testing _too deeply_, so if I'm happy to remove/alter if you'd like.

### The orange buttons & other visible changes

I picked the `eye-open` and `eye-close` icons because it was the best I could find in the Font Awesome version we're using. Open to suggestions, but I'm not too worried since this is dev-only.

The Stop impersonation button isn't great - I wanted to make it "Stop Impersonation", but that would break the menu layout for supervisors (they have an extra link in the menu).

The popover that comes up when you hover the buttons may be a bit too much. I'm ok with removing it entirely if you want.

Oh, and the buttons are orange because the Switch Phase button (another development-only feature) was also orange 😄 