### PR TITLE
Fix the Team link in the email to a user added to a team

### DIFF
--- a/app/views/role_mailer/user_added_to_team.html.slim
+++ b/app/views/role_mailer/user_added_to_team.html.slim
@@ -9,9 +9,9 @@ html
       | }
   body
     p
-      ' You have been added to Team
-      a>[href=team_url(@role.team)]= @role.team.name
-      | as a #{@role.name}.
+      ' You have been added to
+      a href=team_url(@role.team) Team #{@role.team.name}
+      |  as a #{@role.name}.
 
       - if @role.name == 'coach'
         p


### PR DESCRIPTION
This PR fixed the issue submitted by one of our coaches: 

![0b020062-f9db-11e6-8fc4-70119f990c25](https://cloud.githubusercontent.com/assets/164400/23263029/2deca1fc-f9dd-11e6-807e-53f6442c5cf1.png)


It happens when a team doesn't have a name. 

**Before changes:**

![joxi_screenshot_1487859415557](https://cloud.githubusercontent.com/assets/1745735/23262507/45952d62-f9db-11e6-95e9-c9a30e6ebba4.png)
![joxi_screenshot_1487859451698](https://cloud.githubusercontent.com/assets/1745735/23262510/45c630ec-f9db-11e6-83b9-7daf7194fee2.png)

**After changes:**

![joxi_screenshot_1487859432134](https://cloud.githubusercontent.com/assets/1745735/23262508/45b0768a-f9db-11e6-9eb5-8995de4665ea.png)
![joxi_screenshot_1487859468480](https://cloud.githubusercontent.com/assets/1745735/23262509/45c5b914-f9db-11e6-9394-aec4b9582e00.png)
