### PR TITLE
Fix field-descriptions in mentor dashboard

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
         student1_application_giving_back: What do you think you could give back to the community? (2nd student)
         student0_application_language_learning_period: For how many months have you been learning the language of your primary project? (1st student)
         student1_application_language_learning_period: For how many months have you been learning the language of your primary project? (2nd student)
+        student_application_language_learning_period: For how many months have you been learning the language of your primary project?
         student_application_learning_history: What you have been doing to learn programming
         student0_application_learning_history: What you have been doing to learn programming (1st student)
         student1_application_learning_history: What you have been doing to learn programming (2nd student)


### PR DESCRIPTION
Hey @mkalininait,

this fixes the problem described in #649. It's basically just duplicating an existing translation and skipping the *"(student<nr>)"* part to make it fit the presentation form of the mentor dashboard.

<img width="751" alt="screen shot 2017-02-25 at 12 42 25" src="https://cloud.githubusercontent.com/assets/3491815/23330823/96e27200-fb58-11e6-80b5-900233cf89e3.png">
