### PR TITLE
Use expected values to improve strictness computation

### DIFF
--- a/app/models/rating/strictness.rb
+++ b/app/models/rating/strictness.rb
@@ -76,9 +76,9 @@ class Rating::Strictness
     # given reviewer_ids only
     rating_subgroup = ratings.where(user_id: ids)
 
-    # Count the frequencies: How often did a specific
-    # reviewer given a specic value? The relative frequencies
-    # are used as probabilities
+    # Count the frequencies: How often has a specific
+    # reviewer assigned a specic point value? The
+    # distribution hash stores the absolute frequencies
     distribution = rating_subgroup.each_with_object({}) do |rating, hash|
       hash[rating.points.to_s] ||= 0
       hash[rating.points.to_s]  += 1

--- a/app/models/rating/strictness.rb
+++ b/app/models/rating/strictness.rb
@@ -72,8 +72,6 @@ class Rating::Strictness
   # @return [Float] for expected value for application raring of
   # given set of reviewers
   def expected_value_for(ids)
-    distribution = {}
-
     # We are working with the ratings of
     # given reviewer_ids only
     rating_subgroup = ratings.where(user_id: ids)
@@ -81,9 +79,9 @@ class Rating::Strictness
     # Count the frequencies: How often did a specific
     # reviewer given a specic value? The relative frequencies
     # are used as probabilities
-    rating_subgroup.each do |rating|
-      distribution[rating.points.to_s] ||= 0
-      distribution[rating.points.to_s]  += 1
+    distribution = rating_subgroup.each_with_object({}) do |rating, hash|
+      hash[rating.points.to_s] ||= 0
+      hash[rating.points.to_s]  += 1
     end
 
     # Calculate the expected value by sum over the

--- a/app/models/rating/strictness.rb
+++ b/app/models/rating/strictness.rb
@@ -65,19 +65,12 @@ class Rating::Strictness
     @reviewer_ids ||= ratings.pluck(:user_id).uniq
   end
 
-  # @return [Float] overall rating average
-  def average_points_per_reviewer
-    @average_points_per_reviewer ||= ratings.sum(&:points) / reviewer_ids.size.to_f
-  end
-
   def strictness_adjusted_points
     ->(rating) { (rating.points * strictness_per_reviewer[rating.user_id]).to_f }
   end
 
-  def individual_points_for_reviewer(id)
-    ratings.select{|r| r.user_id == id}.sum(&:points)
-  end
-
+  # @return [Float] for expected value for application raring of
+  # given set of reviewers
   def expected_value_for(ids)
     distribution = {}
 

--- a/app/models/rating/strictness.rb
+++ b/app/models/rating/strictness.rb
@@ -76,8 +76,8 @@ class Rating::Strictness
     # given reviewer_ids only
     rating_subgroup = ratings.where(user_id: ids)
 
-    # Count the frequencies: How often has a specific
-    # reviewer assigned a specic point value? The
+    # Count the frequencies: How often has the group
+    # of reviewers assigned a specic point value? The
     # distribution hash stores the absolute frequencies
     distribution = rating_subgroup.each_with_object({}) do |rating, hash|
       hash[rating.points] ||= 0

--- a/app/models/rating/strictness.rb
+++ b/app/models/rating/strictness.rb
@@ -80,8 +80,8 @@ class Rating::Strictness
     # reviewer assigned a specic point value? The
     # distribution hash stores the absolute frequencies
     distribution = rating_subgroup.each_with_object({}) do |rating, hash|
-      hash[rating.points.to_s] ||= 0
-      hash[rating.points.to_s]  += 1
+      hash[rating.points] ||= 0
+      hash[rating.points]  += 1
     end
 
     # Calculate the expected value by sum over the

--- a/app/models/rating/strictness.rb
+++ b/app/models/rating/strictness.rb
@@ -69,7 +69,7 @@ class Rating::Strictness
     ->(rating) { (rating.points * strictness_per_reviewer[rating.user_id]).to_f }
   end
 
-  # @return [Float] for expected value for application raring of
+  # @return [Float] for expected value for application rating of
   # given set of reviewers
   def expected_value_for(ids)
     # We are working with the ratings of
@@ -86,7 +86,7 @@ class Rating::Strictness
 
     # Calculate the expected value, which is defined
     # as the sum over the products of rating point values multiplied by their
-    # probablity
+    # probability
     distribution.sum { |x, frequency_of_x| x.to_f * (frequency_of_x.to_f / rating_subgroup.count.to_f) }
   end
 end

--- a/app/models/rating/strictness.rb
+++ b/app/models/rating/strictness.rb
@@ -84,8 +84,9 @@ class Rating::Strictness
       hash[rating.points]  += 1
     end
 
-    # Calculate the expected value by sum over the
-    # product of value multiplied by its probablity
+    # Calculate the expected value, which is defined
+    # as the sum over the products of rating point values multiplied by their
+    # probablity
     distribution.sum { |x, frequency_of_x| x.to_f * (frequency_of_x.to_f / rating_subgroup.count.to_f) }
   end
 end


### PR DESCRIPTION
When @carpodaster  and me have proposed the [first version of reviewer strictness computation](https://github.com/rails-girls-summer-of-code/rgsoc-teams/pull/741) I made a mistake because of oversimplification. As @mkalininait correctly pointed out, our current formula gets slightly unfair when the amount of ratings is not equal for all reviewers.

Because I was a bit confused at all I started formalizing our problem en détail [here](https://github.com/neumanrq/fair_reviewers/blob/master/theory/index.pdf), where the new formula is taken from (It is the formula for `S^*`, currently Definiton 9 on page 5).

The short version is: After merging this, the strictness will be computed by determining the expectation value for each reviewer and comparing it to the "overall" computation value, instead of a more simple comparison of "amount of points assigned by reviewer A" with "amount points assigned by an average reviewer". 

I'd love to take @carpodaster into account: Maybe we could pair on this during next week and check it against real data. Of course, everyone is invited to ask sceptical questions on this 👀  😄 