### PR TITLE
Fix behavior of default avatar in navbar

### DIFF
--- a/app/assets/stylesheets/partials/_navbar.sass
+++ b/app/assets/stylesheets/partials/_navbar.sass
@@ -9,6 +9,7 @@ nav#navigation
     img
       @extend .img-rounded, .hidden-xs
       padding: 2px
+      max-width: 50px
 
   li.divider + li.divider
     display: none


### PR DESCRIPTION
As I briefly noted in https://github.com/rails-girls-summer-of-code/rgsoc-teams/issues/644#issuecomment-277783073, the "default" avatar image returned if there is no Github-provided avatar for a user kinda bloats the navigation bar.

This PR aligns the behavior of both types of images, default and "normal" avatar to just work fine with the navigation layout.