### PR TITLE
change the email address showing when sending emails over the app

### DIFF
--- a/app/mailers/application_form_mailer.rb
+++ b/app/mailers/application_form_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ApplicationFormMailer < ActionMailer::Base
-  default from: ENV['EMAIL_FROM'] || 'summer-of-code-team@railsgirls.com'
+  default from: ENV['EMAIL_FROM'] || 'contact@rgsoc.org'
 
   default to: 'contact@rgsoc.org'
 

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -2,7 +2,7 @@
 class CommentMailer < ActionMailer::Base
   include ActionView::Helpers::TextHelper
 
-  default from: ENV['EMAIL_FROM'] || 'summer-of-code@railsgirls.com'
+  default from: ENV['EMAIL_FROM'] || 'contact@rgsoc.org'
 
   attr_reader :team, :comment
   helper_method :team, :comment

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ProjectMailer < ActionMailer::Base
-  default from: ENV['EMAIL_FROM'] || 'summer-of-code@railsgirls.com'
+  default from: ENV['EMAIL_FROM'] || 'contact@rgsoc.org'
   default_url_options[:protocol] = 'https'
 
   def proposal(project)

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -2,7 +2,7 @@
 class ReminderMailer < ActionMailer::Base
   include ActionView::Helpers::TextHelper
 
-  default from: ENV['EMAIL_FROM'] || 'summer-of-code@railsgirls.com'
+  default from: ENV['EMAIL_FROM'] || 'contact@rgsoc.org'
 
   def update_log(team)
     @team = team

--- a/app/mailers/role_mailer.rb
+++ b/app/mailers/role_mailer.rb
@@ -2,7 +2,7 @@
 class RoleMailer < ActionMailer::Base
   include ActionView::Helpers::TextHelper
 
-  default from: ENV['EMAIL_FROM'] || 'summer-of-code-team@railsgirls.com'
+  default from: ENV['EMAIL_FROM'] || 'contact@rgsoc.org'
 
   def user_added_to_team(role)
     return unless role.user.present? &&


### PR DESCRIPTION
Currently emails sent over the app will still show our “old” email address (`summer-of-code@railsgirls.com`). This PR changes it to our new one. OMG IT'S OFFICIAL!