### PR TITLE
additional info form changes

### DIFF
--- a/app/controllers/orga/applications_controller.rb
+++ b/app/controllers/orga/applications_controller.rb
@@ -71,7 +71,7 @@ class Orga::ApplicationsController < ApplicationController
 
   def application_params
     if params[:action] == 'update'
-      params.require(:application).permit(:misc_info, :project_visibility,
+      params.require(:application).permit(:misc_info,
                                           :project_name, :city, :country, :coaching_company, Application::FLAGS)
     else
       {

--- a/app/controllers/rating/applications_controller.rb
+++ b/app/controllers/rating/applications_controller.rb
@@ -48,7 +48,6 @@ class Rating::ApplicationsController < Rating::BaseController
   def application_params
     params.require(:application).
       permit(:misc_info,
-            :project_visibility,
             :project_id,
             :city,
             :country,

--- a/app/exporters/applications.rb
+++ b/app/exporters/applications.rb
@@ -12,7 +12,7 @@ module Exporters
       def headers
         @headers ||= ["Team ID"] +
           keys.map { |key| Application.data_label key } +
-          ["Coaching Company", "Misc. Info", "City", "Country", "Project Visibility"] +
+          ["Coaching Company", "Misc. Info", "City", "Country"] +
           Application::FLAGS.map(&:to_s).map(&:titleize)
       end
 
@@ -57,7 +57,7 @@ module Exporters
         application_data_values = application_keys.map{ |k| app.application_data[k] }
         [app.team_id] +
           application_data_values +
-          [:coaching_company, :misc_info, :city, :country, :project_visibility].map { |attribute| app.send attribute } +
+          [:coaching_company, :misc_info, :city, :country].map { |attribute| app.send attribute } +
           Application::FLAGS.map { |flag| app.send flag }
       end
     end

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -62,7 +62,6 @@ module ApplicationsHelper
   def link_to_application_project(application)
     if project = application.project
       link_txt = project.name
-      link_txt += " (#{application.project_visibility})" if application.project_visibility
       link_to link_txt, project
     end
   end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -79,7 +79,8 @@ class Application < ActiveRecord::Base
           :male_gender,
           :zero_community,
           :age_below_18,
-          :less_than_two_coaches]
+          :less_than_two_coaches,
+          :less_than_40_hours_a_week]
 
   FIELDS_REMOVED_IN_BLIND = [:student0_name,
                              :student1_name,

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -74,7 +74,6 @@ class Application < ActiveRecord::Base
   COACHING_COMPANY_WEIGHT = ENV['COACHING_COMPANY_WEIGHT'] || 2
   MENTOR_PICK_WEIGHT = ENV['MENTOR_PICK_WEIGHT'] || 2
   FLAGS = [:remote_team,
-          :mentor_pick,
           :volunteering_team,
           :selected,
           :male_gender,

--- a/app/views/rating/applications/edit.html.slim
+++ b/app/views/rating/applications/edit.html.slim
@@ -5,10 +5,7 @@ h1 = "Application: #{@application.name}"
 = simple_form_for @form_path do |a|
   = a.input :misc_info
   = a.association :project, collection: Project.in_current_season.order(:name), include_blank: '- none -'
-  = a.input :project_visibility
   = a.input :coaching_company
-  = a.input :city
-  = a.input :country, as: :country, label: "Country", prompt: ""
   - Application::FLAGS.each do |key|
     = a.input key, as: :boolean
   = a.submit 'Save'

--- a/app/views/rating/applications/show.html.slim
+++ b/app/views/rating/applications/show.html.slim
@@ -33,9 +33,6 @@
         td Project
         td = link_to_application_project @application
       tr
-        td Project visibility
-        td = @application.project_visibility
-      tr
         td Coaching Company
         td = @application.coaching_company
       tr

--- a/app/views/rating/todos/applications/show.html.slim
+++ b/app/views/rating/todos/applications/show.html.slim
@@ -22,9 +22,6 @@
         td Project
         td = link_to_application_project @application
       tr
-        td Project visibility
-        td = @application.project_visibility
-      tr
         td Coaching Company
         td = @application.coaching_company
       tr

--- a/db/migrate/20170324132500_remove_project_visibility_from_applications.rb
+++ b/db/migrate/20170324132500_remove_project_visibility_from_applications.rb
@@ -1,0 +1,5 @@
+class RemoveProjectVisibilityFromApplications < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :applications, :project_visibility, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170320223310) do
+ActiveRecord::Schema.define(version: 20170324132500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,7 +69,6 @@ ActiveRecord::Schema.define(version: 20170320223310) do
     t.string   "gender_identification_pair",    limit: 255
     t.text     "misc_info"
     t.string   "sponsor_pick",                  limit: 255
-    t.integer  "project_visibility"
     t.boolean  "hidden"
     t.text     "flags",                                     default: [], array: true
     t.string   "country",                       limit: 255

--- a/spec/controllers/rating/applications_controller_spec.rb
+++ b/spec/controllers/rating/applications_controller_spec.rb
@@ -145,7 +145,7 @@ describe Rating::ApplicationsController do
       before { sign_in user }
 
       context 'with valid params' do
-        let(:params) { {id: application, application: {mentor_pick: 1}} }
+        let(:params) { {id: application, application: {less_than_two_coaches: 1}} }
 
         it 'assigns @application' do
           put :update, params: params
@@ -156,7 +156,7 @@ describe Rating::ApplicationsController do
           expect{
             put :update, params: params
             application.reload
-          }.to change{application.mentor_pick}.to true
+          }.to change{application.less_than_two_coaches}.to true
         end
 
         it 'redirects to application' do

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -64,12 +64,6 @@ describe ApplicationsHelper do
       it 'returns link to project' do
         expect(project_link).to eq link_to(project.name, project)
       end
-
-      it 'returns link to project with visiblity when visiblity set' do
-        allow(application).to receive(:project_visibility){ 3 }
-        link_to_project = link_to("#{project.name} (3)", project)
-        expect(project_link).to eq link_to_project
-      end
     end
   end
   describe '.format_application_projects' do


### PR DESCRIPTION
This fixes the first four points in [this issue](https://github.com/rails-girls-summer-of-code/selection_process/issues/52): removing some fields in the additional info form and changing flags as needed.

Note: I've also removed this attribute from the permitted list of params in the controllers, and from the Applications exporter. I'm not sure what the policy is on removing fields from the database though, so I'd love an opinion there: should I remove the `project_visibility` field from the `applications` table?