### PR TITLE
Refactor season phases call

### DIFF
--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -48,7 +48,7 @@ class Orga::SeasonsController < Orga::BaseController
   # by showing the corresponding links in the nav bar
   def switch_phase
     return if Rails.env.production?
-    Season::PhaseSwitcher.switcher(params[:option])
+    Season::PhaseSwitcher.distribute(params[:option])
     redirect_to orga_seasons_path, notice: "We time travelled into the #{params[:option]} phase"
   end
 

--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -48,7 +48,7 @@ class Orga::SeasonsController < Orga::BaseController
   # by showing the corresponding links in the nav bar
   def switch_phase
     return if Rails.env.production?
-    Season::PhaseSwitcher.distribute(params[:phase])
+    Season::PhaseSwitcher.destined(params[:phase])
     redirect_to orga_seasons_path, notice: "We time travelled into the #{params[:phase].humanize.titlecase}"
   end
 

--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -73,7 +73,7 @@ class Orga::SeasonsController < Orga::BaseController
   end
 
   def phase
-    params[:phase].to_sym
+    params[:phase].to_sym if phase.in? PHASES
   end
 
   def set_breadcrumbs

--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -45,22 +45,12 @@ class Orga::SeasonsController < Orga::BaseController
   end
 
   # # switch_phase: enables developers to easily switch between time dependent settings in views
-  # by opening and closing the corresponding links in the nav bar
+  # by showing the corresponding links in the nav bar
   def switch_phase
     return if Rails.env.production?
-      case params[:option]
-      when 'Proposals'
-        Season::PhaseSwitcher.fake_proposals_phase
-      when 'Application'
-        Season::PhaseSwitcher.fake_application_phase
-      when 'CodingSummer'
-        Season::PhaseSwitcher.fake_coding_phase
-      when 'RealTime'
-        Season::PhaseSwitcher.back_to_reality
-      end
+    Season::PhaseSwitcher.switcher(params[:option])
     redirect_to orga_seasons_path, notice: "We time travelled into the #{params[:option]} phase"
   end
-
 
   private
 

--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -48,8 +48,9 @@ class Orga::SeasonsController < Orga::BaseController
   # by showing the corresponding links in the nav bar
   def switch_phase
     return if Rails.env.production?
-    Season::PhaseSwitcher.distribute(params[:option])
-    redirect_to orga_seasons_path, notice: "We time travelled into the #{params[:option]} phase"
+    byebug
+    Season::PhaseSwitcher.distribute(params[:phase])
+    redirect_to orga_seasons_path, notice: "We time travelled into the #{params[:phase].humanize}"
   end
 
   private

--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -48,7 +48,7 @@ class Orga::SeasonsController < Orga::BaseController
   # by showing the corresponding links in the nav bar
   def switch_phase
     return if Rails.env.production?
-    Season::PhaseSwitcher.destined(params[:phase])
+    Season::PhaseSwitcher.destined(phase)
     redirect_to orga_seasons_path, notice: "We time travelled into the #{params[:phase].humanize.titlecase}"
   end
 
@@ -70,6 +70,10 @@ class Orga::SeasonsController < Orga::BaseController
       :project_proposals_open_at,
       :project_proposals_close_at
     )
+  end
+
+  def phase
+    params[:phase].to_sym
   end
 
   def set_breadcrumbs

--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -48,9 +48,8 @@ class Orga::SeasonsController < Orga::BaseController
   # by showing the corresponding links in the nav bar
   def switch_phase
     return if Rails.env.production?
-    byebug
     Season::PhaseSwitcher.distribute(params[:phase])
-    redirect_to orga_seasons_path, notice: "We time travelled into the #{params[:phase].humanize}"
+    redirect_to orga_seasons_path, notice: "We time travelled into the #{params[:phase].humanize.titlecase}"
   end
 
   private

--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -73,7 +73,7 @@ class Orga::SeasonsController < Orga::BaseController
   end
 
   def phase
-    params[:phase].to_sym if phase.in? PHASES
+    params[:phase].to_sym
   end
 
   def set_breadcrumbs

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -60,7 +60,7 @@ class Season::PhaseSwitcher
   end
 
   def self.whitelisted_phases
-    @whitelist_phases ||= [
+    @whitelisted_phases ||= [
         :fake_proposals_phase,
         :fake_application_phase,
         :fake_coding_phase,

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -7,62 +7,62 @@ class Season::PhaseSwitcher
     fake_application_phase
     fake_coding_phase
     back_to_reality
-    ).freeze
+  ).freeze
+
+  def self.destined(phase)
+    raise ArgumentError.new("#{phase} is not a valid phase") unless phase.in? PHASES
+    self.send(phase)
+  end
+
+  private
 
   def self.season
     Season.current
   end
 
-  def self.destined(phase)
-    raise ArgumentError.new("#{phase} is not a valid phase") unless phase.in? PHASES
-    self.public_send(phase)
-  end
-
-  private
-
   def self.fake_coding_phase
     season.update(
-       starts_at: 6.weeks.ago,
-       ends_at: 6.weeks.from_now,
-       applications_open_at: 4.months.ago,
-       applications_close_at: 3.months.ago,
-       acceptance_notification_at: 2.months.ago
+      starts_at: 6.weeks.ago,
+      ends_at: 6.weeks.from_now,
+      applications_open_at: 4.months.ago,
+      applications_close_at: 3.months.ago,
+      acceptance_notification_at: 2.months.ago
     )
   end
 
   def self.fake_proposals_phase
     season.update(
-       starts_at: 6.months.from_now,
-       ends_at: 9.months.from_now,
-       applications_open_at: 3.months.from_now,
-       applications_close_at: 4.months.from_now,
-       acceptance_notification_at: 5.months.from_now,
-       project_proposals_open_at: 4.weeks.ago,
-       project_proposals_close_at: 4.weeks.from_now
+      starts_at: 6.months.from_now,
+      ends_at: 9.months.from_now,
+      applications_open_at: 3.months.from_now,
+      applications_close_at: 4.months.from_now,
+      acceptance_notification_at: 5.months.from_now,
+      project_proposals_open_at: 4.weeks.ago,
+      project_proposals_close_at: 4.weeks.from_now
     )
   end
 
   def self.fake_application_phase
     season.update(
-       starts_at: 2.months.from_now,
-       ends_at: 5.months.from_now,
-       applications_open_at: 2.weeks.ago,
-       applications_close_at: 2.weeks.from_now,
-       acceptance_notification_at: 6.weeks.from_now
+      starts_at: 2.months.from_now,
+      ends_at: 5.months.from_now,
+      applications_open_at: 2.weeks.ago,
+      applications_close_at: 2.weeks.from_now,
+      acceptance_notification_at: 6.weeks.from_now
     )
   end
 
   def self.back_to_reality
     this_year = Date.today.year
     season.update(
-       name: this_year,
-       starts_at: Time.utc(this_year, *Season::SUMMER_OPEN),
-       ends_at: Time.utc(this_year, *Season::SUMMER_CLOSE),
-       applications_open_at: Time.utc(this_year, *Season::APPL_OPEN),
-       applications_close_at: Time.utc(this_year, *Season::APPL_CLOSE),
-       acceptance_notification_at: Time.utc(this_year, *Season::APPL_LETTER),
-       project_proposals_open_at: Time.utc(this_year-1, *Season::PROJECTS_OPEN),
-       project_proposals_close_at: Time.utc(this_year, *Season::PROJECTS_CLOSE),
+      name: this_year,
+      starts_at: Time.utc(this_year, *Season::SUMMER_OPEN),
+      ends_at: Time.utc(this_year, *Season::SUMMER_CLOSE),
+      applications_open_at: Time.utc(this_year, *Season::APPL_OPEN),
+      applications_close_at: Time.utc(this_year, *Season::APPL_CLOSE),
+      acceptance_notification_at: Time.utc(this_year, *Season::APPL_LETTER),
+      project_proposals_open_at: Time.utc(this_year-1, *Season::PROJECTS_OPEN),
+      project_proposals_close_at: Time.utc(this_year, *Season::PROJECTS_CLOSE),
     )
   end
 end

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -5,7 +5,7 @@ class Season::PhaseSwitcher
   end
 
   def self.distribute(phase)
-    self.send phases[phase]
+    self.public_send(phase)
   end
 
   def self.fake_coding_phase

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -4,6 +4,16 @@ class Season::PhaseSwitcher
     Season.current
   end
 
+  def self.switcher(phase)
+    @phases = {
+        'Proposals' => :fake_proposals_phase,
+        'Application' => :fake_application_phase,
+        'CodingSummer' => :fake_coding_phase,
+        'Real Time' => :back_to_reality
+    }
+     self.send @phases[phase]
+  end
+
   def self.fake_coding_phase
     season.update({
        starts_at: 6.weeks.ago,

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -5,7 +5,7 @@ class Season::PhaseSwitcher
   end
 
   def self.destined(phase)
-    unless phase.to_sym.presence_in(whitelisted_phases)
+    unless phase.to_sym.in?(whitelisted_phases)
       raise ArgumentError
     else
       self.public_send(phase)

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -5,9 +5,7 @@ class Season::PhaseSwitcher
   end
 
   def self.destined(phase)
-    unless phase.to_sym.in?(whitelisted_phases)
-      raise ArgumentError
-    else
+    if phase.to_sym.in?(whitelisted_phases)
       self.public_send(phase)
     end
   end
@@ -62,7 +60,7 @@ class Season::PhaseSwitcher
   end
 
   def self.whitelisted_phases
-    @phases ||= [
+    @whitelist_phases ||= [
         :fake_proposals_phase,
         :fake_application_phase,
         :fake_coding_phase,

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -13,8 +13,8 @@ class Season::PhaseSwitcher
     Season.current
   end
 
-  def self.destined(phase: phase)
-    raise ArgumentError.new("#{phase} is not a valid phase") unless phase.in?(PHASES)
+  def self.destined(phase)
+    raise ArgumentError.new("#{phase} is not a valid phase") unless phase.in? PHASES
     self.public_send(phase)
   end
 

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -4,14 +4,8 @@ class Season::PhaseSwitcher
     Season.current
   end
 
-  def self.switcher(phase)
-    phases = {
-        'Proposals' => :fake_proposals_phase,
-        'Application' => :fake_application_phase,
-        'CodingSummer' => :fake_coding_phase,
-        'Real Time' => :back_to_reality
-    }
-     self.send phases[phase]
+  def self.distribute(phase)
+    self.send phases[phase]
   end
 
   def self.fake_coding_phase
@@ -58,6 +52,17 @@ class Season::PhaseSwitcher
        project_proposals_open_at: Time.utc(this_year-1, *Season::PROJECTS_OPEN),
        project_proposals_close_at: Time.utc(this_year, *Season::PROJECTS_CLOSE),
     })
+  end
+
+  private
+
+  def self.phases
+    @phases ||= {
+        'Proposals' => :fake_proposals_phase,
+        'Application' => :fake_application_phase,
+        'CodingSummer' => :fake_coding_phase,
+        'Real Time' => :back_to_reality
+    }
   end
 
 end

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -1,4 +1,3 @@
-# The following is not a dev comment but a magic string, with the compliments of Ruby 2.3
 # frozen_string_literal: true
 
 class Season::PhaseSwitcher

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -4,7 +4,7 @@ class Season::PhaseSwitcher
     Season.current
   end
 
-  def self.distribute(phase)
+  def self.destined(phase)
     unless phase.to_sym.presence_in(whitelisted_phases)
       raise ArgumentError
     else

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -1,3 +1,6 @@
+# The following is not a dev comment but a magic string, with the compliments of Ruby 2.3
+# frozen_string_literal: true
+
 class Season::PhaseSwitcher
 
   def self.season
@@ -5,7 +8,7 @@ class Season::PhaseSwitcher
   end
 
   def self.destined(phase)
-    if phase.to_sym.in?(whitelisted_phases)
+    if phase.in?(whitelisted_phases)
       self.public_send(phase)
     end
   end
@@ -60,11 +63,11 @@ class Season::PhaseSwitcher
   end
 
   def self.whitelisted_phases
-    @whitelisted_phases ||= [
-        :fake_proposals_phase,
-        :fake_application_phase,
-        :fake_coding_phase,
-        :back_to_reality
+    @whitelisted_phases ||= %w[
+        fake_proposals_phase
+        fake_application_phase
+        fake_coding_phase
+        back_to_reality
     ]
   end
 end

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -5,13 +5,13 @@ class Season::PhaseSwitcher
   end
 
   def self.switcher(phase)
-    @phases = {
+    phases = {
         'Proposals' => :fake_proposals_phase,
         'Application' => :fake_application_phase,
         'CodingSummer' => :fake_coding_phase,
         'Real Time' => :back_to_reality
     }
-     self.send @phases[phase]
+     self.send phases[phase]
   end
 
   def self.fake_coding_phase

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -2,31 +2,37 @@
 
 class Season::PhaseSwitcher
 
+  WHITELISTED_PHASES = %i[
+        fake_proposals_phase
+        fake_application_phase
+        fake_coding_phase
+        back_to_reality
+    ]
+
   def self.season
     Season.current
   end
 
-  def self.destined(phase)
-    if phase.in?(whitelisted_phases)
+  def self.destined(phase: phase)
+    if phase.in?(WHITELISTED_PHASES)
       self.public_send(phase)
     end
   end
 
-
   private
 
   def self.fake_coding_phase
-    season.update({
+    season.update(
        starts_at: 6.weeks.ago,
        ends_at: 6.weeks.from_now,
        applications_open_at: 4.months.ago,
        applications_close_at: 3.months.ago,
        acceptance_notification_at: 2.months.ago
-    })
+    )
   end
 
   def self.fake_proposals_phase
-    season.update({
+    season.update(
        starts_at: 6.months.from_now,
        ends_at: 9.months.from_now,
        applications_open_at: 3.months.from_now,
@@ -34,22 +40,22 @@ class Season::PhaseSwitcher
        acceptance_notification_at: 5.months.from_now,
        project_proposals_open_at: 4.weeks.ago,
        project_proposals_close_at: 4.weeks.from_now
-    })
+    )
   end
 
   def self.fake_application_phase
-    season.update({
+    season.update(
        starts_at: 2.months.from_now,
        ends_at: 5.months.from_now,
        applications_open_at: 2.weeks.ago,
        applications_close_at: 2.weeks.from_now,
        acceptance_notification_at: 6.weeks.from_now
-    })
+    )
   end
 
   def self.back_to_reality
     this_year = Date.today.year
-    season.update({
+    season.update(
        name: this_year,
        starts_at: Time.utc(this_year, *Season::SUMMER_OPEN),
        ends_at: Time.utc(this_year, *Season::SUMMER_CLOSE),
@@ -58,15 +64,6 @@ class Season::PhaseSwitcher
        acceptance_notification_at: Time.utc(this_year, *Season::APPL_LETTER),
        project_proposals_open_at: Time.utc(this_year-1, *Season::PROJECTS_OPEN),
        project_proposals_close_at: Time.utc(this_year, *Season::PROJECTS_CLOSE),
-    })
-  end
-
-  def self.whitelisted_phases
-    @whitelisted_phases ||= %w[
-        fake_proposals_phase
-        fake_application_phase
-        fake_coding_phase
-        back_to_reality
-    ]
+    )
   end
 end

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -14,7 +14,8 @@ class Season::PhaseSwitcher
   end
 
   def self.destined(phase: phase)
-    self.public_send(phase) if phase.in?(PHASES)
+    raise ArgumentError.new("#{phase} is not a valid phase") unless phase.in?(PHASES)
+    self.public_send(phase)
   end
 
   private

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -5,8 +5,15 @@ class Season::PhaseSwitcher
   end
 
   def self.distribute(phase)
-    self.public_send(phase)
+    unless phase.to_sym.presence_in(whitelisted_phases)
+      raise ArgumentError
+    else
+      self.public_send(phase)
+    end
   end
+
+
+  private
 
   def self.fake_coding_phase
     season.update({
@@ -54,15 +61,12 @@ class Season::PhaseSwitcher
     })
   end
 
-  private
-
-  def self.phases
-    @phases ||= {
-        'Proposals' => :fake_proposals_phase,
-        'Application' => :fake_application_phase,
-        'CodingSummer' => :fake_coding_phase,
-        'Real Time' => :back_to_reality
-    }
+  def self.whitelisted_phases
+    @phases ||= [
+        :fake_proposals_phase,
+        :fake_application_phase,
+        :fake_coding_phase,
+        :back_to_reality
+    ]
   end
-
 end

--- a/app/models/season/phase_switcher.rb
+++ b/app/models/season/phase_switcher.rb
@@ -2,21 +2,19 @@
 
 class Season::PhaseSwitcher
 
-  WHITELISTED_PHASES = %i[
-        fake_proposals_phase
-        fake_application_phase
-        fake_coding_phase
-        back_to_reality
-    ]
+  PHASES = %i(
+    fake_proposals_phase
+    fake_application_phase
+    fake_coding_phase
+    back_to_reality
+    ).freeze
 
   def self.season
     Season.current
   end
 
   def self.destined(phase: phase)
-    if phase.in?(WHITELISTED_PHASES)
-      self.public_send(phase)
-    end
+    self.public_send(phase) if phase.in?(PHASES)
   end
 
   private

--- a/app/views/orga/seasons/_switch.html.erb
+++ b/app/views/orga/seasons/_switch.html.erb
@@ -3,13 +3,13 @@
 <p>… to adjust all the date-dependent settings for the current season.</p>
 
 <%= form_tag switch_phase_path, :method => :patch do %>
-  <%= radio_button_tag :option, "Proposals" %>
-  <%= label_tag :option_Proposals, "Proposals Phase" %>
-  <%= radio_button_tag :option, "Application" %>
-  <%= label_tag :option_Application, "Application Phase" %> 
-  <%= radio_button_tag :option, "CodingSummer" %> 
-  <%= label_tag :option_CodingSummer, "Coding Summer" %> 
-  <%= radio_button_tag :option, "RealTime" %>
-  <%= label_tag :option_RealTime, "Back to Real Time" %>
+  <%= radio_button_tag :phase, :fake_proposals_phase %>
+  <%= label_tag 'Proposal Phase' %>
+  <%= radio_button_tag :phase, :fake_application_phase %>
+  <%= label_tag 'Application Phase' %> 
+  <%= radio_button_tag :phase, :fake_coding_phase %> 
+  <%= label_tag 'Coding Summer' %> 
+  <%= radio_button_tag :phase, :back_to_reality %>
+  <%= label_tag 'Back to Real Time' %>
   <%= submit_tag "Switch phase", class: 'btn btn-sm btn-warning' %>
 <% end %>

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -52,13 +52,11 @@ context 'when switching phases' do
     end
 
     it 'fails silently when it receives a non-whitelisted phase' do
-      # Just to make sure we have our season in the test DB.
-      # It creates one if it didn't already exist though some other factory:
-      Season.current
-      allow_any_instance_of(Season).to receive(:save).and_raise RuntimeError
-
       phase = 'bad_intentions'
-      expect { Season::PhaseSwitcher.destined(phase) }.not_to change { Season.current.updated_at }
+      # Season.current
+      # allow_any_instance_of(Season).to receive(:save).and_raise RuntimeError
+      expect { Season::PhaseSwitcher.destined(phase) }.not_to change { Season.current.updated_at.strftime("%Y-%m-%d
+%H:%M:%S.%6N") }
     end
   end
 end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -53,9 +53,7 @@ context 'when switching phases' do
 
     it 'fails silently when it receives a non-whitelisted phase' do
       phase = 'bad_intentions'
-      forbidden_call = Season::PhaseSwitcher.destined(phase)
-      expect { forbidden_call }.not_to change { Season.current.updated_at.to_s }
+      expect { Season::PhaseSwitcher.destined(phase) }.not_to change { Season.current.updated_at }
     end
-
   end
 end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 context 'when switching phases' do
   subject { Season.current }
 
-
   describe 'destined' do
     it 'sends the params to a phase setting method' do
       phase = :fake_application_phase
@@ -13,8 +12,8 @@ context 'when switching phases' do
     end
 
     it 'addresses the requested phase' do
-      phase = :fake_proposals_phase
-      Season::PhaseSwitcher.destined(phase)
+      wrong_phase = :fake_proposals_phase
+      Season::PhaseSwitcher.destined(wrong_phase)
       expect(subject).to_not be_application_period
     end
 
@@ -26,9 +25,11 @@ context 'when switching phases' do
   end
 
   describe '#fake_application_phase' do
+
     it 'timeshifts the application phase to today' do
+      phase = :fake_application_phase
       Timecop.travel(Season.current.applications_close_at - 1.month) do
-        Season::PhaseSwitcher.fake_application_phase
+        Season::PhaseSwitcher.destined(phase)
         expect(subject).to be_application_period
       end
     end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -1,13 +1,8 @@
 require 'spec_helper'
 
 describe Season::PhaseSwitcher do
-
-  it "is available as described class" do
-    expect(described_class).to eq Season::PhaseSwitcher
-  end
-
-  context 'when switching phases' do
-    season = Season.current
+  context '.destined' do
+    let(:season) { Season.current }
 
     context 'when the input is valid' do
       it 'gets called on the season object' do
@@ -26,17 +21,12 @@ describe Season::PhaseSwitcher do
     end
 
     context 'when the input is malicious' do
-      phase = :bad_intentions
-
-      it 'raises an error when it receives a non-whitelisted phase' do
+      it 'does not change the season dates' do
+        phase = :bad_intentions
+        RSpec::Matchers.define_negated_matcher :not_change, :change
         expect {
           described_class.destined(phase)
-        }.to raise_error(ArgumentError)
-      end
-      it 'does not change the season dates' do
-        expect {
-          described_class.destined(phase) rescue ArgumentError
-        }.not_to change { Season.current.reload }
+        }.to raise_error(ArgumentError).and not_change { Season.current.reload }
       end
     end
   end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -7,63 +7,36 @@ describe Season::PhaseSwitcher do
   end
 
   context 'when switching phases' do
-    subject { Season.current }
+    season = Season.current
 
-    describe 'destined' do
-      xit 'sends the params to a phase setting method' do
+    context 'when the input is valid' do
+      it 'gets called on the season object' do
         phase = :fake_application_phase
-        expect(subject).to receive(Season::PhaseSwitcher.destined(phase))
+        described_class.destined(phase)
+        season.reload
+        expect(season).to be_application_period
       end
 
-      context 'when directed to the #fake_application_phase' do
-        it 'sets date range so that the season is open for application submissions' do
-          phase = :fake_application_phase
-          Timecop.travel(Season.current.applications_close_at - 1.month) do
-            Season::PhaseSwitcher.destined(phase)
-            expect(subject).to_not be_nil
-            expect(subject).to be_application_period
-          end
-        end
+      it 'changes also when real time happens to be within application_period' do
+        phase = :fake_proposals_phase
+        described_class.destined(phase)
+        season.reload
+        expect(season).not_to be_application_period
       end
+    end
 
-      context 'when directed to the #fake_coding_phase' do
-        it 'sets dates so that the summer of code is currently happening' do
-          phase = :fake_coding_phase
-          Timecop.travel(Season.current.ends_at - 1.week) do
-            Season::PhaseSwitcher.destined(phase)
-            expect(subject).to be_started
-          end
-        end
+    context 'when the input is malicious' do
+      phase = :bad_intentions
+
+      it 'raises an error when it receives a non-whitelisted phase' do
+        expect {
+          described_class.destined(phase)
+        }.to raise_error(ArgumentError)
       end
-
-      context 'when directed to the #fake_proposals_phase' do
-        it 'set dates so that season is open for project proposals' do
-          phase = :fake_proposals_phase
-          Timecop.travel(Season.current.project_proposals_close_at - 2.weeks) do
-            fake_time = Time.now #as returned by Timecop
-            Season::PhaseSwitcher.destined(phase)
-            expect(subject.project_proposals_open_at).to be < fake_time
-            expect(subject.project_proposals_close_at).to be > fake_time
-          end
-        end
-      end
-
-      it 'addresses the requested phase' do
-        another_phase = :fake_proposals_phase
-        Season::PhaseSwitcher.destined(another_phase)
-        Season.current
-        expect(subject).to_not be_application_period
-      end
-
-      context 'it does not accept malicious input' do
-        phase = :bad_intentions
-
-        it 'raises an error when it receives a non-whitelisted phase' do
-          expect { Season::PhaseSwitcher.destined(phase) }.to raise_error(ArgumentError)
-        end
-        it 'does not change the subject' do
-          expect { Season::PhaseSwitcher.destined(phase) rescue ArgumentError }.not_to change { subject.reload }
-        end
+      it 'does not change the season dates' do
+        expect {
+          described_class.destined(phase) rescue ArgumentError
+        }.not_to change { Season.current.reload }
       end
     end
   end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -52,6 +52,11 @@ context 'when switching phases' do
     end
 
     it 'fails silently when it receives a non-whitelisted phase' do
+      # Just to make sure we have our season in the test DB.
+      # It creates one if it didn't already exist though some other factory:
+      Season.current
+      allow_any_instance_of(Season).to receive(:save).and_raise RuntimeError
+
       phase = 'bad_intentions'
       expect { Season::PhaseSwitcher.destined(phase) }.not_to change { Season.current.updated_at }
     end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -12,45 +12,46 @@ context 'when switching phases' do
     end
 
     it 'addresses the requested phase' do
-      wrong_phase = :fake_proposals_phase
-      Season::PhaseSwitcher.destined(wrong_phase)
+      non_existing_phase = :fake_proposals_phase
+      Season::PhaseSwitcher.destined(non_existing_phase)
       expect(subject).to_not be_application_period
     end
 
     it 'fails silently when it receives a non-whitelisted phase' do
       phase = :bad_intentions
-      bad_call = Season::PhaseSwitcher.destined(phase)
-      expect( bad_call ).to be_nil
+      forbidden_call = Season::PhaseSwitcher.destined(phase)
+      expect { forbidden_call }.not_to change { Season.current.updated_at }
     end
-  end
 
-  describe '#fake_application_phase' do
-
-    it 'timeshifts the application phase to today' do
-      phase = :fake_application_phase
-      Timecop.travel(Season.current.applications_close_at - 1.month) do
-        Season::PhaseSwitcher.destined(phase)
-        expect(subject).to be_application_period
+    context 'when directed to the #fake_application_phase' do
+      it 'sets date range so that the season is open for application submissions' do
+        phase = :fake_application_phase
+        Timecop.travel(Season.current.applications_close_at - 1.month) do
+          Season::PhaseSwitcher.destined(phase)
+          expect(subject).to be_application_period
+        end
       end
     end
-  end
 
-  describe '#fake_coding_phase' do
-    it 'timeshifts the coding phase to today' do
-      Timecop.travel(Season.current.ends_at - 1.week) do
-        Season::PhaseSwitcher.fake_coding_phase
-        expect(subject).to be_started
+    context 'when directed to the #fake_coding_phase' do
+      it 'sets dates so that the summer of code is currently happening' do
+        phase = :fake_coding_phase
+        Timecop.travel(Season.current.ends_at - 1.week) do
+          Season::PhaseSwitcher.destined(phase)
+          expect(subject).to be_started
+        end
       end
     end
-  end
 
-  describe '#fake_proposals_phase' do
-    it 'timeshifts the proposal period to today' do
-      Timecop.travel(Season.current.project_proposals_close_at - 2.weeks) do
-        fake_time = Time.now #as returned by Timecop
-        Season::PhaseSwitcher.fake_proposals_phase
-        expect(subject.project_proposals_open_at).to be < fake_time
-        expect(subject.project_proposals_close_at).to be > fake_time
+    context 'when directed to the #fake_proposals_phase' do
+      it 'set dates so that season is open for project proposals' do
+        phase = :fake_proposals_phase
+        Timecop.travel(Season.current.project_proposals_close_at - 2.weeks) do
+          fake_time = Time.now #as returned by Timecop
+          Season::PhaseSwitcher.destined(phase)
+          expect(subject.project_proposals_open_at).to be < fake_time
+          expect(subject.project_proposals_close_at).to be > fake_time
+        end
       end
     end
   end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -54,10 +54,15 @@ context 'when switching phases' do
       expect(subject).to_not be_application_period
     end
 
-    it 'fails silently when it receives a non-whitelisted phase' do
+    context 'it does not accept malicious input' do
       phase = :bad_intentions
-      expect { Season::PhaseSwitcher.destined(phase: phase) }.not_to change { Season.current.updated_at.strftime("%Y-%m-%d
-%H:%M:%S.%6N") }
+
+      it 'raises an error when it receives a non-whitelisted phase' do
+        expect { Season::PhaseSwitcher.destined(phase: phase) }.to raise_error(ArgumentError)
+      end
+      it 'does not change the subject' do
+        expect { Season::PhaseSwitcher.destined(phase: phase) rescue ArgumentError }.not_to change { subject.reload }
+      end
     end
   end
 end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -4,6 +4,27 @@ require 'spec_helper'
 context 'when switching phases' do
   subject { Season.current }
 
+
+  describe 'destined' do
+    it 'sends the params to a phase setting method' do
+      phase = :fake_application_phase
+      Season::PhaseSwitcher.destined(phase)
+      expect(subject).to be_application_period
+    end
+
+    it 'addresses the requested phase' do
+      phase = :fake_proposals_phase
+      Season::PhaseSwitcher.destined(phase)
+      expect(subject).to_not be_application_period
+    end
+
+    it 'fails silently when it receives a non-whitelisted phase' do
+      phase = :bad_intentions
+      bad_call = Season::PhaseSwitcher.destined(phase)
+      expect( bad_call ).to be_nil
+    end
+  end
+
   describe '#fake_application_phase' do
     it 'timeshifts the application phase to today' do
       Timecop.travel(Season.current.applications_close_at - 1.month) do

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -5,29 +5,19 @@ context 'when switching phases' do
   subject { Season.current }
 
   describe 'destined' do
+
     it 'sends the params to a phase setting method' do
-      phase = :fake_application_phase
+      phase = 'fake_application_phase'
       Season::PhaseSwitcher.destined(phase)
       expect(subject).to_not be_nil
     end
 
-    it 'addresses the requested phase' do
-      non_existing_phase = :fake_proposals_phase
-      Season::PhaseSwitcher.destined(non_existing_phase)
-      expect(subject).to_not be_application_period
-    end
-
-    it 'fails silently when it receives a non-whitelisted phase' do
-      phase = :bad_intentions
-      forbidden_call = Season::PhaseSwitcher.destined(phase)
-      expect { forbidden_call }.not_to change { Season.current.updated_at }
-    end
-
     context 'when directed to the #fake_application_phase' do
       it 'sets date range so that the season is open for application submissions' do
-        phase = :fake_application_phase
+        phase = 'fake_application_phase'
         Timecop.travel(Season.current.applications_close_at - 1.month) do
           Season::PhaseSwitcher.destined(phase)
+          expect(subject).to_not be_nil
           expect(subject).to be_application_period
         end
       end
@@ -35,7 +25,7 @@ context 'when switching phases' do
 
     context 'when directed to the #fake_coding_phase' do
       it 'sets dates so that the summer of code is currently happening' do
-        phase = :fake_coding_phase
+        phase = 'fake_coding_phase'
         Timecop.travel(Season.current.ends_at - 1.week) do
           Season::PhaseSwitcher.destined(phase)
           expect(subject).to be_started
@@ -45,7 +35,7 @@ context 'when switching phases' do
 
     context 'when directed to the #fake_proposals_phase' do
       it 'set dates so that season is open for project proposals' do
-        phase = :fake_proposals_phase
+        phase = 'fake_proposals_phase'
         Timecop.travel(Season.current.project_proposals_close_at - 2.weeks) do
           fake_time = Time.now #as returned by Timecop
           Season::PhaseSwitcher.destined(phase)
@@ -54,5 +44,18 @@ context 'when switching phases' do
         end
       end
     end
+
+    it 'addresses the requested phase' do
+      another_phase = 'fake_proposals_phase'
+      Season::PhaseSwitcher.destined(another_phase)
+      expect(subject).to_not be_application_period
+    end
+
+    it 'fails silently when it receives a non-whitelisted phase' do
+      phase = 'bad_intentions'
+      forbidden_call = Season::PhaseSwitcher.destined(phase)
+      expect { forbidden_call }.not_to change { Season.current.updated_at }
+    end
+
   end
 end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -8,7 +8,7 @@ context 'when switching phases' do
     it 'sends the params to a phase setting method' do
       phase = :fake_application_phase
       Season::PhaseSwitcher.destined(phase)
-      expect(subject).to be_application_period
+      expect(subject).to_not be_nil
     end
 
     it 'addresses the requested phase' do

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -47,14 +47,16 @@ context 'when switching phases' do
 
     it 'addresses the requested phase' do
       another_phase = 'fake_proposals_phase'
+
       Season::PhaseSwitcher.destined(another_phase)
+      # Just checking, here too the error is not raised
+      Season.current
+      allow_any_instance_of(Season).to receive(:save).and_raise RuntimeError
       expect(subject).to_not be_application_period
     end
 
     it 'fails silently when it receives a non-whitelisted phase' do
       phase = 'bad_intentions'
-      # Season.current
-      # allow_any_instance_of(Season).to receive(:save).and_raise RuntimeError
       expect { Season::PhaseSwitcher.destined(phase) }.not_to change { Season.current.updated_at.strftime("%Y-%m-%d
 %H:%M:%S.%6N") }
     end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -7,15 +7,15 @@ context 'when switching phases' do
   describe 'destined' do
 
     xit 'sends the params to a phase setting method' do
-      phase = Season::PhaseSwitcher::WHITELISTED_PHASES.first
-      expect(subject).to respond_to(Season::PhaseSwitcher.destined(phase: phase))
+      phase = Season::PhaseSwitcher::PHASES.first
+      expect(subject).to receive(Season::PhaseSwitcher.destined(phase))
     end
 
     context 'when directed to the #fake_application_phase' do
       it 'sets date range so that the season is open for application submissions' do
         phase = :fake_application_phase
         Timecop.travel(Season.current.applications_close_at - 1.month) do
-          Season::PhaseSwitcher.destined(phase: phase)
+          Season::PhaseSwitcher.destined(phase)
           expect(subject).to_not be_nil
           expect(subject).to be_application_period
         end
@@ -26,7 +26,7 @@ context 'when switching phases' do
       it 'sets dates so that the summer of code is currently happening' do
         phase = :fake_coding_phase
         Timecop.travel(Season.current.ends_at - 1.week) do
-          Season::PhaseSwitcher.destined(phase: phase)
+          Season::PhaseSwitcher.destined(phase)
           expect(subject).to be_started
         end
       end
@@ -37,7 +37,7 @@ context 'when switching phases' do
         phase = :fake_proposals_phase
         Timecop.travel(Season.current.project_proposals_close_at - 2.weeks) do
           fake_time = Time.now #as returned by Timecop
-          Season::PhaseSwitcher.destined(phase: phase)
+          Season::PhaseSwitcher.destined(phase)
           expect(subject.project_proposals_open_at).to be < fake_time
           expect(subject.project_proposals_close_at).to be > fake_time
         end
@@ -47,7 +47,7 @@ context 'when switching phases' do
     it 'addresses the requested phase' do
       another_phase = :fake_proposals_phase
 
-      Season::PhaseSwitcher.destined(phase: another_phase)
+      Season::PhaseSwitcher.destined(another_phase)
       Season.current
       expect(subject).to_not be_application_period
     end
@@ -56,10 +56,10 @@ context 'when switching phases' do
       phase = :bad_intentions
 
       it 'raises an error when it receives a non-whitelisted phase' do
-        expect { Season::PhaseSwitcher.destined(phase: phase) }.to raise_error(ArgumentError)
+        expect { Season::PhaseSwitcher.destined(phase) }.to raise_error(ArgumentError)
       end
       it 'does not change the subject' do
-        expect { Season::PhaseSwitcher.destined(phase: phase) rescue ArgumentError }.not_to change { subject.reload }
+        expect { Season::PhaseSwitcher.destined(phase) rescue ArgumentError }.not_to change { subject.reload }
       end
     end
   end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -48,9 +48,7 @@ context 'when switching phases' do
       another_phase = :fake_proposals_phase
 
       Season::PhaseSwitcher.destined(phase: another_phase)
-      # Just checking, here too the error is not raised
       Season.current
-      allow_any_instance_of(Season).to receive(:save).and_raise RuntimeError
       expect(subject).to_not be_application_period
     end
 

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -6,17 +6,16 @@ context 'when switching phases' do
 
   describe 'destined' do
 
-    it 'sends the params to a phase setting method' do
-      phase = 'fake_application_phase'
-      Season::PhaseSwitcher.destined(phase)
-      expect(subject).to_not be_nil
+    xit 'sends the params to a phase setting method' do
+      phase = Season::PhaseSwitcher::WHITELISTED_PHASES.first
+      expect(subject).to respond_to(Season::PhaseSwitcher.destined(phase: phase))
     end
 
     context 'when directed to the #fake_application_phase' do
       it 'sets date range so that the season is open for application submissions' do
-        phase = 'fake_application_phase'
+        phase = :fake_application_phase
         Timecop.travel(Season.current.applications_close_at - 1.month) do
-          Season::PhaseSwitcher.destined(phase)
+          Season::PhaseSwitcher.destined(phase: phase)
           expect(subject).to_not be_nil
           expect(subject).to be_application_period
         end
@@ -25,9 +24,9 @@ context 'when switching phases' do
 
     context 'when directed to the #fake_coding_phase' do
       it 'sets dates so that the summer of code is currently happening' do
-        phase = 'fake_coding_phase'
+        phase = :fake_coding_phase
         Timecop.travel(Season.current.ends_at - 1.week) do
-          Season::PhaseSwitcher.destined(phase)
+          Season::PhaseSwitcher.destined(phase: phase)
           expect(subject).to be_started
         end
       end
@@ -35,10 +34,10 @@ context 'when switching phases' do
 
     context 'when directed to the #fake_proposals_phase' do
       it 'set dates so that season is open for project proposals' do
-        phase = 'fake_proposals_phase'
+        phase = :fake_proposals_phase
         Timecop.travel(Season.current.project_proposals_close_at - 2.weeks) do
           fake_time = Time.now #as returned by Timecop
-          Season::PhaseSwitcher.destined(phase)
+          Season::PhaseSwitcher.destined(phase: phase)
           expect(subject.project_proposals_open_at).to be < fake_time
           expect(subject.project_proposals_close_at).to be > fake_time
         end
@@ -46,9 +45,9 @@ context 'when switching phases' do
     end
 
     it 'addresses the requested phase' do
-      another_phase = 'fake_proposals_phase'
+      another_phase = :fake_proposals_phase
 
-      Season::PhaseSwitcher.destined(another_phase)
+      Season::PhaseSwitcher.destined(phase: another_phase)
       # Just checking, here too the error is not raised
       Season.current
       allow_any_instance_of(Season).to receive(:save).and_raise RuntimeError
@@ -56,8 +55,8 @@ context 'when switching phases' do
     end
 
     it 'fails silently when it receives a non-whitelisted phase' do
-      phase = 'bad_intentions'
-      expect { Season::PhaseSwitcher.destined(phase) }.not_to change { Season.current.updated_at.strftime("%Y-%m-%d
+      phase = :bad_intentions
+      expect { Season::PhaseSwitcher.destined(phase: phase) }.not_to change { Season.current.updated_at.strftime("%Y-%m-%d
 %H:%M:%S.%6N") }
     end
   end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -54,7 +54,7 @@ context 'when switching phases' do
     it 'fails silently when it receives a non-whitelisted phase' do
       phase = 'bad_intentions'
       forbidden_call = Season::PhaseSwitcher.destined(phase)
-      expect { forbidden_call }.not_to change { Season.current.updated_at }
+      expect { forbidden_call }.not_to change { Season.current.updated_at.to_s }
     end
 
   end

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -1,65 +1,69 @@
 require 'spec_helper'
 
+describe Season::PhaseSwitcher do
 
-context 'when switching phases' do
-  subject { Season.current }
+  it "is available as described class" do
+    expect(described_class).to eq Season::PhaseSwitcher
+  end
 
-  describe 'destined' do
+  context 'when switching phases' do
+    subject { Season.current }
 
-    xit 'sends the params to a phase setting method' do
-      phase = Season::PhaseSwitcher::PHASES.first
-      expect(subject).to receive(Season::PhaseSwitcher.destined(phase))
-    end
-
-    context 'when directed to the #fake_application_phase' do
-      it 'sets date range so that the season is open for application submissions' do
+    describe 'destined' do
+      xit 'sends the params to a phase setting method' do
         phase = :fake_application_phase
-        Timecop.travel(Season.current.applications_close_at - 1.month) do
-          Season::PhaseSwitcher.destined(phase)
-          expect(subject).to_not be_nil
-          expect(subject).to be_application_period
+        expect(subject).to receive(Season::PhaseSwitcher.destined(phase))
+      end
+
+      context 'when directed to the #fake_application_phase' do
+        it 'sets date range so that the season is open for application submissions' do
+          phase = :fake_application_phase
+          Timecop.travel(Season.current.applications_close_at - 1.month) do
+            Season::PhaseSwitcher.destined(phase)
+            expect(subject).to_not be_nil
+            expect(subject).to be_application_period
+          end
         end
       end
-    end
 
-    context 'when directed to the #fake_coding_phase' do
-      it 'sets dates so that the summer of code is currently happening' do
-        phase = :fake_coding_phase
-        Timecop.travel(Season.current.ends_at - 1.week) do
-          Season::PhaseSwitcher.destined(phase)
-          expect(subject).to be_started
+      context 'when directed to the #fake_coding_phase' do
+        it 'sets dates so that the summer of code is currently happening' do
+          phase = :fake_coding_phase
+          Timecop.travel(Season.current.ends_at - 1.week) do
+            Season::PhaseSwitcher.destined(phase)
+            expect(subject).to be_started
+          end
         end
       end
-    end
 
-    context 'when directed to the #fake_proposals_phase' do
-      it 'set dates so that season is open for project proposals' do
-        phase = :fake_proposals_phase
-        Timecop.travel(Season.current.project_proposals_close_at - 2.weeks) do
-          fake_time = Time.now #as returned by Timecop
-          Season::PhaseSwitcher.destined(phase)
-          expect(subject.project_proposals_open_at).to be < fake_time
-          expect(subject.project_proposals_close_at).to be > fake_time
+      context 'when directed to the #fake_proposals_phase' do
+        it 'set dates so that season is open for project proposals' do
+          phase = :fake_proposals_phase
+          Timecop.travel(Season.current.project_proposals_close_at - 2.weeks) do
+            fake_time = Time.now #as returned by Timecop
+            Season::PhaseSwitcher.destined(phase)
+            expect(subject.project_proposals_open_at).to be < fake_time
+            expect(subject.project_proposals_close_at).to be > fake_time
+          end
         end
       end
-    end
 
-    it 'addresses the requested phase' do
-      another_phase = :fake_proposals_phase
-
-      Season::PhaseSwitcher.destined(another_phase)
-      Season.current
-      expect(subject).to_not be_application_period
-    end
-
-    context 'it does not accept malicious input' do
-      phase = :bad_intentions
-
-      it 'raises an error when it receives a non-whitelisted phase' do
-        expect { Season::PhaseSwitcher.destined(phase) }.to raise_error(ArgumentError)
+      it 'addresses the requested phase' do
+        another_phase = :fake_proposals_phase
+        Season::PhaseSwitcher.destined(another_phase)
+        Season.current
+        expect(subject).to_not be_application_period
       end
-      it 'does not change the subject' do
-        expect { Season::PhaseSwitcher.destined(phase) rescue ArgumentError }.not_to change { subject.reload }
+
+      context 'it does not accept malicious input' do
+        phase = :bad_intentions
+
+        it 'raises an error when it receives a non-whitelisted phase' do
+          expect { Season::PhaseSwitcher.destined(phase) }.to raise_error(ArgumentError)
+        end
+        it 'does not change the subject' do
+          expect { Season::PhaseSwitcher.destined(phase) rescue ArgumentError }.not_to change { subject.reload }
+        end
       end
     end
   end


### PR DESCRIPTION
Move phases to model. Get rid of the switch statement.

The switch statement has been bugging me since I created it, last year, as a Ruby Nuby. 
The new PhaseSwitcher class looks like the most appropriate place to translate the params to a method call.  

