### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,19 @@ script:
 - bundle exec rake spec
 - bundle exec rake jshint
 deploy:
-  provider: heroku
+- provider: heroku
   api_key:
     secure: ZtYE7hK2EyNWYhkxWSGSrmCNvYZrT7dmxRvi4rg82uHFOtzbEiThjkmwKKD3EK75syGFos3fJszW8GRwJqY9Id6L1Ieg+GpHDMBYJqsLbSRqJ6Mj1vzxbDqV2XsDFkr2e3MTrgNPRX+qmcKnsP9PTwxtey8pAUZFQFTz0i0gxcc=
-  app:
-    master: rgsoc-teams-production
-    fix/sign-off-per-project: rgsoc-teams-staging
+  app: rgsoc-teams-staging
+  run:
+  - rake db:migrate
+  - restart
+  on:
+    repo: rails-girls-summer-of-code/rgsoc-teams
+- provider: heroku
+  api_key:
+    secure: ZtYE7hK2EyNWYhkxWSGSrmCNvYZrT7dmxRvi4rg82uHFOtzbEiThjkmwKKD3EK75syGFos3fJszW8GRwJqY9Id6L1Ieg+GpHDMBYJqsLbSRqJ6Mj1vzxbDqV2XsDFkr2e3MTrgNPRX+qmcKnsP9PTwxtey8pAUZFQFTz0i0gxcc=
+  app: rgsoc-teams-production
   run:
   - rake db:migrate
   - restart


### PR DESCRIPTION
Travis currently only deploys the a certain outdated feature branch to the `staging` app, which leads to having to deploy the to the `staging` app by hand which a) can be forgotten and b) does in my opinion not quite fit the purpose of a staging app _(it should have the changes first...)_

So in order to not have the `staging` app fall behind the production app, I updated the `.travis.yml` to automatically deploy `master` to both environments. Any other branch can still be deployed to staging by hand if someone needs to test something - it's just to make sure `staging` is not falling behind.

The only ways I think this can work is by adding a 2nd "provider" to the deploy section _(Travis experts please correct me)_.