### PR TITLE
Fix for back-button behavior in Chrome

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,6 +1,7 @@
 class ActivitiesController < ApplicationController
   before_action :normalize_params, only: :index
   before_action :cors_preflight, only: :index
+  before_action :set_vary_header, only: :index
   after_action  :cors_set_headers, only: :index
 
   before_action :set_activities
@@ -10,33 +11,36 @@ class ActivitiesController < ApplicationController
     respond_to do |format|
       format.html
       format.json { render json: @activities }
-      format.atom { render :layout => false  }
+      format.atom { render layout: false  }
     end
   end
 
   private
 
-    def set_activities
-      @activities = Activity.includes(:team).with_kind(whitelisted_kind).ordered.page(params[:page])
-      @activities = @activities.by_team(params[:team_id]) if params[:team_id].present?
-    end
+  def set_vary_header
+    response.headers['Vary'] = 'Accept'
+  end
 
-    def teams
-      Team.in_current_season.selected.order(:name)
-    end
-    helper_method :teams
+  def set_activities
+    @activities = Activity.includes(:team).with_kind(whitelisted_kind).ordered.page(params[:page])
+    @activities = @activities.by_team(params[:team_id]) if params[:team_id].present?
+  end
 
-    def normalize_params
-      params[:kind] = 'all' if params[:kind].blank?
-    end
+  def teams
+    Team.in_current_season.selected.order(:name)
+  end
+  helper_method :teams
 
-    def whitelisted_kind
-      @whitelisted_kind ||= Array(params[:kind]).detect { |kind| public_activities.include? kind } || public_activities
-    end
+  def normalize_params
+    params[:kind] = 'all' if params[:kind].blank?
+  end
 
-    def public_activities
-      @public_activities ||= %w(feed_entry status_update)
-    end
-    helper_method :public_activities
+  def whitelisted_kind
+    @whitelisted_kind ||= Array(params[:kind]).detect { |kind| public_activities.include? kind } || public_activities
+  end
+
+  def public_activities
+    @public_activities ||= %w(feed_entry status_update)
+  end
+  helper_method :public_activities
 end
-


### PR DESCRIPTION
This prevents Chrome from responding with the wrong format when using
the back button. Background: Chrome's cache does not distinguish between
the formats otherwise.

Video fuck yeah:
![header](https://cloud.githubusercontent.com/assets/3491815/24836854/5e0882bc-1d27-11e7-9a4a-0f8c58e80661.gif)
