### PR TITLE
Adds structure to Application View

### DIFF
--- a/app/assets/stylesheets/controllers/applications.sass
+++ b/app/assets/stylesheets/controllers/applications.sass
@@ -46,3 +46,7 @@
     font-weight: bold
   .comment p
     font-size: 1em
+  .application_view h3
+    color: $railsred
+    margin-top: 2em
+    margin-bottom: 1em

--- a/app/views/rating/applications/_application_data.html.slim
+++ b/app/views/rating/applications/_application_data.html.slim
@@ -1,230 +1,164 @@
-- ad = application.application_data
+.application_view
 
-b = Application.data_label("student0_application_age")
-p = auto_link(show_or_na(ad["student0_application_age"]))
+  - ad = application.application_data
 
-hr
+  h3 Basics
 
-b = Application.data_label("student1_application_age")
-p = auto_link(show_or_na(ad["student1_application_age"]))
+  b = Application.data_label("student0_application_age")
+  p = auto_link(show_or_na(ad["student0_application_age"]))
 
-hr
+  b = Application.data_label("student1_application_age")
+  p = auto_link(show_or_na(ad["student1_application_age"]))
 
-b = Application.data_label("student0_application_gender_identification")
-p = auto_link(show_or_na(ad["student0_application_gender_identification"]))
+  b = Application.data_label("student0_application_gender_identification")
+  p = auto_link(show_or_na(ad["student0_application_gender_identification"]))
 
-hr
+  b = Application.data_label("student1_application_gender_identification")
+  p = auto_link(show_or_na(ad["student1_application_gender_identification"]))
 
-b = Application.data_label("student1_application_gender_identification")
-p = auto_link(show_or_na(ad["student1_application_gender_identification"]))
+  b = Application.data_label("student0_application_diversity")
+  p = auto_link(show_or_na(ad["student0_application_diversity"]))
 
-hr
+  b = Application.data_label("student1_application_diversity")
+  p = auto_link(show_or_na(ad["student1_application_diversity"]))
 
-b = Application.data_label("student0_application_diversity")
-p = auto_link(show_or_na(ad["student0_application_diversity"]))
+  b = Application.data_label("student0_application_location")
+  p = auto_link(show_or_na(ad["student0_application_location"]))
 
-hr
+  b = Application.data_label("student1_application_location")
+  p = auto_link(show_or_na(ad["student1_application_location"]))
 
-b = Application.data_label("student1_application_diversity")
-p = auto_link(show_or_na(ad["student1_application_diversity"]))
+  h3 Background Information
 
-hr
+  b = Application.data_label("student0_application_about")
+  p = auto_link(show_or_na(ad["student0_application_about"]))
 
-b = Application.data_label("student0_application_location")
-p = auto_link(show_or_na(ad["student0_application_location"]))
+  b = Application.data_label("student1_application_about")
+  p = auto_link(show_or_na(ad["student1_application_about"]))
 
-hr
+  b = Application.data_label("student0_application_code_background")
+  p = auto_link(show_or_na(ad["student0_application_code_background"]))
 
-b = Application.data_label("student1_application_location")
-p = auto_link(show_or_na(ad["student1_application_location"]))
+  b = Application.data_label("student1_application_code_background")
+  p = auto_link(show_or_na(ad["student1_application_code_background"]))
 
-hr
+  h3 Community Involvement
 
-b = Application.data_label("student0_application_about")
-p = auto_link(show_or_na(ad["student0_application_about"]))
+  b = Application.data_label("student0_application_community_engagement")
+  p = auto_link(show_or_na(ad["student0_application_community_engagement"]))
 
-hr
+  b = Application.data_label("student1_application_community_engagement")
+  p = auto_link(show_or_na(ad["student1_application_community_engagement"]))
 
-b = Application.data_label("student1_application_about")
-p = auto_link(show_or_na(ad["student1_application_about"]))
+  b = Application.data_label("student0_application_giving_back")
+  p = auto_link(show_or_na(ad["student0_application_giving_back"]))
 
-hr
+  b = Application.data_label("student1_application_giving_back")
+  p = auto_link(show_or_na(ad["student1_application_giving_back"]))
 
-b = Application.data_label("student0_application_code_background")
-p = auto_link(show_or_na(ad["student0_application_code_background"]))
+  h3 Programming skills
 
-hr
+  b = Application.data_label("student0_application_skills")
+  p = auto_link(show_or_na(ad["student0_application_skills"]))
 
-b = Application.data_label("student1_application_code_background")
-p = auto_link(show_or_na(ad["student1_application_code_background"]))
+  b = Application.data_label("student1_application_skills")
+  p = auto_link(show_or_na(ad["student1_application_skills"]))
 
-hr
+  b = Application.data_label("student0_application_coding_level")
+  p = auto_link(show_or_na(ad["student0_application_coding_level"]) + "/5")
 
-b = Application.data_label("student0_application_community_engagement")
-p = auto_link(show_or_na(ad["student0_application_community_engagement"]))
+  b = Application.data_label("student1_application_coding_level")
+  p = auto_link(show_or_na(ad["student1_application_coding_level"]) + "/5")
 
-hr
+  b = Application.data_label("student0_application_language_learning_period")
+  p = auto_link(show_or_na(ad["student0_application_language_learning_period"] )+ " months")
 
-b = Application.data_label("student1_application_community_engagement")
-p = auto_link(show_or_na(ad["student1_application_community_engagement"]))
+  b = Application.data_label("student1_application_language_learning_period")
+  p = auto_link(show_or_na(ad["student1_application_language_learning_period"] )+ " months")
 
-hr
+  b = Application.data_label("student0_application_learning_history")
+  p = auto_link(show_or_na(ad["student0_application_learning_history"]))
 
-b = Application.data_label("student0_application_giving_back")
-p = auto_link(show_or_na(ad["student0_application_giving_back"]))
+  b = Application.data_label("student1_application_learning_history")
+  p = auto_link(show_or_na(ad["student1_application_learning_history"]))
 
-hr
+  b = Application.data_label("student0_application_code_samples")
+  p = auto_link(show_or_na(ad["student0_application_code_samples"]))
 
-b = Application.data_label("student1_application_giving_back")
-p = auto_link(show_or_na(ad["student1_application_giving_back"]))
+  b = Application.data_label("student1_application_code_samples")
+  p = auto_link(show_or_na(ad["student1_application_code_samples"]))
 
-hr
+  h3 Goals and motivation
 
-b = Application.data_label("student0_application_skills")
-p = auto_link(show_or_na(ad["student0_application_skills"]))
+  b = Application.data_label("student0_application_goals")
+  p = auto_link(show_or_na(ad["student0_application_goals"]))
 
-hr
+  b = Application.data_label("student1_application_goals")
+  p = auto_link(show_or_na(ad["student1_application_goals"]))
 
-b = Application.data_label("student1_application_skills")
-p = auto_link(show_or_na(ad["student1_application_skills"]))
+  b = Application.data_label("student0_application_motivation")
+  p = auto_link(show_or_na(ad["student0_application_motivation"]))
 
-hr
+  b = Application.data_label("student1_application_motivation")
+  p = auto_link(show_or_na(ad["student1_application_motivation"]))
 
-b = Application.data_label("student0_application_coding_level")
-p = auto_link(show_or_na(ad["student0_application_coding_level"]) + "/5")
+  h3 Financial matters
 
-hr
+  b = Application.data_label("student0_application_money")
+  p = auto_link(show_or_na(ad["student0_application_money"]) + " USD")
 
-b = Application.data_label("student1_application_coding_level")
-p = auto_link(show_or_na(ad["student1_application_coding_level"]) + "/5")
+  b = Application.data_label("student1_application_money")
+  p = auto_link(show_or_na(ad["student1_application_money"]) + " USD")
 
-hr
+  b = Application.data_label("student0_application_minimum_money")
+  p = auto_link(show_or_na(ad["student0_application_minimum_money"]))
 
-b = Application.data_label("student0_application_language_learning_period")
-p = auto_link(show_or_na(ad["student0_application_language_learning_period"] )+ " months")
+  b = Application.data_label("student1_application_minimum_money")
+  p = auto_link(show_or_na(ad["student1_application_minimum_money"]))
 
-hr
+  - project1 = Project.find_by(id: ad["project1_id"])
+  - link_to_if project1, project1.try(:name), project1
 
-b = Application.data_label("student1_application_language_learning_period")
-p = auto_link(show_or_na(ad["student1_application_language_learning_period"] )+ " months")
+  h3 Projects
 
-hr
+  b = Application.data_label("project1_id")
+  p = link_to_if project1, project1.try(:name), project1
 
-b = Application.data_label("student0_application_learning_history")
-p = auto_link(show_or_na(ad["student0_application_learning_history"]))
+  - project2 = Project.find_by(id: ad["project2_id"])
+  - link_to_if project2, project2.try(:name), project2
 
-hr
+  b = Application.data_label("project2_id")
+  p = link_to_if project2, project2.try(:name), project2
 
-b = Application.data_label("student1_application_learning_history")
-p = auto_link(show_or_na(ad["student1_application_learning_history"]))
+  b = Application.data_label("why_selected_project1")
+  p = auto_link(show_or_na(ad["why_selected_project1"]))
 
-hr
+  b = Application.data_label("why_selected_project2")
+  p = auto_link(show_or_na(ad["why_selected_project2"]))
 
-b = Application.data_label("student0_application_code_samples")
-p = auto_link(show_or_na(ad["student0_application_code_samples"]))
+  b = Application.data_label("plan_project1")
+  p = auto_link(show_or_na(render_markdown(ad["plan_project1"])))
 
-hr
+  b = Application.data_label("plan_project2")
+  p = auto_link(show_or_na(render_markdown(ad["plan_project2"])))
 
-b = Application.data_label("student1_application_code_samples")
-p = auto_link(show_or_na(ad["student1_application_code_samples"]))
+  h3 Team
 
-hr
+  b = Application.data_label("working_together")
+  p = auto_link(show_or_na(ad["working_together"]))
 
-b = Application.data_label("student0_application_goals")
-p = auto_link(show_or_na(ad["student0_application_goals"]))
+  h3 Volunteering
 
-hr
+  b = Application.data_label("voluntary")
+  p = auto_link(show_or_na(ad["voluntary"]))
 
-b = Application.data_label("student1_application_goals")
-p = auto_link(show_or_na(ad["student1_application_goals"]))
+  b = Application.data_label("voluntary_hours_per_week")
+  p = auto_link(show_or_na(ad["voluntary_hours_per_week"]))
 
-hr
+  h3 Miscellaneous
 
-b = Application.data_label("student0_application_motivation")
-p = auto_link(show_or_na(ad["student0_application_motivation"]))
+  b = Application.data_label("heard_about_it")
+  p = auto_link(show_or_na(ad["heard_about_it"]))
 
-hr
-
-b = Application.data_label("student1_application_motivation")
-p = auto_link(show_or_na(ad["student1_application_motivation"]))
-
-hr
-
-b = Application.data_label("student0_application_money")
-p = auto_link(show_or_na(ad["student0_application_money"]) + " USD")
-
-hr
-
-b = Application.data_label("student1_application_money")
-p = auto_link(show_or_na(ad["student1_application_money"]) + " USD")
-
-hr
-
-b = Application.data_label("student0_application_minimum_money")
-p = auto_link(show_or_na(ad["student0_application_minimum_money"]))
-
-hr
-
-b = Application.data_label("student1_application_minimum_money")
-p = auto_link(show_or_na(ad["student1_application_minimum_money"]))
-
-- project1 = Project.find_by(id: ad["project1_id"])
-- link_to_if project1, project1.try(:name), project1
-
-hr
-
-b = Application.data_label("project1_id")
-p = link_to_if project1, project1.try(:name), project1
-
-- project2 = Project.find_by(id: ad["project2_id"])
-- link_to_if project2, project2.try(:name), project2
-
-hr
-
-b = Application.data_label("project2_id")
-p = link_to_if project2, project2.try(:name), project2
-
-hr
-
-b = Application.data_label("why_selected_project1")
-p = auto_link(show_or_na(ad["why_selected_project1"]))
-
-hr
-
-b = Application.data_label("why_selected_project2")
-p = auto_link(show_or_na(ad["why_selected_project2"]))
-
-hr
-
-b = Application.data_label("plan_project1")
-p = auto_link(show_or_na(render_markdown(ad["plan_project1"])))
-
-hr
-
-b = Application.data_label("plan_project2")
-p = auto_link(show_or_na(render_markdown(ad["plan_project2"])))
-
-hr
-
-b = Application.data_label("working_together")
-p = auto_link(show_or_na(ad["working_together"]))
-
-hr
-
-b = Application.data_label("voluntary")
-p = auto_link(show_or_na(ad["voluntary"]))
-
-hr
-
-b = Application.data_label("voluntary_hours_per_week")
-p = auto_link(show_or_na(ad["voluntary_hours_per_week"]))
-
-hr
-
-b = Application.data_label("heard_about_it")
-p = auto_link(show_or_na(ad["heard_about_it"]))
-
-hr
-
-b = Application.data_label("misc_info")
-p = auto_link(show_or_na(ad["misc_info"]))
+  b = Application.data_label("misc_info")
+  p = auto_link(show_or_na(ad["misc_info"]))

--- a/app/views/rating/applications/show.html.slim
+++ b/app/views/rating/applications/show.html.slim
@@ -2,6 +2,7 @@
 
 #application
   h1 = "Application: #{@application.name}"
+
   ul
     li
       span = "Team: "
@@ -23,6 +24,8 @@
       span = "Coaches:"
       span = link_to_team_members(@application.team, :coach)
 
+  hr
+
   h2 Additional Info
 
   p = link_to 'Edit additional Info', edit_rating_application_path(@application)
@@ -40,11 +43,17 @@
         td Flags
         td = format_application_flags(@application)
 
+  hr
+
   h2 Mentors' feedback
   = render partial: 'mentor_feedback', locals: { application: @application }
 
+  hr
+
   h2 Submitted Application
   = render partial: 'application_data', locals: { application: @application }
+
+  hr
 
   #comments
     h2 Comments


### PR DESCRIPTION
Covers https://github.com/rails-girls-summer-of-code/selection_process/issues/51, "Split the application page into sections (and add Titles) like on the Application form"

@beanieboi I removed your `hr`s from the **Submitted application** section. I added sub-section titles there, and `hr` started adding a bit too much structure. I hope you don't mind.

I added `hr`s between different sections in the application view though. I don't know if it improved the view or not (not a designer) :D