### PR TITLE
[WIP] responsive improvements to projects index view

### DIFF
--- a/app/assets/stylesheets/controllers/projects.sass
+++ b/app/assets/stylesheets/controllers/projects.sass
@@ -15,9 +15,15 @@
 
 
 #login-required-overlay .well
-  position: absolute
-  top: 20%
-  left: 50%
-  margin-left: -250px
-  width: 500px
   box-shadow: 5px 9px 36px -9px black
+  position: absolute
+  @media screen and (max-width: $screen-sm-max)
+    width: 80%
+    top: 50%
+    left: 50%
+    transform: translate(-50%, -50%)
+  @media screen and (min-width: $screen-sm)
+    top: 20%
+    left: 50%
+    margin-left: -250px
+    width: 500px

--- a/app/views/orga/projects/index.html.slim
+++ b/app/views/orga/projects/index.html.slim
@@ -1,6 +1,6 @@
 h1 Listing Projects
 
-table.table.table-striped.table-bordered.table-condensed
+table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
   thead
     tr
       th Name
@@ -30,5 +30,37 @@ table.table.table-striped.table-bordered.table-condensed
           - else
             = link_to 'Lock comments', [:lock, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
 
-br
+- @projects.each do |project|
+  table.table.table-striped.table-bordered.table-condensed.hidden-md.hidden-lg
+    tbody
+      tr
+        td Name
+        td = link_to project.name, project
+      tr
+        td Submitted
+        td = l project.created_at, format: :shortest
+      tr
+        td Submitted by
+        td = link_to project.submitter.name, project.submitter
+      tr
+        td State
+        td = project_status project
+      tr
+        td Tags
+        td = project_tags project
+      tr
+        td Actions
+        td
+          - if project.may_accept?
+            = link_to 'Accept', [:accept, :orga, project], method: :put, class: 'btn btn-sm btn-success'
+          - if project.may_reject?
+            = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger'
+      tr
+        td Comments
+        td
+          - if project.comments_locked?
+            = link_to 'Unlock comments', [:unlock, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
+          - else
+            = link_to 'Lock comments', [:lock, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
 
+br

--- a/app/views/orga/projects/index.html.slim
+++ b/app/views/orga/projects/index.html.slim
@@ -32,35 +32,34 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
 
 - @projects.each do |project|
   table.table.table-striped.table-bordered.table-condensed.hidden-md.hidden-lg
-    tbody
-      tr
-        td Name
-        td = link_to project.name, project
-      tr
-        td Submitted
-        td = l project.created_at, format: :shortest
-      tr
-        td Submitted by
-        td = link_to project.submitter.name, project.submitter
-      tr
-        td State
-        td = project_status project
-      tr
-        td Tags
-        td = project_tags project
-      tr
-        td Actions
-        td
-          - if project.may_accept?
-            = link_to 'Accept', [:accept, :orga, project], method: :put, class: 'btn btn-sm btn-success'
-          - if project.may_reject?
-            = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger'
-      tr
-        td Comments
-        td
-          - if project.comments_locked?
-            = link_to 'Unlock comments', [:unlock, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
-          - else
-            = link_to 'Lock comments', [:lock, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
+    tr
+      th Name
+      td = link_to project.name, project
+    tr
+      th Submitted
+      td = l project.created_at, format: :shortest
+    tr
+      th Submitted by
+      td = link_to project.submitter.name, project.submitter
+    tr
+      th State
+      td = project_status project
+    tr
+      th Tags
+      td = project_tags project
+    tr
+      th Actions
+      td
+        - if project.may_accept?
+          = link_to 'Accept', [:accept, :orga, project], method: :put, class: 'btn btn-sm btn-success'
+        - if project.may_reject?
+          = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger'
+    tr
+      th Comments
+      td
+        - if project.comments_locked?
+          = link_to 'Unlock comments', [:unlock, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
+        - else
+          = link_to 'Lock comments', [:lock, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
 
 br

--- a/app/views/projects/_login_required.html.erb
+++ b/app/views/projects/_login_required.html.erb
@@ -5,7 +5,7 @@
     <p>This action on the RGSoC Teams App requires a user account.</p>
     <p>
       <%= link_to user_github_omniauth_authorize_path, class: "btn btn-primary btn-lg" do %>
-        <i class="icon-github"></i>&nbsp;Login with your Github account.
+        <i class="icon-github"></i>&nbsp;Login with Github
       <% end %>
       <%= link_to "Cancel", root_path, class: "btn btn-lg" %>
     </p>

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -41,38 +41,37 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
 
 - @projects.each do |project|
   table.table.table-striped.table-bordered.table-condensed.hidden-md.hidden-lg
-    tbody
+    tr
+      th Name
+      td = link_to project.name, project
+    - if can? :crud, project
       tr
-        td Name
-        td = link_to project.name, project
-      - if can? :crud, project
-        tr
-          td Actions
-          td 
-            .project-actions
-              = link_to [:edit, project] do
-                = icon('edit')
-              = link_to project, data: { confirm: 'This action cannot be undone. Are you sure?' }, method: :delete do
-                = icon('minus-sign')
+        th Actions
+        td 
+          .project-actions
+            = link_to [:edit, project] do
+              = icon('edit')
+            = link_to project, data: { confirm: 'This action cannot be undone. Are you sure?' }, method: :delete do
+              = icon('minus-sign')
+    tr
+      th Tags
+      td = project_tags project
+    - if project.comments.any?
       tr
-        td Tags
-        td = project_tags project
-      - if project.comments.any?
-        tr
-          td Comments
-          td = link_to project.comments.count, project_path(project, anchor: 'comments'), class: 'label label-default'
-      tr
-        td title="Application referencing this project as 1st choice" Applications (1st Choice)
-        td
-          span.label.label-default title="Application still in draft mode"= project.first_choice_application_drafts.draft.count
-          | /
-          span.label.label-primary title="Applications sent in" = project.first_choice_application_drafts.applied.count
-      tr
-        td title="Application referencing this project as 2nd choice" Applications (2nd Choice)
-        td
-          span.label.label-default title="Applications still in draft mode" = project.second_choice_application_drafts.draft.count
-          | /
-          span.label.label-primary title="Applications sent in" = project.second_choice_application_drafts.applied.count
-      tr
-        td Status
-        td = project_status project
+        th Comments
+        td = link_to project.comments.count, project_path(project, anchor: 'comments'), class: 'label label-default'
+    tr
+      th title="Application referencing this project as 1st choice" Applications (1st Choice)
+      td
+        span.label.label-default title="Application still in draft mode"= project.first_choice_application_drafts.draft.count
+        | /
+        span.label.label-primary title="Applications sent in" = project.first_choice_application_drafts.applied.count
+    tr
+      th title="Application referencing this project as 2nd choice" Applications (2nd Choice)
+      td
+        span.label.label-default title="Applications still in draft mode" = project.second_choice_application_drafts.draft.count
+        | /
+        span.label.label-primary title="Applications sent in" = project.second_choice_application_drafts.applied.count
+    tr
+      th Status
+      td = project_status project

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -6,7 +6,7 @@ h1.header
   = icon('group')
   span Projects
 
-table.table.table-striped.table-bordered.table-condensed
+table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
   tr
     th Name
     th Tags
@@ -38,3 +38,41 @@ table.table.table-striped.table-bordered.table-condensed
         | /
         span.label.label-primary title="Applications sent in" = project.second_choice_application_drafts.applied.count
       td = project_status project
+
+- @projects.each do |project|
+  table.table.table-striped.table-bordered.table-condensed.hidden-md.hidden-lg
+    tbody
+      tr
+        td Name
+        td = link_to project.name, project
+      - if can? :crud, project
+        tr
+          td Actions
+          td 
+            .project-actions
+              = link_to [:edit, project] do
+                = icon('edit')
+              = link_to project, data: { confirm: 'This action cannot be undone. Are you sure?' }, method: :delete do
+                = icon('minus-sign')
+      tr
+        td Tags
+        td = project_tags project
+      - if project.comments.any?
+        tr
+          td Comments
+          td = link_to project.comments.count, project_path(project, anchor: 'comments'), class: 'label label-default'
+      tr
+        td title="Application referencing this project as 1st choice" Applications (1st Choice)
+        td
+          span.label.label-default title="Application still in draft mode"= project.first_choice_application_drafts.draft.count
+          | /
+          span.label.label-primary title="Applications sent in" = project.first_choice_application_drafts.applied.count
+      tr
+        td title="Application referencing this project as 2nd choice" Applications (2nd Choice)
+        td
+          span.label.label-default title="Applications still in draft mode" = project.second_choice_application_drafts.draft.count
+          | /
+          span.label.label-primary title="Applications sent in" = project.second_choice_application_drafts.applied.count
+      tr
+        td Status
+        td = project_status project


### PR DESCRIPTION
⚠️ Achtung: work in progress still!

This aims to close https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/600
- improves the index views of projects (both the “normal” and the orga one)

<img width="315" alt="screen shot 2017-01-11 at 22 04 01" src="https://cloud.githubusercontent.com/assets/3143348/21866462/a9316d66-d84a-11e6-88cf-a27b70a520c3.png"> <img width="317" alt="screen shot 2017-01-11 at 22 04 25" src="https://cloud.githubusercontent.com/assets/3143348/21866543/ebce8bf4-d84a-11e6-9d48-a453a24ab3aa.png">

- makes the login screen on mobile prettier (don't know why it doesn't look centered in the browser device inspector, on my iPhone tested locally with ngrok it looks centered 🤔 )

<img width="314" alt="screen shot 2017-01-11 at 22 26 06" src="https://cloud.githubusercontent.com/assets/3143348/21867159/40472720-d84d-11e6-94e4-fb8432d4a677.png">


