### PR TITLE
Use Postgres 9.5 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 sudo: false
+dist: trusty
 rvm:
 - 2.4.1
 bundler_args: "-j4 --without development production --quiet"
@@ -29,6 +30,6 @@ deploy:
   on:
     repo: rails-girls-summer-of-code/rgsoc-teams
 addons:
-  postgresql: '9.3'
+  postgresql: '9.5'
 after_success:
 - bundle exec codeclimate-test-reporter


### PR DESCRIPTION
As the `production` app runs Postgres 9.5 and there have been some changes regarding `hstore` *(and other JSON related things)* between 9.3 and 9.5, I thought it would be saver to also run our CI with the respective version.

However: it's not available on Travis' default container infrastructure, so I had to switch to the (beta) [trusty linux](https://docs.travis-ci.com/user/getting-started/#Selecting-infrastructure-(optional)).