### PR TITLE
Fix ninja commas or missing whitespace in conferences links … once and for all?

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,7 +140,7 @@ module ApplicationHelper
     conferences.map do |conference|
       text = conference.name
       if verbose
-        extra = [conference.location, format_conference_date(conference.starts_on, conference.ends_on)].reject(&:blank?).join(', ')
+        extra = [conference.location, format_conference_date(conference.starts_on, conference.ends_on)].reject(&:blank?).join(' – ')
         text += " (#{extra})" unless extra.blank?
       end
       link_to(text, conference)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -139,7 +139,10 @@ module ApplicationHelper
   def links_to_conferences(conferences, extra_info = false)
     conferences.map do |conference|
       text = conference.name
-      text += " (#{conference.location}#{format_conference_date(conference.starts_on, conference.ends_on)})" if extra_info
+      if extra_info
+        extra = [conference.location, format_conference_date(conference.starts_on, conference.ends_on)].reject(&:blank?).join(', ')
+        text += " (#{extra})" unless extra.blank?
+      end
       link_to(text, conference)
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,13 +133,13 @@ module ApplicationHelper
     end
   end
 
-  # @param conferences [Array<Conference>] list of Conference records
-  # @param extra_info [Boolean] append verbose info?
-  # @return [Array<String>] list of HTML anchor tags to conferences
-  def links_to_conferences(conferences, extra_info = false)
+  # @param conferences [Array<Conference>] a list of Conference records
+  # @param verbose [Boolean] appends location and date info if true (defaults to false)
+  # @return [Array<String>] a list of HTML anchor tags to conferences
+  def links_to_conferences(conferences, verbose: false)
     conferences.map do |conference|
       text = conference.name
-      if extra_info
+      if verbose
         extra = [conference.location, format_conference_date(conference.starts_on, conference.ends_on)].reject(&:blank?).join(', ')
         text += " (#{extra})" unless extra.blank?
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,6 +133,9 @@ module ApplicationHelper
     end
   end
 
+  # @param conferences [Array<Conference>] list of Conference records
+  # @param extra_info [Boolean] append verbose info?
+  # @return [Array<String>] list of HTML anchor tags to conferences
   def links_to_conferences(conferences, extra_info = false)
     conferences.map do |conference|
       text = conference.name

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -91,7 +91,7 @@ nav.page
   ul.conferences
     - @team.members.each do |user|
       - if user.conferences.in_current_season.any?
-        li = "#{link_to user.name, user}: #{links_to_conferences(user.conferences.in_current_season, true).join(', ')}".html_safe
+        li = "#{link_to user.name, user}: #{links_to_conferences(user.conferences.in_current_season, verbose: true).join(', ')}".html_safe
 
 - if @team.activities.any?
   h3

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -52,7 +52,7 @@ nav.actions
     ul.conferences
       - @user.attendances.includes(:conference).order('conferences.starts_on').each do |a|
         li
-          = links_to_conferences([a.conference], true).first
+          = links_to_conferences([a.conference], verbose: true).first
           - if @user == current_user
             ' #{link_to "Tweet About It!", conference_tweet_link(a.conference), class: 'btn btn-default'}
           - if can?(:crud, a) and admin?

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -52,8 +52,7 @@ nav.actions
     ul.conferences
       - @user.attendances.includes(:conference).order('conferences.starts_on').each do |a|
         li
-          ' #{link_to a.conference.name, a.conference}
-          ' (#{a.conference.location}#{format_conference_date(a.conference.starts_on, a.conference.ends_on)})
+          = links_to_conferences([a.conference], true).first
           - if @user == current_user
             ' #{link_to "Tweet About It!", conference_tweet_link(a.conference), class: 'btn btn-default'}
           - if can?(:crud, a) and admin?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ApplicationHelper do
+RSpec.describe ApplicationHelper do
   describe '#application_disambiguation_link' do
     let(:draft) { create :application_draft }
     let(:user)  { create :user }
@@ -101,6 +101,54 @@ describe ApplicationHelper do
         "<a href=\"/users?role=mentor\">Mentor</a> at <a href=\"/teams/#{@team.id}\">Team 29-enim (Sinatra)</a>"
       )
     end
+  end
+
+  describe '#links_to_conferences' do
+    let(:conference) { build_stubbed :conference }
+
+
+    it 'creates a simple link to a single conference' do
+      subject = links_to_conferences [conference]
+      expect(subject).to eql [link_to(conference.name, conference)]
+    end
+
+    context 'with extra info flag' do
+      subject { links_to_conferences [conference], true }
+
+      it 'will not display empty brackets' do
+        expect(subject).to eql [link_to(conference.name, conference)]
+      end
+
+      context 'with location' do
+        let(:conference) { build_stubbed :conference, location: 'Melée Island' }
+
+        it 'will add the location in brackets' do
+          link_text = "#{conference.name} (Melée Island)"
+          expect(subject).to eql [link_to(link_text, conference)]
+        end
+      end
+
+      context 'with starts_on and ends_on present' do
+        let(:conference) { build_stubbed :conference, starts_on: '2017-03-14', ends_on: '2017-03-17' }
+
+        it 'will add the date range in brackets' do
+          link_text = "#{conference.name} (14 Mar 17 - 17 Mar 17)"
+          expect(subject).to eql [link_to(link_text, conference)]
+        end
+      end
+
+      context 'with location and and all dates present' do
+        let(:conference) do
+          build_stubbed :conference, location: 'Melée Island', starts_on: '2017-03-14', ends_on: '2017-03-17'
+        end
+
+        it 'will add location and date range in brackets' do
+          link_text = "#{conference.name} (Melée Island, 14 Mar 17 - 17 Mar 17)"
+          expect(subject).to eql [link_to(link_text, conference)]
+        end
+      end
+    end
+
   end
 
   describe '.icon' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -120,10 +120,10 @@ RSpec.describe ApplicationHelper do
       end
 
       context 'with location' do
-        let(:conference) { build_stubbed :conference, location: 'Melée Island' }
+        let(:conference) { build_stubbed :conference, location: 'Melée Island, Carribean' }
 
         it 'will add the location in brackets' do
-          link_text = "#{conference.name} (Melée Island)"
+          link_text = "#{conference.name} (Melée Island, Carribean)"
           expect(subject).to eql [link_to(link_text, conference)]
         end
       end
@@ -139,11 +139,11 @@ RSpec.describe ApplicationHelper do
 
       context 'with location and and all dates present' do
         let(:conference) do
-          build_stubbed :conference, location: 'Melée Island', starts_on: '2017-03-14', ends_on: '2017-03-17'
+          build_stubbed :conference, location: 'Melée Island, Carribean', starts_on: '2017-03-14', ends_on: '2017-03-17'
         end
 
         it 'will add location and date range in brackets' do
-          link_text = "#{conference.name} (Melée Island, 14 Mar 17 - 17 Mar 17)"
+          link_text = "#{conference.name} (Melée Island, Carribean – 14 Mar 17 - 17 Mar 17)"
           expect(subject).to eql [link_to(link_text, conference)]
         end
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe ApplicationHelper do
     end
 
     context 'with extra info flag' do
-      subject { links_to_conferences [conference], true }
+      subject { links_to_conferences [conference], verbose: true }
 
       it 'will not display empty brackets' do
         expect(subject).to eql [link_to(conference.name, conference)]


### PR DESCRIPTION
Some experiments as part of my investigation for #573 led to this PR. I think it supersedes your PR, @F3PiX which is why I would appreciate if you could have a look at this.

I removed the slight difference in displaying conference attendances; they all use the helper logic now. I've also added a bucketload of test examples that will hopefully silence conference formatting error for good now :smile: 