### PR TITLE
[364] Add mentor sign-off and fav

### DIFF
--- a/app/controllers/mentor/applications_controller.rb
+++ b/app/controllers/mentor/applications_controller.rb
@@ -15,6 +15,13 @@ class Mentor::ApplicationsController < Mentor::BaseController
     redirect_to action: :index
   end
 
+  def fav
+    @application = Application.find(application.id)
+    @application.update_attribute(:mentor_fav, true)
+    flash[:notice] = "Successfully fav'ed #{@application.team.name}'s application."
+    redirect_to action: :index
+  end
+
   private
 
   def projects

--- a/app/controllers/mentor/applications_controller.rb
+++ b/app/controllers/mentor/applications_controller.rb
@@ -8,6 +8,11 @@ class Mentor::ApplicationsController < Mentor::BaseController
     @comment     = application.find_or_initialize_comment_by(current_user)
   end
 
+  def signoff
+    Application.find(application.id).sign_off! as: current_user
+    redirect_to action: :index
+  end
+
   private
 
   def projects

--- a/app/controllers/mentor/applications_controller.rb
+++ b/app/controllers/mentor/applications_controller.rb
@@ -1,22 +1,21 @@
 class Mentor::ApplicationsController < Mentor::BaseController
+  before_action :application, only: [:show, :signoff, :fav]
+
   def index
     @applications = applications
   end
 
   def show
-    @application = application
-    @comment     = application.find_or_initialize_comment_by(current_user)
+    @comment = application.find_or_initialize_comment_by(current_user)
   end
 
   def signoff
-    @application = application
     Application.find(@application.id).sign_off! as: current_user
     flash[:notice] = "Successfully signed-off #{@application.team_name}'s application."
     redirect_to action: :index
   end
 
   def fav
-    @application = application
     Application.find(@application.id).update_attribute(:mentor_fav, true)
     flash[:notice] = "Successfully fav'ed #{@application.team_name}'s application."
     redirect_to action: :index
@@ -32,7 +31,7 @@ class Mentor::ApplicationsController < Mentor::BaseController
   end
 
   def application
-    Mentor::Application.find(id: params[:id], projects: projects)
+    @application ||= Mentor::Application.find(id: params[:id], projects: projects)
   end
 
   def applications

--- a/app/controllers/mentor/applications_controller.rb
+++ b/app/controllers/mentor/applications_controller.rb
@@ -9,16 +9,16 @@ class Mentor::ApplicationsController < Mentor::BaseController
   end
 
   def signoff
-    @application = Application.find(application.id)
-    @application.sign_off! as: current_user
-    flash[:notice] = "Successfully signed-off #{@application.team.name}'s application."
+    @application = application
+    Application.find(@application.id).sign_off! as: current_user
+    flash[:notice] = "Successfully signed-off #{@application.team_name}'s application."
     redirect_to action: :index
   end
 
   def fav
-    @application = Application.find(application.id)
-    @application.update_attribute(:mentor_fav, true)
-    flash[:notice] = "Successfully fav'ed #{@application.team.name}'s application."
+    @application = application
+    Application.find(@application.id).update_attribute(:mentor_fav, true)
+    flash[:notice] = "Successfully fav'ed #{@application.team_name}'s application."
     redirect_to action: :index
   end
 

--- a/app/controllers/mentor/applications_controller.rb
+++ b/app/controllers/mentor/applications_controller.rb
@@ -9,7 +9,9 @@ class Mentor::ApplicationsController < Mentor::BaseController
   end
 
   def signoff
-    Application.find(application.id).sign_off! as: current_user
+    @application = Application.find(application.id)
+    @application.sign_off! as: current_user
+    flash[:notice] = "Successfully signed-off #{@application.team.name}'s application."
     redirect_to action: :index
   end
 

--- a/app/models/mentor/application.rb
+++ b/app/models/mentor/application.rb
@@ -8,7 +8,7 @@ module Mentor
     attr_accessor :student0, :student1
     attr_accessor :first_choice
 
-    delegate :signed_off?, to: :persisted_application
+    delegate :signed_off?, :signed_off_at, to: :persisted_application
 
     def choice
       first_choice ? 1 : 2

--- a/app/models/mentor/application.rb
+++ b/app/models/mentor/application.rb
@@ -33,6 +33,10 @@ module Mentor
       true
     end
 
+    def signed_off?
+      persisted_application.signed_off?
+    end
+
     private
 
     # Converts arguments to a format suitable for initializing a Mentor::Student object.
@@ -41,6 +45,10 @@ module Mentor
     # @return [Hash] arguments in correct format
     def studentize(attrs)
       attrs.tap { |a| a.keys.each{ |k| a[k.gsub(/student(0|1)_application_/, '')] = a.delete(k) } }
+    end
+
+    def persisted_application
+      @persisted_application ||= ::Application.find id
     end
 
     class << self

--- a/app/models/mentor/application.rb
+++ b/app/models/mentor/application.rb
@@ -8,7 +8,7 @@ module Mentor
     attr_accessor :student0, :student1
     attr_accessor :first_choice
 
-    delegate :signed_off?, :signed_off_at, to: :persisted_application
+    delegate :mentor_fav?, :signed_off?, :signed_off_at, to: :persisted_application
 
     def choice
       first_choice ? 1 : 2

--- a/app/models/mentor/application.rb
+++ b/app/models/mentor/application.rb
@@ -8,6 +8,8 @@ module Mentor
     attr_accessor :student0, :student1
     attr_accessor :first_choice
 
+    delegate :signed_off?, to: :persisted_application
+
     def choice
       first_choice ? 1 : 2
     end
@@ -31,10 +33,6 @@ module Mentor
 
     def persisted?
       true
-    end
-
-    def signed_off?
-      persisted_application.signed_off?
     end
 
     private

--- a/app/models/mentor/application.rb
+++ b/app/models/mentor/application.rb
@@ -29,6 +29,10 @@ module Mentor
         user:             mentor)
     end
 
+    def persisted?
+      true
+    end
+
     private
 
     # Converts arguments to a format suitable for initializing a Mentor::Student object.

--- a/app/views/mentor/applications/index.html.slim
+++ b/app/views/mentor/applications/index.html.slim
@@ -19,8 +19,8 @@ table.applications.table.table-striped.table-bordered.table-condensed.table-hove
           = link_to application.project_name, project_path(application.project_id)
           - if application.first_choice
             |&nbsp;#{icon('star')}
-        td = link_to icon('ok') + " Sign-off", '#', class: 'btn btn-primary'
-        td = link_to icon('heart') + " Favorite", '#', class: 'btn btn-success'
+        td = link_to icon('ok'), '#', class: 'btn btn-primary', data: { confirm: 'By signing-off this application, you deem this team fit to work on your project and that they meet the requirements. Proceed?' }
+        td = link_to icon('heart'), '#', class: 'btn btn-success', data: { confirm: 'By fav\'ing this application, you declare that this would be one of your preferred teams. You can fav more than one application. Proceed?' }
 p
   i Teams may apply for two projects. Their second choice serves as a fallback if they do not get accepted for the first one
   br

--- a/app/views/mentor/applications/index.html.slim
+++ b/app/views/mentor/applications/index.html.slim
@@ -19,7 +19,11 @@ table.applications.table.table-striped.table-bordered.table-condensed.table-hove
           = link_to application.project_name, project_path(application.project_id)
           - if application.first_choice
             |&nbsp;#{icon('star')}
-        td = link_to icon('ok'), '#', class: 'btn btn-primary', data: { confirm: 'By signing-off this application, you deem this team fit to work on your project and that they meet the requirements. Proceed?' }
+        td
+          - if application.signed_off?
+            = content_tag :em, icon('ok'), class: 'btn btn-disabled', disabled: true, title: "Signed-off at #{l application.signed_off_at}"
+          - else
+            = link_to icon('ok'), signoff_mentor_application_path(application), method: :put, class: 'btn btn-primary', data: { confirm: 'By signing-off this application, you deem this team fit to work on your project and that they meet the requirements. Proceed?' }
         td = link_to icon('heart'), '#', class: 'btn btn-success', data: { confirm: 'By fav\'ing this application, you declare that this would be one of your preferred teams. You can fav more than one application. Proceed?' }
 p
   i Teams may apply for two projects. Their second choice serves as a fallback if they do not get accepted for the first one

--- a/app/views/mentor/applications/index.html.slim
+++ b/app/views/mentor/applications/index.html.slim
@@ -23,12 +23,12 @@ table.applications.table.table-striped.table-bordered.table-condensed.table-hove
           - if application.signed_off?
             = content_tag :em, icon('ok'), class: 'btn btn-disabled', disabled: true, title: "Signed-off at #{l application.signed_off_at}"
           - else
-            = link_to icon('ok'), signoff_mentor_application_path(application), method: :put, class: 'btn btn-primary', data: { confirm: 'By signing-off this application, you deem this team fit to work on your project and that they meet the requirements. Proceed?' }
+            = link_to icon('ok'), signoff_mentor_application_path(application), method: :put, class: 'btn btn-primary', data: { confirm: 'By signing-off this application, you deem this team fit to work on your project and that they meet the requirements. This cannot be undone. Proceed?' }
         td
           - if application.mentor_fav?
             = content_tag :em, icon('heart'), class: 'btn btn-disabled', disabled: true, title: "Marked as one of your favorites"
           - else
-            = link_to icon('heart'), fav_mentor_application_path(application), method: :put, class: 'btn btn-success', data: { confirm: 'By fav\'ing this application, you declare that this would be one of your preferred teams. You can fav more than one application. Proceed?' }
+            = link_to icon('heart'), fav_mentor_application_path(application), method: :put, class: 'btn btn-success', data: { confirm: 'By fav\'ing this application, you declare that this would be one of your preferred teams. You can fav more than one application. This cannot be undone. Proceed?' }
 p
   i Teams may apply for two projects. Their second choice serves as a fallback if they do not get accepted for the first one
   br

--- a/app/views/mentor/applications/index.html.slim
+++ b/app/views/mentor/applications/index.html.slim
@@ -24,7 +24,11 @@ table.applications.table.table-striped.table-bordered.table-condensed.table-hove
             = content_tag :em, icon('ok'), class: 'btn btn-disabled', disabled: true, title: "Signed-off at #{l application.signed_off_at}"
           - else
             = link_to icon('ok'), signoff_mentor_application_path(application), method: :put, class: 'btn btn-primary', data: { confirm: 'By signing-off this application, you deem this team fit to work on your project and that they meet the requirements. Proceed?' }
-        td = link_to icon('heart'), fav_mentor_application_path(application), method: :put, class: 'btn btn-success', data: { confirm: 'By fav\'ing this application, you declare that this would be one of your preferred teams. You can fav more than one application. Proceed?' }
+        td
+          - if application.mentor_fav?
+            = content_tag :em, icon('heart'), class: 'btn btn-disabled', disabled: true, title: "Marked as one of your favorites"
+          - else
+            = link_to icon('heart'), fav_mentor_application_path(application), method: :put, class: 'btn btn-success', data: { confirm: 'By fav\'ing this application, you declare that this would be one of your preferred teams. You can fav more than one application. Proceed?' }
 p
   i Teams may apply for two projects. Their second choice serves as a fallback if they do not get accepted for the first one
   br

--- a/app/views/mentor/applications/index.html.slim
+++ b/app/views/mentor/applications/index.html.slim
@@ -9,15 +9,16 @@ table.applications.table.table-striped.table-bordered.table-condensed.table-hove
     tr
       th Application (Team)
       th Project
-      th Choice
       th Sign-off
       th Fav
   tbody
     - @applications.each do |application|
       tr
         td = link_to application.team_name, mentor_application_path(id: application.id)
-        td = link_to application.project_name, project_path(application.project_id)
-        td = icon('star') if application.first_choice
+        td
+          = link_to application.project_name, project_path(application.project_id)
+          - if application.first_choice
+            |&nbsp;#{icon('star')}
         td = link_to icon('ok') + " Sign-off", '#', class: 'btn btn-primary'
         td = link_to icon('heart') + " Favorite", '#', class: 'btn btn-success'
 p

--- a/app/views/mentor/applications/index.html.slim
+++ b/app/views/mentor/applications/index.html.slim
@@ -24,7 +24,7 @@ table.applications.table.table-striped.table-bordered.table-condensed.table-hove
             = content_tag :em, icon('ok'), class: 'btn btn-disabled', disabled: true, title: "Signed-off at #{l application.signed_off_at}"
           - else
             = link_to icon('ok'), signoff_mentor_application_path(application), method: :put, class: 'btn btn-primary', data: { confirm: 'By signing-off this application, you deem this team fit to work on your project and that they meet the requirements. Proceed?' }
-        td = link_to icon('heart'), '#', class: 'btn btn-success', data: { confirm: 'By fav\'ing this application, you declare that this would be one of your preferred teams. You can fav more than one application. Proceed?' }
+        td = link_to icon('heart'), fav_mentor_application_path(application), method: :put, class: 'btn btn-success', data: { confirm: 'By fav\'ing this application, you declare that this would be one of your preferred teams. You can fav more than one application. Proceed?' }
 p
   i Teams may apply for two projects. Their second choice serves as a fallback if they do not get accepted for the first one
   br

--- a/app/views/mentor/applications/index.html.slim
+++ b/app/views/mentor/applications/index.html.slim
@@ -10,6 +10,7 @@ table.applications.table.table-striped.table-bordered.table-condensed.table-hove
       th Application (Team)
       th Project
       th Choice
+      th Sign-off
       th Fav
   tbody
     - @applications.each do |application|
@@ -17,7 +18,8 @@ table.applications.table.table-striped.table-bordered.table-condensed.table-hove
         td = link_to application.team_name, mentor_application_path(id: application.id)
         td = link_to application.project_name, project_path(application.project_id)
         td = icon('star') if application.first_choice
-        td = application.project_plan
+        td = link_to icon('ok') + " Sign-off", '#', class: 'btn btn-primary'
+        td = link_to icon('heart') + " Favorite", '#', class: 'btn btn-success'
 p
   i Teams may apply for two projects. Their second choice serves as a fallback if they do not get accepted for the first one
   br

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,7 +111,9 @@ RgsocTeams::Application.routes.draw do
   end
 
   namespace :mentor do
-    resources :applications, only: [:index, :show]
+    resources :applications, only: [:index, :show] do
+      put :signoff, on: :member
+    end
     resources :comments, only: [:create, :update]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,7 +112,10 @@ RgsocTeams::Application.routes.draw do
 
   namespace :mentor do
     resources :applications, only: [:index, :show] do
-      put :signoff, on: :member
+      member do
+        put :fav
+        put :signoff
+      end
     end
     resources :comments, only: [:create, :update]
   end

--- a/db/migrate/20170308224946_add_mentor_fav_to_applications.rb
+++ b/db/migrate/20170308224946_add_mentor_fav_to_applications.rb
@@ -1,0 +1,5 @@
+class AddMentorFavToApplications < ActiveRecord::Migration[5.0]
+  def change
+    add_column :applications, :mentor_fav, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170228220934) do
+ActiveRecord::Schema.define(version: 20170308224946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 20170228220934) do
     t.integer  "signed_off_by"
     t.datetime "signed_off_at"
     t.integer  "project_id"
+    t.boolean  "mentor_fav"
     t.index "((application_data -> 'project1_id'::text))", name: "application_data_project1_id", using: :btree
     t.index "((application_data -> 'project2_id'::text))", name: "application_data_project2_id", using: :btree
     t.index ["application_draft_id"], name: "index_applications_on_application_draft_id", using: :btree

--- a/spec/controllers/mentor/applications_controller_spec.rb
+++ b/spec/controllers/mentor/applications_controller_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe Mentor::ApplicationsController do
         it 'redirects back to index' do
           put :signoff, params: { id: application.id }
           expect(response).to redirect_to mentor_applications_path
+          expect(flash[:notice]).to be_present
         end
       end
 

--- a/spec/controllers/mentor/applications_controller_spec.rb
+++ b/spec/controllers/mentor/applications_controller_spec.rb
@@ -154,4 +154,38 @@ RSpec.describe Mentor::ApplicationsController do
       end
     end
   end
+
+  describe 'PUT fav' do
+    context 'as a project_maintainer of this season' do
+      let!(:project) { create(:project, :in_current_season, :accepted, submitter: user) }
+
+      before { sign_in user }
+
+      context 'for an application that they are a mentor of' do
+        let(:application) { create(:application, :in_current_season, :for_project, project1: project) }
+
+        it 'sets the mentor_fav flag' do
+          expect { put :fav, params: { id: application.id } }
+            .to change { application.reload.mentor_fav }.to true
+        end
+
+        it 'redirects back to index' do
+          put :fav, params: { id: application.id }
+          expect(response).to redirect_to mentor_applications_path
+          expect(flash[:notice]).to be_present
+        end
+      end
+
+      context 'when not maintaining the project' do
+        it 'returns a 404' do
+          other_project = create(:project, :in_current_season, :accepted)
+          application   = create(:application, :in_current_season, :for_project, project1: other_project)
+
+          expect { put :fav, params: { id: application.id } }
+            .to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+
+  end
 end

--- a/spec/models/mentor/application_spec.rb
+++ b/spec/models/mentor/application_spec.rb
@@ -206,4 +206,11 @@ describe Mentor::Application do
       expect(subject).to be_a_new(Mentor::Comment)
     end
   end
+
+  describe '#to_param' do
+    it 'returns the underlying active record id' do
+      subject.id = 4711
+      expect(subject.to_param).to eql '4711'
+    end
+  end
 end

--- a/spec/models/mentor/application_spec.rb
+++ b/spec/models/mentor/application_spec.rb
@@ -213,4 +213,20 @@ describe Mentor::Application do
       expect(subject.to_param).to eql '4711'
     end
   end
+
+  describe '#signed_off?' do
+    let!(:application) { create(:application, :in_current_season, :for_project, project1: project1) }
+    let!(:project1)    { create(:project, :in_current_season) }
+
+    subject { described_class.new id: application.id }
+
+    context 'with a signed-off application database record' do
+      before { application.sign_off! }
+      it { is_expected.to be_signed_off }
+    end
+
+    context 'when the underlying application database record is not yet sign-off' do
+      it { is_expected.not_to be_signed_off }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #364 – see below for screenies.

Feedback about the confirmation dialogues' text blurb most welcome.

Right now the sign-off and the fav is a one-way ticket. One cannot undo this. If an undo-function is desired, I suggest we still merge this first so that mentors can do their thing already.

The feature is currently deployed on staging.

**General overview**
![1](https://cloud.githubusercontent.com/assets/164400/23728208/f73aabe8-045b-11e7-8f29-42dbf5e94c5c.png)
----

**Confirm blurb sign-off**
![confirm_signoff](https://cloud.githubusercontent.com/assets/164400/23728227/0e7079fa-045c-11e7-908e-605398b3c35a.png)
----

**Confirm blurb fav**
![confirm_fav](https://cloud.githubusercontent.com/assets/164400/23728245/1995ec48-045c-11e7-884c-9d3fb4b954fe.png)
----