### PR TITLE
Update puma config

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,4 +1,4 @@
-workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+workers Integer(ENV['WEB_CONCURRENCY'] || 1)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count
 


### PR DESCRIPTION
I looked a bit into the `R14 - Memory Quota Exceeded` problem on Heroku *(production app)*. It looks like I configured too many Puma workers. See e.g. [this section](https://devcenter.heroku.com/articles/ruby-memory-use#too-many-workers) in Heroku's docs around the topic.

Using two workers is *theoretically* possible with a Rails app running on one dyno - but it does not work for every app.

TLDR: I think reducing the workers to just one should fix the problem of exceeding the memory quota basically 10min after app start.