### PR TITLE
[678] Require team to have a name

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,7 +5,7 @@ class Team < ActiveRecord::Base
 
   KINDS = %w(sponsored voluntary)
 
-  validates :name, uniqueness: true, allow_blank: true
+  validates :name, presence: true, uniqueness: true
   # validate :must_have_members
   validate :disallow_multiple_student_roles
   validate :disallow_duplicate_members

--- a/db/migrate/20170228220934_add_names_to_existing_teams.rb
+++ b/db/migrate/20170228220934_add_names_to_existing_teams.rb
@@ -1,0 +1,14 @@
+class AddNamesToExistingTeams < ActiveRecord::Migration[5.0]
+  class Team < ActiveRecord::Base
+    self.table_name = 'teams'
+  end
+
+  def up
+    Team.where("name IS NULL OR name = ''").each do |team|
+      team.update_attribute :name, "<unnamed #{team.number}>"
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170123173604) do
+ActiveRecord::Schema.define(version: 20170228220934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -15,6 +15,7 @@ describe Team do
   it { is_expected.to have_many(:status_updates) }
   it { is_expected.to have_many(:roles).inverse_of(:team) }
 
+  it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
 
   context 'multiple team memberships' do
@@ -256,8 +257,9 @@ describe Team do
   describe 'creating a new team' do
     before do
       Team.destroy_all
-      subject.save!
     end
+
+    subject { create :team }
 
     it 'sets the team number' do
       expect(subject.reload.number).to eql 1

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -339,17 +339,13 @@ describe Team do
   describe 'checking' do
     let(:user) { FactoryGirl.create(:user) }
 
-    it 'calls set_last_checked' do
-      expect(subject).to receive(:set_last_checked)
-      subject.checked = user
-      subject.save!
-    end
+    subject { create :team }
 
     it 'changes last_checked_*' do
-      expect do
+      expect {
         subject.checked = user
         subject.save!
-      end.to change(subject, :last_checked_by) && change(subject, :last_checked_at)
+      }.to change(subject, :last_checked_by) && change(subject, :last_checked_at)
     end
   end
 


### PR DESCRIPTION
Closes #678

* `Team#name` was explicitely allowed to be blank before; I don't know and I can't see why.
* Makes `:name` a required attribute
* Adds a bogus name to all existing teams w/o a proper team name