### PR TITLE
Fixes additional info in the application view

### DIFF
--- a/app/views/rating/applications/show.html.slim
+++ b/app/views/rating/applications/show.html.slim
@@ -26,6 +26,7 @@
   h2 Additional Info
 
   p = link_to 'Edit additional Info', edit_rating_application_path(@application)
+  b Misc info:
   p = @application.misc_info
   table.misc_info
     tbody
@@ -35,9 +36,6 @@
       tr
         td Coaching Company
         td = @application.coaching_company
-      tr
-        td Location
-        td = "#{@application.city} #{@application.country}"
       tr
         td Flags
         td = format_application_flags(@application)


### PR DESCRIPTION
Add-on to this task: https://github.com/rails-girls-summer-of-code/selection_process/issues/52

The **Additional Info** section in the Application view reflects the contents of the **Additional Info form** better now.