### PR TITLE
Use predefined values for "How have you heard about the program?" field

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -82,7 +82,7 @@ class ApplicationDraftsController < ApplicationController
 
   def application_draft_params
     params.require(:application_draft).
-      permit(:project1_id, :project2_id, :project_plan, :misc_info, :heard_about_it, :voluntary, :voluntary_hours_per_week, :working_together, :why_selected_project)
+      permit(:project1_id, :project2_id, :project_plan, :misc_info, :voluntary, :voluntary_hours_per_week, :working_together, :why_selected_project, heard_about_it: [])
   end
 
   def student_params

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -3,6 +3,30 @@ class ApplicationDraft < ActiveRecord::Base
 
   include AASM
 
+  # `heard_about_it` checkbox choices
+
+  DIRECT_OUTREACH_CHOICES = [
+    'RGSoC Blog',
+    'RGSoC Twitter',
+    'RGSoC Facebook',
+    'RGSoC Newsletter',
+    'RGSoC Organisers'
+  ]
+
+  PARTNER_CHOICES = [
+    'Past RGSoC participants',
+    'Another diversity initiative outreach',
+    'Study group / Workshop',
+    'Conference'
+  ]
+
+  OTHER_CHOICES = [
+    'Friends',
+    'Mass media'
+  ]
+
+  ALL_CHOICES = DIRECT_OUTREACH_CHOICES + PARTNER_CHOICES + OTHER_CHOICES
+
   # FIXME
   STUDENT0_REQUIRED_FIELDS = Student::REQUIRED_DRAFT_FIELDS.map { |m| "student0_#{m}" }
   STUDENT1_REQUIRED_FIELDS = Student::REQUIRED_DRAFT_FIELDS.map { |m| "student1_#{m}" }
@@ -34,6 +58,7 @@ class ApplicationDraft < ActiveRecord::Base
   validates *STUDENT1_CHAR_LIMITED_FIELDS, length: { maximum: Student::CHARACTER_LIMIT }, on: :apply
 
   before_validation :set_current_season
+  before_save :clean_up_heard_about_it
 
   attr_accessor :current_user
 
@@ -144,5 +169,9 @@ class ApplicationDraft < ActiveRecord::Base
 
   def set_current_season
     self.season ||= Season.current
+  end
+
+  def clean_up_heard_about_it
+    self.heard_about_it = self.heard_about_it.reject(&:empty?)
   end
 end

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -44,13 +44,13 @@ class ApplicationDraft < ActiveRecord::Base
 
   validates :team, presence: true
   validates :project1, :project_plan, presence: true, on: :apply
-  validates :heard_about_it, presence: true, on: :apply
   validates :working_together, presence: true, on: :apply
   validates :why_selected_project, presence: true, on: :apply
   validates :voluntary_hours_per_week, presence: true, on: :apply, if: :voluntary?
   validate :only_one_application_draft_allowed, if: :team, on: :create
   validate :different_projects_required
   validate :accepted_projects_required, on: :apply
+  validate :at_least_one_heard_about_it, on: :apply
 
   validates *STUDENT0_REQUIRED_FIELDS, presence: true, on: :apply
   validates *STUDENT1_REQUIRED_FIELDS, presence: true, on: :apply
@@ -159,6 +159,10 @@ class ApplicationDraft < ActiveRecord::Base
     if projects.any? { |p| p && !p.accepted? } # if they don't exist, the presence validation will handle it
       errors.add(:projects, 'must have been accepted')
     end
+  end
+
+  def at_least_one_heard_about_it
+    errors.add(:heard_about_it, 'Please select at least one!') unless heard_about_it && heard_about_it.reject(&:empty?).size > 0
   end
 
   def only_one_application_draft_allowed

--- a/app/views/application_drafts/_form.html.slim
+++ b/app/views/application_drafts/_form.html.slim
@@ -72,7 +72,15 @@ p.attention
       = f.input :voluntary_hours_per_week, as: :integer, label: 'As a voluntary team, how many hours per week would you be able to work on the project?', hint: 'Please only enter a full number, e.g. 15', input_html: { disabled: !application_draft.as_student? || application_draft.applied? }
 
       h2 Miscellaneous
-      = f.input :heard_about_it, as: :text, label: 'How have you heard about the program?', input_html: { rows: 3, disabled: !application_draft.as_student? || application_draft.applied? }
+
+      h3 How have you heard about the program?
+      = f.input :heard_about_it, collection: ApplicationDraft::DIRECT_OUTREACH_CHOICES.map {|choice| [choice, choice]}, as: :check_boxes, label: "RGSoC direct outreach", :input_html => {multiple: true }
+
+      = f.input :heard_about_it, collection: ApplicationDraft::PARTNER_CHOICES.map {|choice| [choice, choice]}, as: :check_boxes, label: "Past participants or 'Partners'", :input_html => {multiple: true }
+
+      = f.input :heard_about_it, collection: ApplicationDraft::OTHER_CHOICES.map {|choice| [choice, choice]}, as: :check_boxes, label: "Other channels", :input_html => {multiple: true }
+      = f.input :heard_about_it, label: "Other (please specify)", :input_html => {multiple: true, value: (application_draft.heard_about_it - ApplicationDraft::ALL_CHOICES).first }
+
       = f.input :misc_info, as: :text, label: 'Anything else to add?', hint: 'Address anything that you feel is relevant to your application and was not covered previously. For example: Do you have a coaching company? Do you have extra remote coaches on board? etc..', input_html: { rows: 4, disabled: !application_draft.as_student? || application_draft.applied? }
 
       = render 'save_draft_button', f: f if application_draft.draft?

--- a/app/views/application_drafts/_form.html.slim
+++ b/app/views/application_drafts/_form.html.slim
@@ -74,11 +74,11 @@ p.attention
       h2 Miscellaneous
 
       h3 How have you heard about the program?
-      = f.input :heard_about_it, collection: ApplicationDraft::DIRECT_OUTREACH_CHOICES.map {|choice| [choice, choice]}, as: :check_boxes, label: "RGSoC direct outreach", :input_html => {multiple: true }
+      = f.input :heard_about_it, collection: ApplicationDraft::DIRECT_OUTREACH_CHOICES.map {|choice| [choice, choice]}, as: :check_boxes, label: "RGSoC direct outreach", :input_html => {multiple: true }, error: false
 
-      = f.input :heard_about_it, collection: ApplicationDraft::PARTNER_CHOICES.map {|choice| [choice, choice]}, as: :check_boxes, label: "Past participants or 'Partners'", :input_html => {multiple: true }
+      = f.input :heard_about_it, collection: ApplicationDraft::PARTNER_CHOICES.map {|choice| [choice, choice]}, as: :check_boxes, label: "Past participants or 'Partners'", :input_html => {multiple: true }, error: false
 
-      = f.input :heard_about_it, collection: ApplicationDraft::OTHER_CHOICES.map {|choice| [choice, choice]}, as: :check_boxes, label: "Other channels", :input_html => {multiple: true }
+      = f.input :heard_about_it, collection: ApplicationDraft::OTHER_CHOICES.map {|choice| [choice, choice]}, as: :check_boxes, label: "Other channels", :input_html => {multiple: true }, error: false
       = f.input :heard_about_it, label: "Other (please specify)", :input_html => {multiple: true, value: (application_draft.heard_about_it - ApplicationDraft::ALL_CHOICES).first }
 
       = f.input :misc_info, as: :text, label: 'Anything else to add?', hint: 'Address anything that you feel is relevant to your application and was not covered previously. For example: Do you have a coaching company? Do you have extra remote coaches on board? etc..', input_html: { rows: 4, disabled: !application_draft.as_student? || application_draft.applied? }

--- a/db/migrate/20170112155942_adapt_heard_about_it_to_array.rb
+++ b/db/migrate/20170112155942_adapt_heard_about_it_to_array.rb
@@ -1,0 +1,13 @@
+class AdaptHeardAboutItToArray < ActiveRecord::Migration[5.0]
+  def change
+    add_column :application_drafts, :heard_about_it_new, :string, array: true, default: []
+
+    ApplicationDraft.all.each do |draft|
+      draft.heard_about_it_new = [draft.heard_about_it]
+      draft.save!
+    end
+
+    remove_column :application_drafts, :heard_about_it
+    rename_column :application_drafts, :heard_about_it_new, :heard_about_it
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,6 @@ ActiveRecord::Schema.define(version: 20170115230058) do
     t.text     "project_name"
     t.text     "project_url"
     t.text     "misc_info"
-    t.text     "heard_about_it"
     t.datetime "signed_off_at"
     t.integer  "team_id"
     t.integer  "season_id"
@@ -52,6 +51,7 @@ ActiveRecord::Schema.define(version: 20170115230058) do
     t.integer  "project2_id"
     t.text     "working_together"
     t.text     "why_selected_project"
+    t.string   "heard_about_it",           default: [],                   array: true
     t.index ["project1_id"], name: "index_application_drafts_on_project1_id", using: :btree
     t.index ["project2_id"], name: "index_application_drafts_on_project2_id", using: :btree
     t.index ["season_id"], name: "index_application_drafts_on_season_id", using: :btree
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 20170115230058) do
     t.string   "sponsor_pick",                  limit: 255
     t.integer  "project_visibility"
     t.boolean  "hidden"
-    t.text     "flags",                                     default: [], array: true
+    t.text     "flags",                         default: [], array: true
     t.string   "country",                       limit: 255
     t.string   "city",                          limit: 255
     t.string   "coaching_company",              limit: 255
@@ -101,41 +101,41 @@ ActiveRecord::Schema.define(version: 20170115230058) do
     t.text     "text"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
-    t.integer  "commentable_id"
     t.string   "commentable_type"
+    t.integer  "commentable_id"
     t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type", using: :btree
   end
 
   create_table "conferences", force: :cascade do |t|
-    t.string   "name",               limit: 255
-    t.string   "location",           limit: 255
-    t.string   "twitter",            limit: 255
-    t.string   "url",                limit: 255
+    t.string   "name", limit: 255
+    t.string   "location", limit: 255
+    t.string   "twitter", limit: 255
+    t.string   "url", limit: 255
     t.date     "starts_on"
     t.date     "ends_on"
     t.integer  "tickets"
     t.integer  "accomodation"
     t.integer  "flights"
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
-    t.integer  "round",                          default: 1
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.integer  "round",              default: 1
     t.boolean  "lightningtalkslots"
     t.integer  "season_id"
     t.index ["season_id"], name: "index_conferences_on_season_id", using: :btree
   end
 
   create_table "mailings", force: :cascade do |t|
-    t.string   "from",       limit: 255
-    t.string   "to",         limit: 255
-    t.string   "cc",         limit: 255
-    t.string   "bcc",        limit: 255
-    t.string   "subject",    limit: 255
+    t.string   "from", limit: 255
+    t.string   "to", limit: 255
+    t.string   "cc", limit: 255
+    t.string   "bcc", limit: 255
+    t.string   "subject", limit: 255
     t.text     "body"
     t.datetime "sent_at"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.integer  "group",                  default: 0
-    t.text     "seasons",                default: [],              array: true
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.integer  "group",      default: 0
+    t.text     "seasons",    default: [],              array: true
   end
 
   create_table "notes", force: :cascade do |t|
@@ -147,7 +147,7 @@ ActiveRecord::Schema.define(version: 20170115230058) do
   end
 
   create_table "projects", force: :cascade do |t|
-    t.string   "name",                 limit: 255
+    t.string   "name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "submitter_id"
@@ -160,9 +160,9 @@ ActiveRecord::Schema.define(version: 20170115230058) do
     t.text     "issues_and_features"
     t.boolean  "beginner_friendly"
     t.string   "aasm_state"
-    t.text     "tags",                             default: [],    array: true
+    t.text     "tags",                 default: [],    array: true
     t.string   "source_url"
-    t.boolean  "comments_locked",                  default: false
+    t.boolean  "comments_locked",      default: false
     t.string   "code_of_conduct"
     t.text     "requirements"
     t.string   "license"
@@ -176,24 +176,24 @@ ActiveRecord::Schema.define(version: 20170115230058) do
     t.integer  "user_id"
     t.boolean  "pick"
     t.integer  "rateable_id"
-    t.string   "rateable_type",  limit: 255
+    t.string   "rateable_type", limit: 255
     t.index ["rateable_id", "rateable_type"], name: "index_ratings_on_rateable_id_and_rateable_type", using: :btree
   end
 
   create_table "roles", force: :cascade do |t|
     t.integer  "team_id"
     t.integer  "user_id"
-    t.string   "name",               limit: 255
-    t.datetime "created_at",                                         null: false
-    t.datetime "updated_at",                                         null: false
-    t.text     "state",                          default: "pending", null: false
+    t.string   "name", limit: 255
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.text     "state",              default: "pending", null: false
     t.string   "confirmation_token"
   end
 
   create_table "seasons", force: :cascade do |t|
     t.date     "starts_at"
     t.date     "ends_at"
-    t.string   "name",                       limit: 255
+    t.string   "name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "applications_open_at"
@@ -204,42 +204,42 @@ ActiveRecord::Schema.define(version: 20170115230058) do
   end
 
   create_table "sources", force: :cascade do |t|
-    t.string   "url",        limit: 255
+    t.string   "url", limit: 255
     t.integer  "team_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.string   "kind",       limit: 255
-    t.string   "feed_url",   limit: 255
-    t.string   "title",      limit: 255
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string   "kind", limit: 255
+    t.string   "feed_url", limit: 255
+    t.string   "title", limit: 255
   end
 
   create_table "submissions", force: :cascade do |t|
     t.integer  "mailing_id"
-    t.string   "to",         limit: 255
+    t.string   "to", limit: 255
     t.text     "error"
     t.datetime "sent_at"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "teams", force: :cascade do |t|
-    t.string   "name",               limit: 255
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
-    t.string   "log_url",            limit: 255
+    t.string   "name", limit: 255
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.string   "log_url", limit: 255
     t.text     "description"
     t.integer  "number"
-    t.string   "kind",               limit: 255
-    t.string   "twitter_handle",     limit: 255
-    t.string   "github_handle",      limit: 255
+    t.string   "kind", limit: 255
+    t.string   "twitter_handle", limit: 255
+    t.string   "github_handle", limit: 255
     t.date     "starts_on"
     t.date     "finishes_on"
-    t.string   "post_info",          limit: 255
+    t.string   "post_info", limit: 255
     t.date     "last_checked_at"
     t.integer  "last_checked_by"
     t.integer  "season_id"
-    t.boolean  "invisible",                      default: false
-    t.integer  "applications_count",             default: 0,     null: false
+    t.boolean  "invisible",          default: false
+    t.integer  "applications_count", default: 0,     null: false
     t.string   "project_name"
     t.index ["applications_count"], name: "index_teams_on_applications_count", using: :btree
     t.index ["season_id"], name: "index_teams_on_season_id", using: :btree
@@ -247,27 +247,27 @@ ActiveRecord::Schema.define(version: 20170115230058) do
 
   create_table "users", force: :cascade do |t|
     t.integer  "github_id"
-    t.string   "github_handle",                        limit: 255
-    t.string   "name",                                 limit: 255
-    t.string   "email",                                limit: 255
-    t.string   "location",                             limit: 255
+    t.string   "github_handle", limit: 255
+    t.string   "name", limit: 255
+    t.string   "email", limit: 255
+    t.string   "location", limit: 255
     t.text     "bio"
-    t.string   "homepage",                             limit: 255
-    t.string   "avatar_url",                           limit: 255
-    t.datetime "created_at",                                                       null: false
-    t.datetime "updated_at",                                                       null: false
+    t.string   "homepage", limit: 255
+    t.string   "avatar_url", limit: 255
+    t.datetime "created_at",                                           null: false
+    t.datetime "updated_at",                                           null: false
     t.integer  "team_id"
-    t.string   "twitter_handle",                       limit: 255
-    t.string   "irc_handle",                           limit: 255
-    t.string   "tshirt_size",                          limit: 255
+    t.string   "twitter_handle", limit: 255
+    t.string   "irc_handle", limit: 255
+    t.string   "tshirt_size", limit: 255
     t.text     "postal_address"
-    t.string   "timezone",                             limit: 255
-    t.string   "interested_in",                        limit: 255, default: [],                 array: true
+    t.string   "timezone", limit: 255
+    t.string   "interested_in",  limit:255,                       default: [],                 array: true
     t.boolean  "hide_email"
-    t.boolean  "is_company",                                       default: false
-    t.string   "company_name",                         limit: 255
+    t.boolean  "is_company",                           default: false
+    t.string   "company_name", limit: 255
     t.text     "company_info"
-    t.string   "country",                              limit: 255
+    t.string   "country", limit: 255
     t.integer  "application_coding_level"
     t.text     "application_gender_identification"
     t.text     "application_minimum_money"

--- a/spec/factories/application_drafts.rb
+++ b/spec/factories/application_drafts.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
 
       association :project1, :accepted, factory: :project
       project_plan { FFaker::Lorem.paragraph }
-      heard_about_it { FFaker::Lorem.paragraph }
+      heard_about_it { [FFaker::Lorem.paragraph] }
       why_selected_project { FFaker::Lorem.paragraph }
       working_together { FFaker::Lorem.paragraph }
       misc_info { FFaker::Lorem.paragraph } # NOTE not a required field

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe ApplicationDraft do
 
       it_behaves_like 'proxies :apply validation', :project1
       it_behaves_like 'proxies :apply validation', :project_plan
-      it_behaves_like 'proxies :apply validation', :heard_about_it
       it_behaves_like 'proxies :apply validation', :working_together
       it_behaves_like 'proxies :apply validation', :why_selected_project
 


### PR DESCRIPTION
This addresses #580 by adapting the model of `application_drafts` to allow to have several `heard_about_it` options.

We've got predefined options this as outlined in the issue, categorised accordingly.

The applicant can also write down a value for `other`. Although the issue mentioned a checkbox to "activate" the "Other" field, I felt we could forgo this, as it might create an extra click in the workflow, and applications can disregard the "Other" field if they don't wish to fill it in.

This also removes the presence validation for `heard_about_it`.