### PR TITLE
Prepare conferences table for upcoming changes 

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -9,7 +9,6 @@ class ConferencesController < ApplicationController
   end
 
   private
-
     def conferences
       @conferences ||= Conference.ordered(sort_params).in_current_season
     end
@@ -22,7 +21,7 @@ class ConferencesController < ApplicationController
 
     def sort_params
       {
-        order: %w(name location starts_on).include?(params[:sort]) ? params[:sort] : nil,
+        order: %w(name location starts_on round).include?(params[:sort]) ? params[:sort] : nil,
         direction: %w(asc desc).include?(params[:direction]) ? params[:direction] : nil
       }
     end

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -3,6 +3,14 @@ class ConferencesController < ApplicationController
 
   def new
   end
+ 
+  def index
+    @conferences = conferences
+  end
+ 
+  def show
+    @conference = Conference.find(params[:id])
+  end
 
   def redirect
     redirect_to orga_conferences_path
@@ -11,14 +19,8 @@ class ConferencesController < ApplicationController
   private
  
   def conferences
-    @conferences ||= Conference.ordered(sort_params).in_current_season
+    Conference.ordered(sort_params).in_current_season
   end
-  helper_method :conferences
-
-  def conference
-     @conference ||= Conference.find(params[:id])
-  end
-  helper_method :conference
 
   def sort_params
     {

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -9,20 +9,21 @@ class ConferencesController < ApplicationController
   end
 
   private
-    def conferences
-      @conferences ||= Conference.ordered(sort_params).in_current_season
-    end
-    helper_method :conferences
+ 
+  def conferences
+    @conferences ||= Conference.ordered(sort_params).in_current_season
+  end
+  helper_method :conferences
 
-    def conference
-       @conference ||= Conference.find(params[:id])
-    end
-    helper_method :conference
+  def conference
+     @conference ||= Conference.find(params[:id])
+  end
+  helper_method :conference
 
-    def sort_params
-      {
-        order: %w(name location starts_on round).include?(params[:sort]) ? params[:sort] : nil,
-        direction: %w(asc desc).include?(params[:direction]) ? params[:direction] : nil
-      }
-    end
+  def sort_params
+    {
+      order: %w(name location starts_on round).include?(params[:sort]) ? params[:sort] : nil,
+      direction: %w(asc desc).include?(params[:direction]) ? params[:direction] : nil
+    }
+  end
 end

--- a/app/controllers/orga/conferences_controller.rb
+++ b/app/controllers/orga/conferences_controller.rb
@@ -47,7 +47,7 @@ class Orga::ConferencesController < Orga::BaseController
 
   def sort_params
     {
-      order: %w(name location starts_on).include?(params[:sort]) ? params[:sort] : nil,
+      order: %w(name location starts_on round).include?(params[:sort]) ? params[:sort] : nil,
       direction: %w(asc desc).include?(params[:direction]) ? params[:direction] : nil
     }
   end

--- a/app/controllers/orga/conferences_controller.rb
+++ b/app/controllers/orga/conferences_controller.rb
@@ -1,9 +1,14 @@
 class Orga::ConferencesController < Orga::BaseController
 
+  def new
+    @conference = Conference.new
+  end
+  
   def create
-    conference.season = current_season
+    @conference = Conference.new(conference_params)
+    @conference.season = current_season
     respond_to do |format|
-      if conference.save
+      if @conference.save
         format.html { redirect_to orga_conference_path(conference) }
       else
         format.html { render action: :new }
@@ -30,19 +35,19 @@ class Orga::ConferencesController < Orga::BaseController
     @conferences ||= Conference.ordered(sort_params).in_current_season
   end
   helper_method :conferences
-
+  
   def conference
-    @conference ||= params[:id] ? Conference.find(params[:id]) : Conference.new(conference_params)
+    @conference ||= Conference.find(params[:id])
   end
   helper_method :conference
 
   def conference_params
-    params[:conference] ? params.require(:conference).permit(
+    params.require(:conference).permit(
       :name, :url, :location, :twitter,
       :tickets, :flights, :accomodation,
       :starts_on, :ends_on, :round, :lightningtalkslots,
       attendances_attributes: [:id, :github_handle, :_destroy]
-    ) : {}
+    )
   end
 
   def sort_params

--- a/app/controllers/orga/conferences_controller.rb
+++ b/app/controllers/orga/conferences_controller.rb
@@ -34,7 +34,7 @@ class Orga::ConferencesController < Orga::BaseController
   private
 
   def find_conference
-    Conference.find(params[:id])
+    @conference ||= Conference.find(params[:id])
   end
   
   def conferences

--- a/app/controllers/orga/conferences_controller.rb
+++ b/app/controllers/orga/conferences_controller.rb
@@ -1,45 +1,45 @@
 class Orga::ConferencesController < Orga::BaseController
+  before_action :find_resource, only: [:show, :edit, :update, :destroy]
 
+  def index
+    @conferences = conferences
+  end
+  
   def new
     @conference = Conference.new
   end
   
   def create
-    @conference = Conference.new(conference_params)
-    @conference.season = current_season
-    respond_to do |format|
-      if @conference.save
-        format.html { redirect_to orga_conference_path(conference) }
-      else
-        format.html { render action: :new }
-      end
+    @conference = Conference.new(conference_params.merge(season: current_season))
+    if @conference.save
+     redirect_to orga_conference_path(@conference)
+    else
+      render action: :new
     end
   end
-
+  
   def update
-    if conference.update(conference_params)
-      redirect_to orga_conference_path(conference)
+    if @conference.update(conference_params)
+      redirect_to orga_conference_path(@conference)
     else
       render action: :edit
     end
   end
 
   def destroy
-    conference.destroy!
+    @conference.destroy!
     redirect_to orga_conferences_path, notice: 'The conference has been deleted.'
   end
 
   private
 
-  def conferences
-    @conferences ||= Conference.ordered(sort_params).in_current_season
-  end
-  helper_method :conferences
-  
-  def conference
+  def find_resource
     @conference ||= Conference.find(params[:id])
   end
-  helper_method :conference
+  
+  def conferences
+    Conference.ordered(sort_params).in_current_season
+  end
 
   def conference_params
     params.require(:conference).permit(

--- a/app/controllers/orga/conferences_controller.rb
+++ b/app/controllers/orga/conferences_controller.rb
@@ -1,5 +1,5 @@
 class Orga::ConferencesController < Orga::BaseController
-  before_action :find_resource, only: [:show, :edit, :update, :destroy]
+  before_action :find_conference, only: [:show, :edit, :update, :destroy]
 
   def index
     @conferences = conferences
@@ -33,8 +33,8 @@ class Orga::ConferencesController < Orga::BaseController
 
   private
 
-  def find_resource
-    @conference ||= Conference.find(params[:id])
+  def find_conference
+    Conference.find(params[:id])
   end
   
   def conferences

--- a/app/views/conferences/_details.html.slim
+++ b/app/views/conferences/_details.html.slim
@@ -1,24 +1,24 @@
 .conference
   dl.dl-horizontal
     dt Location
-    dd = conference.location
+    dd = @conference.location
     dt Date
-    dd = conference.date_range
+    dd = @conference.date_range
     dt Twitter
-    dd = format_conference_twitter(conference.twitter)
+    dd = format_conference_twitter(@conference.twitter)
     dt Homepage
-    dd = link_to conference.url, conference.url
+    dd = link_to @conference.url, @conference.url
     dt Tickets total
-    dd = format_conference_scholarships(conference.tickets, conference.flights, conference.accomodation)
+    dd = format_conference_scholarships(@conference.tickets, @conference.flights, @conference.accomodation)
     dt Tickets left
-    dd = conference.tickets_left
+    dd = @conference.tickets_left
     dt Lightning Talk Slots
-    - if conference.lightningtalkslots?
+    - if @conference.lightningtalkslots?
       dd = "yes"
     - else
       dd = "no"
 
   h4 Attendees
   ul.attendees
-    - conference.attendees.each do |user|
+    - @conference.attendees.each do |user|
       li = "#{link_to user.name.present? ? user.name : user.github_handle, user} #{", #{user.teams.map { |team| link_to(team.display_name, team) }.join(', ')}" if user.teams.any? }".html_safe

--- a/app/views/conferences/_table.html.erb
+++ b/app/views/conferences/_table.html.erb
@@ -1,44 +1,11 @@
-<table class="table-striped table-bordered table-condensed conferences">
-  <thead>
-  <tr>
-    <th> <%= sortable "Conference" %> </th>
-    <th> <%= sortable "Location" %> </th>
-    <th> <%= sortable "Dates" %> </th>
-    <th> Attendees </th>
-    <th> Tickets left </th>
-    <th> Lightning Talk Slots?</th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% conferences.where(round: 2).each do |conference| %>
-  <tr>
-    <td> <%= link_to conference.name, [namespace, conference] %></td>
-    <td> <%= conference.location %></td>
-    <td> <%= conference.date_range %></td>
-    <td> <%= conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-' %></td>
-    <td> <%= conference.tickets_left %></td>
-    <td><%= conference.lightningtalkslots? ? "yes" : "no" %></td>
-  </tr>
-      <% end %>
-    </tbody>
-</table>
-
-<br>
-<p><%= link_to "View as Calendar", calendar_path %>
-</p>
-
-<p><%= link_to "Show/Hide First Round Conferences", "#", onclick: "$('.first-conferences').toggle()" %></p>
-
-<div class="first-conferences" style='display:none;'>
-<h1 class=" header">Conferences (1st round)</h1>
-
+<h1 class="header">Conferences</h1>
 <table class="table-striped table-bordered table-condensed conferences">
   <thead>
     <tr>
-      <th> <%= sortable "Conference" %> </th>
-      <th> <%= sortable "Location" %> </th>
-      <th> <%= sortable "Dates" %> </th>
+      <th> <%= sortable :name, "Conference" %> </th>
+      <th> <%= sortable :location %> </th>
+      <th> <%= sortable :starts_on, "Dates" %> </th>
+      <th> <%= sortable :round %> </th>
       <th> Attendees </th>
       <th> Tickets left </th>
       <th> Lightning Talk Slots?</th>
@@ -46,16 +13,19 @@
   </thead>
 
   <tbody>
-  <% conferences.where(round: 1).each do |conference| %>
+    <% conferences.each do |conference| %>
       <tr>
         <td> <%= link_to conference.name, [namespace, conference] %></td>
         <td> <%= conference.location %></td>
         <td> <%= conference.date_range %></td>
+        <td> <%= conference.round if conference.round.present? %> </td>
         <td> <%= conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-' %></td>
         <td> <%= conference.tickets_left %></td>
         <td><%= conference.lightningtalkslots? ? "yes" : "no" %></td>
       </tr>
-  <% end %>
+    <% end %>
   </tbody>
 </table>
-</div>
+
+<br>
+<p><%= link_to "View as Calendar", calendar_path %></p>

--- a/app/views/conferences/_table.html.erb
+++ b/app/views/conferences/_table.html.erb
@@ -2,24 +2,24 @@
 <table class="table-striped table-bordered table-condensed conferences">
   <thead>
     <tr>
-      <th> <%= sortable :name, "Conference" %> </th>
-      <th> <%= sortable :location %> </th>
-      <th> <%= sortable :starts_on, "Dates" %> </th>
-      <th> <%= sortable :round %> </th>
-      <th> Attendees </th>
-      <th> Tickets left </th>
-      <th> Lightning Talk Slots?</th>
+      <th><%= sortable :name, "Conference" %></th>
+      <th><%= sortable :location %></th>
+      <th><%= sortable :starts_on, "Dates" %></th>
+      <th><%= sortable :round %></th>
+      <th>Attendees</th>
+      <th>Tickets left</th>
+      <th>Lightning Talk Slots?</th>
     </tr>
   </thead>
   <tbody>
     <% conferences.each do |conference| %>
       <tr>
-        <td> <%= link_to conference.name, [namespace, conference] %></td>
-        <td> <%= conference.location %></td>
-        <td> <%= conference.date_range %></td>
-        <td> <%= conference.round %></td>
-        <td> <%= conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-' %></td>
-        <td> <%= conference.tickets_left %></td>
+        <td><%= link_to conference.name, [namespace, conference] %></td>
+        <td><%= conference.location %></td>
+        <td><%= conference.date_range %></td>
+        <td><%= conference.round %></td>
+        <td><%= conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-' %></td>
+        <td><%= conference.tickets_left %></td>
         <td><%= conference.lightningtalkslots? ? "yes" : "no" %></td>
       </tr>
     <% end %>

--- a/app/views/conferences/_table.html.erb
+++ b/app/views/conferences/_table.html.erb
@@ -17,6 +17,7 @@
         <td> <%= link_to conference.name, [namespace, conference] %></td>
         <td> <%= conference.location %></td>
         <td> <%= conference.date_range %></td>
+        <td> <%= conference.round %></td>
         <td> <%= conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-' %></td>
         <td> <%= conference.tickets_left %></td>
         <td><%= conference.lightningtalkslots? ? "yes" : "no" %></td>

--- a/app/views/conferences/_table.html.erb
+++ b/app/views/conferences/_table.html.erb
@@ -11,14 +11,12 @@
       <th> Lightning Talk Slots?</th>
     </tr>
   </thead>
-
   <tbody>
     <% conferences.each do |conference| %>
       <tr>
         <td> <%= link_to conference.name, [namespace, conference] %></td>
         <td> <%= conference.location %></td>
         <td> <%= conference.date_range %></td>
-        <td> <%= conference.round if conference.round.present? %> </td>
         <td> <%= conference.attendees.any? ? links_to_attendances(conference).join(', ').html_safe : '-' %></td>
         <td> <%= conference.tickets_left %></td>
         <td><%= conference.lightningtalkslots? ? "yes" : "no" %></td>
@@ -26,6 +24,5 @@
     <% end %>
   </tbody>
 </table>
-
 <br>
 <p><%= link_to "View as Calendar", calendar_path %></p>

--- a/app/views/conferences/index.html.slim
+++ b/app/views/conferences/index.html.slim
@@ -1,1 +1,1 @@
-= render 'conferences/table', namespace: nil
+= render 'conferences/table', namespace: nil, conferences: @conferences

--- a/app/views/conferences/index.html.slim
+++ b/app/views/conferences/index.html.slim
@@ -1,5 +1,1 @@
-h1.header
-  / = icon('users')
-  span Conferences (2nd round)
-
 = render 'conferences/table', namespace: nil

--- a/app/views/conferences/show.html.slim
+++ b/app/views/conferences/show.html.slim
@@ -4,6 +4,6 @@ nav.page
       li = icon('chevron-left')
       li = link_to 'All conferences', conferences_path, class: 'back'
 
-h1 class="conference" = conference.name
+h1 class="conference" = @conference.name
 
-= render 'conferences/details', namespace: nil
+= render 'conferences/details', namespace: nil, conferences: @conferences

--- a/app/views/orga/conferences/_form.html.slim
+++ b/app/views/orga/conferences/_form.html.slim
@@ -1,9 +1,9 @@
-= simple_nested_form_for ([:orga, conference]) do |f|
-  - if conference.errors.any?
+= simple_nested_form_for ([:orga, @conference]) do |f|
+  - if @conference.errors.any?
     #error_explanation
-      h2 = "#{pluralize(conference.errors.count, "error")} prohibited this conference from being saved:"
+      h2 = "#{pluralize(@conference.errors.count, "error")} prohibited this conference from being saved:"
       ul
-        - conference.errors.full_messages.each do |message|
+        - @conference.errors.full_messages.each do |message|
           li = message
 
   = f.input :name
@@ -14,8 +14,8 @@
   = f.input :ends_on, order: [:day, :month, :year], input_html: { class: 'short' }
   = f.input :round, collection: 1..2
   = f.input :tickets, default: 0, collection: 0..20
-  = f.input :flights, default:0, collection: 0..(conference&.tickets || 20)
-  = f.input :accomodation, label: "Accommodation", default:0, collection: 0..(conference&.tickets || 20)
+  = f.input :flights, default:0, collection: 0..(@conference&.tickets || 20)
+  = f.input :accomodation, label: "Accommodation", default:0, collection: 0..(@conference&.tickets || 20)
   = f.input :lightningtalkslots, label: "Lightning Talk Slots"
 
   h3 Attendees

--- a/app/views/orga/conferences/_form.html.slim
+++ b/app/views/orga/conferences/_form.html.slim
@@ -1,4 +1,4 @@
-= simple_nested_form_for ([:orga, @conference]) do |f|
+= simple_nested_form_for([:orga, @conference]) do |f|
   - if @conference.errors.any?
     #error_explanation
       h2 = "#{pluralize(@conference.errors.count, "error")} prohibited this conference from being saved:"

--- a/app/views/orga/conferences/edit.html.slim
+++ b/app/views/orga/conferences/edit.html.slim
@@ -9,7 +9,7 @@ nav.page
 nav.actions
   ul
     li
-      = link_to 'Destroy', conference, data: { confirm: 'Are you sure?' }, method: :delete, class: 'destroy'
+      = link_to 'Destroy', @conference, data: { confirm: 'Are you sure?' }, method: :delete, class: 'destroy'
 
 h1 Editing conference
 

--- a/app/views/orga/conferences/index.html.slim
+++ b/app/views/orga/conferences/index.html.slim
@@ -4,4 +4,4 @@ nav.actions
   ul.list-inline
     li = link_to icon('plus', 'New Conference'), new_orga_conference_path, class: 'btn btn-default btn-sm'
 
-= render 'conferences/table', namespace: :orga
+= render 'conferences/table', namespace: :orga, conferences: @conferences

--- a/app/views/orga/conferences/index.html.slim
+++ b/app/views/orga/conferences/index.html.slim
@@ -2,9 +2,6 @@
 
 nav.actions
   ul.list-inline
-    li = link_to icon('plus', 'New Conference'), new_orga_conference_path, class: 'btn btn-primary btn-sm'
-h1.header
-  / = icon('users')
-  span Conferences (2nd round)
+    li = link_to icon('plus', 'New Conference'), new_orga_conference_path, class: 'btn btn-default btn-sm'
 
 = render 'conferences/table', namespace: :orga

--- a/app/views/orga/conferences/show.html.slim
+++ b/app/views/orga/conferences/show.html.slim
@@ -6,10 +6,10 @@ nav.page
       li = icon('chevron-left')
       li = link_to 'All conferences', orga_conferences_path, class: 'back'
 
-h1 class="conference" = conference.name
+h1 class="conference" = @conference.name
 
 nav.btn-group
-  = link_to 'Edit', edit_orga_conference_path(conference), class: 'edit btn btn-default'
-  = link_to 'Delete', orga_conference_path(conference), method: :delete, class: 'edit btn btn-default', data: { confirm: 'Are you sure?' }
+  = link_to 'Edit', edit_orga_conference_path(@conference), class: 'edit btn btn-default'
+  = link_to 'Delete', orga_conference_path(@conference), method: :delete, class: 'edit btn btn-default', data: { confirm: 'Are you sure?' }
 
 = render 'conferences/details', namespace: :orga


### PR DESCRIPTION
Instead of #750 
Now that the Conference raffle rounds are gone, and we are preparing for a different setup, this PR is preparing the conferences table. 

- Moved title to partial
- Removed toggle in view for round 1 vs 2
- Removed repeated table for second round
- Temp: added round (sortable) to table
- Restored sortable functionality (sortability used to be there, but got lost somewhere)
- Updated button style
- cleanup controller, use regular CRUD setup