### PR TITLE
[BLOCKED] Polishing conferences table

### DIFF
--- a/app/views/conferences/_table.html.erb
+++ b/app/views/conferences/_table.html.erb
@@ -1,3 +1,4 @@
+<h1 class=" header">Conferences (1st round)</h1>
 <table class="table-striped table-bordered table-condensed conferences">
   <thead>
   <tr>
@@ -11,7 +12,7 @@
   </thead>
 
   <tbody>
-  <% conferences.where(round: 2).each do |conference| %>
+  <% conferences.where(round: 1).each do |conference| %>
   <tr>
     <td> <%= link_to conference.name, [namespace, conference] %></td>
     <td> <%= conference.location %></td>
@@ -28,10 +29,10 @@
 <p><%= link_to "View as Calendar", calendar_path %>
 </p>
 
-<p><%= link_to "Show/Hide First Round Conferences", "#", onclick: "$('.first-conferences').toggle()" %></p>
+<p><%= link_to "Show/Hide Other Round Conferences", "#", onclick: "$('.next-conferences').toggle()" %></p>
 
-<div class="first-conferences" style='display:none;'>
-<h1 class=" header">Conferences (1st round)</h1>
+<div class="next-conferences" style='display:none;'>
+<h1 class=" header">Conferences (2nd round)</h1>
 
 <table class="table-striped table-bordered table-condensed conferences">
   <thead>
@@ -46,7 +47,7 @@
   </thead>
 
   <tbody>
-  <% conferences.where(round: 1).each do |conference| %>
+  <% conferences.where(round: 2).each do |conference| %>
       <tr>
         <td> <%= link_to conference.name, [namespace, conference] %></td>
         <td> <%= conference.location %></td>

--- a/app/views/conferences/index.html.slim
+++ b/app/views/conferences/index.html.slim
@@ -1,5 +1,2 @@
-h1.header
-  / = icon('users')
-  span Conferences (2nd round)
 
 = render 'conferences/table', namespace: nil

--- a/app/views/orga/conferences/index.html.slim
+++ b/app/views/orga/conferences/index.html.slim
@@ -2,9 +2,6 @@
 
 nav.actions
   ul.list-inline
-    li = link_to icon('plus', 'New Conference'), new_orga_conference_path, class: 'btn btn-primary btn-sm'
-h1.header
-  / = icon('users')
-  span Conferences (2nd round)
+    li = link_to icon('plus', 'New Conference'), new_orga_conference_path, class: 'btn btn-default btn-small'
 
 = render 'conferences/table', namespace: :orga


### PR DESCRIPTION
Still working on polishing the Conferences. 

- Reverse toggle, so now it shows Round 1 by default, and toggle Round 2
- Update button
- Move table title from namespace view to shared partial.

Goal: making working on the Conferences table easier and nicer. 

