### PR TITLE
Limit user' s attendances to max 3

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,6 +59,8 @@ class User < ActiveRecord::Base
     "over 60",
   ]
 
+  MAX_ATTENDANCES_PER_ROUND = 3
+
   include ActiveModel::ForbiddenAttributesProtection
   include Authentication::ActiveRecordHelpers
   include ProfilesHelper
@@ -103,11 +105,19 @@ class User < ActiveRecord::Base
 
   validates :name, :email, :country, :location, presence: true, unless: :github_import
 
-  accepts_nested_attributes_for :attendances, allow_destroy: true, limit: 3
+  accepts_nested_attributes_for :attendances, allow_destroy: true, reject_if: :too_many_attendances
+  # , reject_if: -> (attendance) {attendances.conferences Conference.in_current_season.include? attendance.conference}
   accepts_nested_attributes_for :roles, allow_destroy: true
 
   before_save :sanitize_location
   after_create :complete_from_github
+
+  def too_many_attendances
+    this_round_attendances = attendances.collect {
+      |attendance| attendance.conference.in?(Conference.in_current_season)
+    }.count
+    this_round_attendances > MAX_ATTENDANCES_PER_ROUND
+  end
 
   # This field is used to skip validations when creating
   # a preliminary user, e.g. when adding a non existant person

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,7 +103,7 @@ class User < ActiveRecord::Base
 
   validates :name, :email, :country, :location, presence: true, unless: :github_import
 
-  accepts_nested_attributes_for :attendances, allow_destroy: true
+  accepts_nested_attributes_for :attendances, allow_destroy: true, limit: 3
   accepts_nested_attributes_for :roles, allow_destroy: true
 
   before_save :sanitize_location

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,22 +105,23 @@ class User < ActiveRecord::Base
 
   validates :name, :email, :country, :location, presence: true, unless: :github_import
 
-  accepts_nested_attributes_for :attendances, allow_destroy: true, reject_if: :too_many_attendances
-  # , reject_if: -> (attendance) {attendances.conferences Conference.in_current_season.include? attendance.conference}
+  accepts_nested_attributes_for :attendances, allow_destroy: true,
+    reject_if: :too_many_attendances
   accepts_nested_attributes_for :roles, allow_destroy: true
 
   before_save :sanitize_location
   after_create :complete_from_github
 
   def too_many_attendances
-    this_round_attendances = attendances.collect {
+    # TODO add round?
+    attendances = attendances.collect {
       |attendance| attendance.conference.in?(Conference.in_current_season)
     }.count
-    this_round_attendances > MAX_ATTENDANCES_PER_ROUND
+    attendances >= MAX_ATTENDANCES_PER_ROUND
   end
 
   # This field is used to skip validations when creating
-  # a preliminary user, e.g. when adding a non existant person
+  # a preliminary user, e.g. when adding a non existent person
   # to a team using the github handle.
   attr_reader :github_import
 

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -65,7 +65,8 @@
           = s.input :conference_id, as: :select, collection: conferences, required: false, label: false, default: 1
 
           = s.link_to_remove 'Remove'
-        = f.link_to_add 'I want to add another conference!', :attendances, class: 'btn btn-primary form-btn-group'
+        - if @user.attendances.size < 3
+           = f.link_to_add 'I want to add another conference!', :attendances, class: 'btn btn-primary form-btn-group'
 
   h3.page-header Private information
   p.help-block This information will only be visible to yourself and the organizers.

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -62,8 +62,7 @@
         .header
           label Conference
         = f.simple_fields_for :attendances do |s|
-          = s.input :conference_id, as: :select, collection: conferences, required: false, label: false, default: 1
-
+          = s.input :conference_id, as: :select, collection: conferences, required: false, label: false
           = s.link_to_remove 'Remove'
         - if @user.attendances.size < 3
            = f.link_to_add 'I want to add another conference!', :attendances, class: 'btn btn-primary form-btn-group'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,10 @@
 # Teams
-FactoryGirl.create_list(:team, 5, :in_current_season, :skip_validations, kind: "sponsored")
-FactoryGirl.create(:team, :in_current_season, :skip_validations, kind: "voluntary")
-FactoryGirl.create(:team, :in_current_season, :skip_validations) # rejected application
+FactoryGirl.create_list(:team, 5, :in_current_season, kind: "sponsored")
+FactoryGirl.create(:team, :in_current_season, kind: "voluntary")
+FactoryGirl.create(:team, :in_current_season) # rejected application
 
-FactoryGirl.create(:team, :last_season, :skip_validations, kind: "sponsored")
-FactoryGirl.create(:team, :last_season, :skip_validations, kind: "voluntary")
+FactoryGirl.create(:team, :last_season, kind: "sponsored")
+FactoryGirl.create(:team, :last_season, kind: "voluntary")
 
 # Users with different roles
 FactoryGirl.create_list(:team, 5, :in_current_season, kind: "sponsored")
@@ -33,10 +33,16 @@ FactoryGirl.create(:project, :accepted, :in_current_season)
 FactoryGirl.create(:project, :rejected, :in_current_season)
 
 # Conferences
-2.times do
-  FactoryGirl.create(:conference, :in_current_season, round: 1)
+6.times do
+  random_date = rand(1.year).seconds.from_now
+  FactoryGirl.create(:conference, :in_current_season,
+    location: FFaker::Venue.name,
+    starts_on: random_date,
+    ends_on: random_date + 2.days,
+    lightningtalkslots: rand < 0.5,
+    tickets: [2,4,6].sample,
+    accomodation: 2,
+    flights: 0,
+    round: [1,2].sample
+  )
 end
-2.times do
-  FactoryGirl.create(:conference, :in_current_season, round: 2)
-end
-FactoryGirl.create_list(:conference, 2) # without season

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,15 +32,3 @@ FactoryGirl.create(:application_draft, :appliable)
 FactoryGirl.create(:project, :in_current_season) #proposed
 FactoryGirl.create(:project, :accepted, :in_current_season)
 FactoryGirl.create(:project, :rejected, :in_current_season)
-
-# Conferences
-4.times do
-  FactoryGirl.create(:conference, :in_current_season,
-    location: FFaker::Venue.name,
-    starts_on: rand(1.year).seconds.from_now,
-    lightningtalkslots: rand < 0.5,
-    tickets: [2,4,6].sample,
-    accomodation: 2,
-    flights: 0
-  )
-end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,10 @@
 # Teams
-FactoryGirl.create_list(:team, 5, :in_current_season, kind: "sponsored")
-FactoryGirl.create(:team, :in_current_season, kind: "voluntary")
-FactoryGirl.create(:team, :in_current_season) #not accepted
+FactoryGirl.create_list(:team, 5, :in_current_season, :skip_validations, kind: "sponsored")
+FactoryGirl.create(:team, :in_current_season, :skip_validations, kind: "voluntary")
+FactoryGirl.create(:team, :in_current_season, :skip_validations) # rejected application
 
-FactoryGirl.create(:team, :last_season, kind: "sponsored")
-FactoryGirl.create(:team, :last_season, kind: "voluntary")
+FactoryGirl.create(:team, :last_season, :skip_validations, kind: "sponsored")
+FactoryGirl.create(:team, :last_season, :skip_validations, kind: "voluntary")
 
 # Users with different roles
 FactoryGirl.create_list(:team, 5, :in_current_season, kind: "sponsored")
@@ -19,7 +19,6 @@ FactoryGirl.create(:supervisor)
 # To explore use cases where user has no role yet
 FactoryGirl.create_list(:user, 3)
 
-
 # Status updates for different teams
 5.times do
   FactoryGirl.create(:status_update, published_at: Time.now, team: Team.all.sample)
@@ -32,3 +31,12 @@ FactoryGirl.create(:application_draft, :appliable)
 FactoryGirl.create(:project, :in_current_season) #proposed
 FactoryGirl.create(:project, :accepted, :in_current_season)
 FactoryGirl.create(:project, :rejected, :in_current_season)
+
+# Conferences
+2.times do
+  FactoryGirl.create(:conference, :in_current_season, round: 1)
+end
+2.times do
+  FactoryGirl.create(:conference, :in_current_season, round: 2)
+end
+FactoryGirl.create_list(:conference, 2) # without season

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -15,6 +15,10 @@ FactoryGirl.define do
       season { Season.find_or_create_by name: (Date.today.year - 1) }
     end
 
+    trait :skip_validations do
+      to_create {|instance| instance.save(validate: false) }
+    end
+
     trait :supervise do
       name 'supervise'
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,7 @@ describe User do
   it { expect(subject).to have_many(:teams) }
   it { expect(subject).to have_many(:application_drafts) }
   it { expect(subject).to have_many(:attendances).dependent(:destroy) }
+  it { expect(subject).to accept_nested_attributes_for(:attendances).limit(3) }
   it { expect(subject).to have_many(:conferences) }
   it { expect(subject).to have_many(:roles) }
   it { expect(subject).to have_many(:todos).dependent(:destroy) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,7 @@ describe User do
   it { expect(subject).to have_many(:teams) }
   it { expect(subject).to have_many(:application_drafts) }
   it { expect(subject).to have_many(:attendances).dependent(:destroy) }
-  it { expect(subject).to accept_nested_attributes_for(:attendances).limit(3) }
+  it { expect(subject).to accept_nested_attributes_for(:attendances) }
   it { expect(subject).to have_many(:conferences) }
   it { expect(subject).to have_many(:roles) }
   it { expect(subject).to have_many(:todos).dependent(:destroy) }
@@ -328,14 +328,13 @@ describe User do
       expect(student).to be_current_student
     end
   end
-
+  
   describe 'Search for user names and team names' do
     before do
       @cruyff = FactoryGirl.create(:user, name: "Johan Cruyff")
       @eesy = FactoryGirl.create(:user, name: "Eesy Peesy")
       @team = FactoryGirl.create(:team, name: "Cheesy")
       @cheesy = FactoryGirl.create(:student, team: @team)
-
     end
 
     it 'returns user with matching name' do


### PR DESCRIPTION
Part 1 of #414 
This adds a simple limit to the number of conferences a user can attend.
In user profile (user/:id/edit):
* On submitting a form, the 4th conference will not be saved.
* On loading the form, when more than 2 conferences are saved before, the link to 'Add another conference' will not show up.

TODO after this PR:
- [ ] better UX (see #565)
- [ ] make the attendances aware of raffle rounds
