### PR TITLE
Show mentor dashboard for project submitters

### DIFF
--- a/app/controllers/mentor/applications_controller.rb
+++ b/app/controllers/mentor/applications_controller.rb
@@ -11,7 +11,10 @@ class Mentor::ApplicationsController < Mentor::BaseController
   private
 
   def projects
-    Project.where(submitter: current_user)
+    Project.
+      in_current_season.
+      accepted.
+      where(submitter: current_user)
   end
 
   def application

--- a/app/controllers/mentor/base_controller.rb
+++ b/app/controllers/mentor/base_controller.rb
@@ -1,4 +1,10 @@
 class Mentor::BaseController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { require_role 'mentor' }
+  before_action -> { require_project_maintainer }
+
+  private
+
+  def require_project_maintainer
+    redirect_to '/', alert: "Project maintainer required" unless current_user.project_maintainer?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -176,6 +176,10 @@ class User < ActiveRecord::Base
     roles.mentor.any?
   end
 
+  def project_maintainer?
+    Project.accepted.where(submitter: self).any?
+  end
+
   def supervisor?
     roles.supervisor.any?
   end

--- a/app/views/application/_nav_signed_in.html.slim
+++ b/app/views/application/_nav_signed_in.html.slim
@@ -14,7 +14,7 @@ li.dropdown
       li = link_to 'Status Updates', [:students, :status_updates]
     - if current_user.supervisor? && current_season.started?
       li = link_to 'Supervisor Dashboard', supervisor_dashboard_path
-    - if current_user.mentor?
+    - if current_user.project_maintainer?
       li = link_to 'Mentor Dashboard', mentor_applications_path
     li.divider.hidden-xs
     - if current_user != true_user

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -236,6 +236,30 @@ describe User do
     end
   end
 
+  describe '#project_maintainer?' do
+    let!(:maintainer) { create(:user) }
+
+    it 'returns false for users who did not submit a project' do
+      student = FactoryGirl.create(:student)
+      expect(student).not_to be_project_maintainer
+    end
+
+    it 'returns true if user has submitted an accepted project' do
+      create(:project, :accepted, submitter: maintainer)
+      expect(maintainer).to be_project_maintainer
+    end
+
+    it 'returns false if user has submitted a rejected project' do
+      create(:project, :rejected, submitter: maintainer)
+      expect(maintainer).not_to be_project_maintainer
+    end
+
+    it 'returns false if user has just proposed a project' do
+      create(:project, submitter: maintainer)
+      expect(maintainer).not_to be_project_maintainer
+    end
+  end
+
   describe '#student?' do
     it 'returns false for users w/o a role' do
       expect(subject).not_to be_student

--- a/spec/requests/navigation_spec.rb
+++ b/spec/requests/navigation_spec.rb
@@ -110,10 +110,11 @@ RSpec.describe 'Navigation', type: :request do
       end
     end
 
-    context 'for mentors' do
-      let(:user) { create(:mentor) }
+    context 'for project_maintainers' do
+      let(:user) { create(:user) }
 
       before do
+        create(:project, :accepted, submitter: user)
         sign_in user
         get '/'
       end
@@ -218,10 +219,11 @@ RSpec.describe 'Navigation', type: :request do
       end
     end
 
-    context 'for mentors' do
-      let(:user) { create(:mentor) }
+    context 'for project_maintainers' do
+      let(:user) { create(:user) }
 
       before do
+        create(:project, :accepted, submitter: user)
         sign_in user
         get '/'
       end


### PR DESCRIPTION
Hey @alicetragedy, this adds the changes specified in #648: submitters of accepted projects for the current season have access to the mentor dashboard during application phase.

The applications they see are of course also from the current season.