### PR TITLE
Avoid orphaned attendances

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -2,7 +2,7 @@ class Conference < ActiveRecord::Base
 
   include HasSeason
 
-  has_many :attendances
+  has_many :attendances, dependent: :destroy
   has_many :attendees, through: :attendances, source: :user
   validates :name, :round, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,7 @@ class User < ActiveRecord::Base
   has_many :teams, -> { distinct }, through: :roles
   has_many :application_drafts, through: :teams
   has_many :applications, through: :teams
-  has_many :attendances
+  has_many :attendances, dependent: :destroy
   has_many :conferences, through: :attendances
 
   validates :github_handle, presence: true, uniqueness: { case_sensitive: false }

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -50,7 +50,7 @@ nav.actions
   - if @user.conferences.any?
     h4 Conferences
     ul.conferences
-      - @user.attendances.includes(:conference).order('conferences.starts_on').each do |a|
+      - @user.attendances.joins(:conference).order('conferences.starts_on').each do |a|
         li
           ' #{link_to a.conference.name, a.conference}
           ' (#{a.conference.location}#{format_conference_date(a.conference.starts_on, a.conference.ends_on)})

--- a/db/migrate/20170107110820_remove_orphaned_attendance_records.rb
+++ b/db/migrate/20170107110820_remove_orphaned_attendance_records.rb
@@ -1,0 +1,12 @@
+class Attendance < ActiveRecord::Base
+  belongs_to :conference
+end
+
+class RemoveOrphanedAttendanceRecords < ActiveRecord::Migration[5.0]
+  def up
+    Attendance.where(conference: nil).destroy_all
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161124184157) do
+ActiveRecord::Schema.define(version: 20170107110820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe UsersController do
+RSpec.describe UsersController do
   render_views
 
   let(:valid_attributes) { build(:user).attributes.except('github_id', 'avatar_url', *User.immutable_attributes.map(&:to_s)) }
@@ -71,6 +71,18 @@ describe UsersController do
       user = create(:user)
       get :show, { params: { id: user.to_param } }, valid_session
       expect(assigns(:user)).to eq(user)
+    end
+
+    context 'with conferences' do
+      let!(:attendance) { create :attendance }
+      let(:user)        { attendance.user }
+      let(:conference)  { attendance.conference }
+
+      it 'lists the users conference attendances' do
+        get :show, params: { id: user.to_param }
+        expect(response).to be_success
+        expect(response.body).to match conference.name
+      end
     end
 
     context 'with user logged in' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -83,6 +83,19 @@ RSpec.describe UsersController do
         expect(response).to be_success
         expect(response.body).to match conference.name
       end
+
+      context 'with attendance orphans' do
+        let!(:orphan) { create :attendance, user: user }
+
+        before { orphan.conference.delete }
+
+        # There are some stale attendance records in the system since
+        # attendences used to stick around when their conference was deleted
+        it 'will not list attendances w/o conference' do
+          get :show, params: { id: user.to_param }
+          expect(response).to be_success
+        end
+      end
     end
 
     context 'with user logged in' do

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Conference do
   it_behaves_like 'HasSeason'
 
-  it { is_expected.to have_many(:attendances) }
+  it { is_expected.to have_many(:attendances).dependent(:destroy) }
   it { is_expected.to have_many(:attendees) }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:round) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ describe User do
 
   it { expect(subject).to have_many(:teams) }
   it { expect(subject).to have_many(:application_drafts) }
-  it { expect(subject).to have_many(:attendances) }
+  it { expect(subject).to have_many(:attendances).dependent(:destroy) }
   it { expect(subject).to have_many(:conferences) }
   it { expect(subject).to have_many(:roles) }
   it { expect(subject).to validate_presence_of(:github_handle) }


### PR DESCRIPTION
Fix #586 – the bug described in the issue must have occurred due to a deleted conference.

This PR will delete attendances alongside its conference. It is possible that the attendance records were intentionally allowed to linger so that we may know of a student's attendance even after its corresponding conference record was deleted. I do not think we need it - knowing that there was some kind of conference attendance without actually knowing _which_ conference exactly hardly provides value. What do you think?

The PR leaves existing attendance orphans intact but avoids the error described in the #586 using the fix @F3PiX suggested.

