### PR TITLE
Fix conference format on different profile pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -135,8 +135,10 @@ module ApplicationHelper
 
   def links_to_conferences(conferences, extra_info = false)
     conferences.map do |conference|
-      text = conference.name
-      text += " (#{conference.location}#{format_conference_date(conference.starts_on, conference.ends_on)})" if extra_info
+      text = conference.name + " ("
+      text += "#{conference.location}, " if conference.location.present?
+      text += "#{format_conference_date(conference.starts_on, conference.ends_on)})" if
+          extra_info
       link_to(text, conference)
     end
   end

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -50,8 +50,11 @@ nav.actions
     ul.conferences
       - @user.attendances.includes(:conference).order('conferences.starts_on').each do |a|
         li
-          ' #{link_to a.conference.name, a.conference}
-          ' (#{a.conference.location}#{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
+          '#{link_to a.conference.name, a.conference}
+          '(
+          - if a.conference.location.present?
+            '#{a.conference.location},
+          '#{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
           - if @user == current_user
             ' #{link_to "Tweet About It!", conference_tweet_link(a.conference), class: 'btn btn-default'}
           - if can?(:crud, a) and admin?


### PR DESCRIPTION
In the never ending story of comma's and spaces:

The conference texts have different formats on the teams profile page and the user profile page.
This fix solves a missing space on the user profile page when the conference location is given.

The formatting was [suspicious](https://github.com/rails-girls-summer-of-code/rgsoc-teams/pull/560#issuecomment-263961154) and turned out NOT to be okay:
Before:
![user page](https://cloud.githubusercontent.com/assets/6314687/21296538/8f2f6f88-c56e-11e6-9d92-d970f0c76fd1.png)

After:
![user page after](https://cloud.githubusercontent.com/assets/6314687/21296561/bb8a37d4-c56e-11e6-8d4d-980d1d5b78bc.png)

(Apart from the leading space, that I couldn't solve. I'll leave that for now.)
