### PR TITLE
Fixed export functionality

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -22,6 +22,9 @@
 @import "partials/fonts"
 @import "partials/github-ribbon"
 
+// Changes the collapse point for the top menu bar
+$grid-float-breakpoint: 990px
+
 // Third-party
 @import "bootstrap"
 @import "bootstrap/theme"

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -77,6 +77,7 @@ html, body
     margin-top: 12px
     outline: none
     text-align: center
+    border: none
     i
       position: relative
 
@@ -151,6 +152,7 @@ html, body
       background-color: transparent !important
       a
         background-color: transparent !important
+        text-shadow: none
 
     .navbar-collapse.collapsing,
     .navbar-collapse.collapse.in

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -63,6 +63,8 @@ html, body
     margin: -3px 0 0 -15px
 
   a.button-burger
+    @media screen and (min-width: $screen-md)
+      display: none
     @include icon($reorder)
     width: 35px
     height: 35px
@@ -75,8 +77,6 @@ html, body
     margin-top: 12px
     outline: none
     text-align: center
-    @media screen and (min-width: $screen-md)
-      display: none
     i
       position: relative
 
@@ -86,29 +86,41 @@ html, body
     li
       margin-bottom: 0.5rem
 
-  nav
-    @media screen and (min-width: $screen-md)
-      li
-        a
-          display: inline
-          padding: 0
-  nav.user
+  .nav
     color: $darkgray
 
-  nav.top
-    margin-bottom: 5%
-    @media screen and (min-width: $screen-md)
-      ul
-        margin-top: -55px
+  .navbar
+    border-bottom: none
+    .navbar-brand
+      padding: 0px
+
+  @media screen and (min-width: $screen-md)
+    .navbar
+      background-color: $railsred
+      .navbar-header
+        background-color: $railsred
+      .navbar-collapse
+        background-color: $railsred
+    .navbar-default
+      float: right
+      background: $railsred
+      border: none !important
+      -webkit-box-shadow: none
+      box-shadow: none
+
+    .nav.top
+      margin-top: 15px
       li
-        display: inline-block
+        a
+          padding: 4px
+          display: inline-block
         &:after
           content: ''
           width: 2rem
           font-family: FontAwesome
           font-size: 0.7rem
           color: $white
-          margin: 0 0.6rem 0 0.6rem
+          margin: 0 0.4rem 0 0rem
         &:last-child:after
           content: none
       li.announcement
@@ -123,50 +135,40 @@ html, body
           color: white
           background-color: $railsred
 
+    a
+      color: $white
+      text-decoration: none
+
+  @media screen and (max-width: $screen-md)
+    .navbar-collapse,
+    .navbar-inverse
+      background-color: transparent !important
+      background-image: none !important
+    .collapsing,
+    .collapse.in
+      border: none !important
+    li
+      background-color: transparent !important
       a
-        color: white
-        text-decoration: none
+        background-color: transparent !important
 
-    // Changes bootstraps default collapsing breakpoint
-    @media (min-width: $screen-xs) and (max-width: $screen-sm-max)
-      .navbar-collapse.collapse
-        display: none !important
-
-      .navbar-collapse.collapse.in
-        display: block !important
-
-      .navbar-nav
+    .navbar-collapse.collapsing,
+    .navbar-collapse.collapse.in
+      border: 1px solid #ccc
+      border-right-color: #999
+      border-bottom-color: #999
+      margin-top: 10px
+      background-color: none
+      .nav
+        margin-left: auto
+        max-width: 200px
+      ul
         li
-          float: none
-
-  .divider
-    @media screen and (max-width: $screen-md)
-      border: 0.1px solid $railsred
-      width: 90%
-      margin-left: 5%
-    &:after
-      content: none !important
-
-
-  #menu-navbar
-    @media screen and (max-width: $screen-md)
-      z-index: 100
+          a
+            color: $railsred
 
   .navbar-toggle
-    @media screen and (max-width: $screen-md)
-      padding: 5px 7px
-
-  .col-xs-offset-5
-    @media screen and (max-width: 750px)
-      margin-left: 46.66666667%
-    @media (min-width: $screen-sm) and (max-width: $screen-sm-max)
-      margin-left: 70.66666667%
-
-.navbar-default .navbar-nav
-  @media screen and (max-width: $screen-md)
-  li
-    a
-      color: $railsred
+    padding: 5px 0px
 
 #footer
   footer

--- a/app/exporters/teams.rb
+++ b/app/exporters/teams.rb
@@ -1,9 +1,9 @@
 module Exporters
   class Teams < Base
 
-    (2015..Date.today.year).each do |season|
-      define_method "accepted_#{season}" do
-        season = Season.find_by(name: season)
+    (2015..Date.today.year).each do |year|
+      define_method "accepted_#{year}" do
+        season = Season.find_by(name: year)
         teams = Team.accepted.where(season: season).includes(:members)
         export(teams)
       end

--- a/app/exporters/users.rb
+++ b/app/exporters/users.rb
@@ -1,9 +1,9 @@
 module Exporters
   class Users < Base
 
-    (2015..Date.today.year).each do |season|
-      define_method "students_#{season}" do
-        season = Season.find_by(name: season)
+    (2015..Date.today.year).each do |year|
+      define_method "students_#{year}" do
+        season = Season.find_by(name: year)
         export_for_season(season)
       end
     end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,44 +1,38 @@
 section#header
   header.container
-    div.row
-      div.col-xs-7
-        = link_to image_tag("logo_subnavi.png"), root_path
-      div.col-xs-5
-        div.text-right
-          a href="#" class="button-burger navbar-toggle" data-toggle="collapse" data-target="#menu"
-            = icon('reorder')
-      div.col-xs-12
-        div.col-xs-offset-5.col-xs-7.col-sm-offset-5.col-sm-4.col-md-offset-2.col-md-10.col-lrg-12#menu-navbar
-          nav class="top navbar-default" role="navigation"
-            div class="navbar-collapse collapse" id="menu"
-              ul class="nav navbar-nav navbar-right"
-                li = link_to 'Home &rarr;'.html_safe, 'http://railsgirlssummerofcode.org'
-                - if Season.projects_proposable?
-                  li class="announcement"
-                    = link_to 'Submit your Project', new_project_path
-                - if current_season.application_period?
-                  li = link_to 'Projects', projects_path
-                - if show_application_link?
-                  li = application_disambiguation_link
-                - if current_user.try :current_student?
-                  - if current_season.started?
-                    li = link_to 'Status Updates', [:students, :status_updates], class: params[:controller] == 'students/status_updates' ? 'active' : ''
-                - if current_user.try :supervisor?
-                  li = link_to 'Dashboard', supervisor_dashboard_path
-                - if current_season.started?
-                  li = link_to 'Activity',     root_path,  class: params[:controller] == 'activities' ? 'active' : ''
-                li = link_to 'Teams',        teams_path, class: params[:controller] == 'teams' ? 'active' : ''
-                li = link_to 'Community', users_path, class: params[:controller] == 'users' ? 'active' : ''
-                - if current_season.started?
-                  li = link_to 'Conferences',  conferences_path,  class: params[:controller] == 'conferences' ? 'active' : ''
-                /- if signed_in? && current_user.roles.includes?('reviewer')  # TODO bring this into a reviewer dashboard
-                /  li = link_to 'Applications', applications_path
-                li class="divider"
-                - if signed_in?
-                  li = "#{link_to 'Profile', current_user}".html_safe
-                  - if current_user != true_user
-                    li.announcement = link_to icon('eye-close', 'Stop'), stop_impersonating_users_path, method: :post, title: 'Stop Impersonation'
-                  - else
-                    li = link_to "Sign out", sign_out_path, method: :delete
-                - else
-                  li = link_to icon('github', 'Sign in'), user_github_omniauth_authorize_path
+    div.navbar.navbar-inverse.navbar-static-top role="navigation"
+      div.navbar-header
+        = link_to image_tag("logo_subnavi.png"), root_path, class: "navbar-brand"
+        a href="#" class="button-burger navbar-toggle collapsed" data-toggle="collapse" data-target="#menu"
+          = icon('reorder')
+      div.collapse.navbar-collapse#menu
+        ul class="nav navbar-nav top navbar-rightn navbar-default"
+          li = link_to 'Home &rarr;'.html_safe, 'http://railsgirlssummerofcode.org'
+          - if Season.projects_proposable?
+            li class="announcement"
+              = link_to 'Submit your Project', new_project_path
+          - if current_season.application_period?
+            li = link_to 'Projects', projects_path
+          - if show_application_link?
+            li = application_disambiguation_link
+          - if current_user.try :current_student?
+            - if current_season.started?
+              li = link_to 'Status Updates', [:students, :status_updates], class: params[:controller] == 'students/status_updates' ? 'active' : ''
+          - if current_user.try :supervisor?
+            li = link_to 'Dashboard', supervisor_dashboard_path
+          - if current_season.started?
+            li = link_to 'Activity',     root_path,  class: params[:controller] == 'activities' ? 'active' : ''
+          li = link_to 'Teams',        teams_path, class: params[:controller] == 'teams' ? 'active' : ''
+          li = link_to 'Community', users_path, class: params[:controller] == 'users' ? 'active' : ''
+          - if current_season.started?
+            li = link_to 'Conferences',  conferences_path,  class: params[:controller] == 'conferences' ? 'active' : ''
+          /- if signed_in? && current_user.roles.includes?('reviewer')  # TODO bring this into a reviewer dashboard
+          /  li = link_to 'Applications', applications_path
+          - if signed_in?
+            li = "#{link_to 'Profile', current_user}".html_safe
+            - if current_user != true_user
+              li.announcement = link_to icon('eye-close', 'Stop'), stop_impersonating_users_path, method: :post, title: 'Stop Impersonation'
+            - else
+              li = link_to "Sign out", sign_out_path, method: :delete
+          - else
+            li = link_to icon('github', 'Sign in'), user_github_omniauth_authorize_path

--- a/spec/exporters/teams_spec.rb
+++ b/spec/exporters/teams_spec.rb
@@ -21,13 +21,21 @@ RSpec.describe Exporters::Teams do
 
     let!(:old_team) { create :team, season: old_season, name: "OLDTEAM" }
     let!(:new_team) { create :team, :in_current_season, name: "NEWTEAM" }
-    let!(:app_team) { create :team, :applying_team, season: old_season, name: "APPLYINGTEAM" }
+    let!(:app_team) { create :team, :applying_team, name: "APPLYINGTEAM" }
 
     it 'exports all accepted teams of the given season' do
       export_method = "accepted_#{old_season.year}"
       expect(described_class.send export_method).to match 'OLDTEAM'
       expect(described_class.send export_method).not_to match 'NEWSTUDENT'
       expect(described_class.send export_method).not_to match 'APPLYINGTEAM'
+    end
+
+    # This was a bug and checks that this will not
+    # occur again :)
+    it 'should still work when called twice' do
+      export_method = "accepted_#{old_season.year}"
+      expect(described_class.send export_method).to match 'OLDTEAM'
+      expect(described_class.send export_method).to match 'OLDTEAM'
     end
 
     it 'will raise an exception when trying to export a nonexistent season' do

--- a/spec/exporters/users_spec.rb
+++ b/spec/exporters/users_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Exporters::Users do
       expect(described_class.send export_method).not_to match 'NEWSTUDENT'
     end
 
+    # This was a bug and checks that this will not
+    # occur again :)
+    it 'should still work when called twice' do
+      export_method = "students_#{old_season.year}"
+      expect(described_class.send export_method).to match 'OLDSTUDENT'
+      expect(described_class.send export_method).to match 'OLDSTUDENT'
+    end
+
     it 'will raise an exception when trying to export a nonexistent season' do
       export_method = "students_1970"
       expect { described_class.send export_method }.to raise_error NoMethodError


### PR DESCRIPTION
The dynamically created methods overwrote the param injected
into the method. This lead to the problem that the instance
could only export one thing. Every export after it was damaged
because of a wrong value in the season variable.

The navigation was kinda broken on all browsers because of
a wrong nesting of rows and widths of columns inside of the
row. For example in Safari you could not click on anything that
was close to the top navigation because of an div overlap.

I replaced it completely with a new, cleaned up navigation and
made it look like the old one.

<img width="1022" alt="bildschirmfoto 2017-01-20 um 23 08 58" src="https://cloud.githubusercontent.com/assets/56195/22167281/aa40218a-df65-11e6-98fc-4020981514c7.png">

<img width="763" alt="bildschirmfoto 2017-01-20 um 23 08 52" src="https://cloud.githubusercontent.com/assets/56195/22167282/ad7600cc-df65-11e6-9702-92325ed5f9f5.png">


