### PR TITLE
Fix: remove role from user's profile

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,7 +99,7 @@ class UsersController < ApplicationController
         :application_location, :application_minimum_money, :application_money, :application_goals, :application_code_background,
         interested_in: [],
         attendances_attributes: [:id, :conference_id, :_destroy],
-        roles_attributes: [:id, :name, :team_id]
+        roles_attributes: [:id, :name, :team_id, :_destroy]
       )
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,7 +81,7 @@ class User < ActiveRecord::Base
   validate :immutable_github_handle
 
   accepts_nested_attributes_for :attendances, allow_destroy: true
-  accepts_nested_attributes_for :roles
+  accepts_nested_attributes_for :roles, allow_destroy: true
 
   before_save :sanitize_location
   after_create :complete_from_github


### PR DESCRIPTION
Solves #154
Removing a role from a user's profile (as an admin), did not actually remove the role. Allowing 'destroy's on nested attributes fixes this.