### PR TITLE
Make rated applications in the todo list stand out

### DIFF
--- a/app/assets/stylesheets/controllers/ratings.sass
+++ b/app/assets/stylesheets/controllers/ratings.sass
@@ -15,3 +15,6 @@
   .rating-fixed &
     position: fixed
     top: 0
+
+.todo--rated
+  background-color: #e8fdf5 //washed green

--- a/app/views/rating/todos/index.html.slim
+++ b/app/views/rating/todos/index.html.slim
@@ -13,7 +13,7 @@ table.table
       th Rated at
   tbody
     - @todos.each do |todo|
-      tr
+      tr.todo class=(todo.rating&.updated_at ? 'todo--rated' : '')
         td= link_to(todo.application.team_name, [:rating, todo.application])
         td= todo.eligible? ? icon('check') : icon('ban')
         td.text-right= todo.sign_offs?.first ? icon('check') : icon('ban')


### PR DESCRIPTION
Give them a nice "washed green" background so it's easy to see which ones still need doing.

![2017-04-06-182805_1845x253_scrot](https://cloud.githubusercontent.com/assets/32212/24765094/d0193cb2-1af6-11e7-901f-46a583f68b65.png)
