### PR TITLE
extend the period of unconfirmed access to the teams app

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -103,7 +103,7 @@ Devise.setup do |config|
   # able to access the website for two days without confirming his account,
   # access will be blocked just in the third day. Default is 0.days, meaning
   # the user cannot access the website without confirming his account.
-  config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 30.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm


### PR DESCRIPTION
We're getting lots of support tickets from people who didn't manage to confirm their accounts within 2 days after the confirmation email has been sent. Partially it happened because they didn't receive those emails.

Anyway, in order to stop this flow of support requests, I'm extending the period of unconfirmed access to the Teams app – till the moment when we decide how to handle unconfirmed users better.