### PR TITLE
Include a new intermediate state (pending) for the projects

### DIFF
--- a/app/assets/stylesheets/controllers/projects.sass
+++ b/app/assets/stylesheets/controllers/projects.sass
@@ -27,3 +27,6 @@
     left: 50%
     margin-left: -250px
     width: 500px
+
+.space_btns
+  margin-left: 10px

--- a/app/controllers/orga/projects_controller.rb
+++ b/app/controllers/orga/projects_controller.rb
@@ -14,7 +14,7 @@ class Orga::ProjectsController < Orga::BaseController
     redirect_to [:orga, :projects]
   end
 
-  def pending
+  def start_review
     if @project.start_review!
       flash[:notice] = "Successfully marked project as pending!"
     else

--- a/app/controllers/orga/projects_controller.rb
+++ b/app/controllers/orga/projects_controller.rb
@@ -14,6 +14,15 @@ class Orga::ProjectsController < Orga::BaseController
     redirect_to [:orga, :projects]
   end
 
+  def pending
+    if @project.start_review!
+      flash[:notice] = "Successfully marked project as pending!"
+    else
+      flash[:alert]  = "There has been an error marking this project as pending."
+    end
+    redirect_to [:orga, :projects]
+  end
+
   def reject
     if @project.reject!
       flash[:notice] = "Project has been rejected!"

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -8,6 +8,8 @@ module ProjectsHelper
                     'label-success'
                   when 'rejected'
                     'label-danger'
+                  when 'pending'
+                    'label-warning'
                   end
     content_tag :span, project.aasm_state, class: "label #{label_class}"
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,13 +21,18 @@ class Project < ActiveRecord::Base
     state :proposed, initial: true
     state :accepted
     state :rejected
+    state :pending
+
+    event :start_review do
+      transitions from: :proposed, to: :pending
+    end
 
     event :accept do
-      transitions from: :proposed, to: :accepted
+      transitions from: :pending, to: :accepted
     end
 
     event :reject do
-      transitions from: :proposed, to: :rejected, after: -> { self.comments_locked = true }
+      transitions from: :pending, to: :rejected, after: -> { self.comments_locked = true }
     end
   end
 

--- a/app/views/orga/projects/index.html.slim
+++ b/app/views/orga/projects/index.html.slim
@@ -10,7 +10,7 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
       th Submitted by
       th State
       th Tags
-      th colspan=3
+      th colspan=5
 
   tbody
     - @projects.each do |project|
@@ -21,11 +21,11 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
         td = project_status project
         td = project_tags project
         td
+          - if project.may_start_review?
+            = link_to 'Start Review', [:pending, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
+        td
           - if project.may_accept?
             = link_to 'Accept', [:accept, :orga, project], method: :put, class: 'btn btn-sm btn-success'
-        td
-          - if project.may_start_review?
-            = link_to 'Pending', [:pending, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
         td
           - if project.may_reject?
             = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger'

--- a/app/views/orga/projects/index.html.slim
+++ b/app/views/orga/projects/index.html.slim
@@ -24,6 +24,9 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
           - if project.may_accept?
             = link_to 'Accept', [:accept, :orga, project], method: :put, class: 'btn btn-sm btn-success'
         td
+          - if project.may_start_review?
+            = link_to 'Pending', [:pending, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
+        td
           - if project.may_reject?
             = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger'
         td
@@ -54,6 +57,8 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
       td
         - if project.may_accept?
           = link_to 'Accept', [:accept, :orga, project], method: :put, class: 'btn btn-sm btn-success'
+        - if project.may_start_review?
+          = link_to 'Pending', [:pending, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
         - if project.may_reject?
           = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger'
     tr

--- a/app/views/orga/projects/index.html.slim
+++ b/app/views/orga/projects/index.html.slim
@@ -22,13 +22,11 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
         td = project_tags project
         td
           - if project.may_start_review?
-            = link_to 'Start Review', [:pending, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
-        td
+            = link_to 'Start review', [:start_review, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
           - if project.may_accept?
             = link_to 'Accept', [:accept, :orga, project], method: :put, class: 'btn btn-sm btn-success'
-        td
           - if project.may_reject?
-            = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger'
+            = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger space_btns'
         td
           - if project.comments_locked?
             = link_to 'Unlock comments', [:unlock, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
@@ -58,7 +56,7 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
         - if project.may_accept?
           = link_to 'Accept', [:accept, :orga, project], method: :put, class: 'btn btn-sm btn-success'
         - if project.may_start_review?
-          = link_to 'Pending', [:pending, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
+          = link_to 'Start review', [:start_review, :orga, project], method: :put, class: 'btn btn-sm btn-warning'
         - if project.may_reject?
           = link_to 'Reject', [:reject, :orga, project], method: :put, class: 'btn btn-sm btn-danger'
     tr

--- a/app/views/orga/projects/index.html.slim
+++ b/app/views/orga/projects/index.html.slim
@@ -10,7 +10,7 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
       th Submitted by
       th State
       th Tags
-      th colspan=5
+      th colspan=3
 
   tbody
     - @projects.each do |project|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
     resources :projects, only: [:index] do
       member do
         put :accept
-        put :pending
+        put :start_review
         put :reject
         put :lock
         put :unlock

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
     resources :projects, only: [:index] do
       member do
         put :accept
+        put :pending
         put :reject
         put :lock
         put :unlock

--- a/spec/controllers/orga/projects_controller_spec.rb
+++ b/spec/controllers/orga/projects_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Orga::ProjectsController do
 
   
     describe 'PUT pending' do
-      it 'start review for accept or reject project' do
+      it 'start review before accept or reject a project' do
         expect { put :pending, params: { id: project.to_param }}.
           to change { project.reload.aasm_state }.to "pending"
         expect(response).to redirect_to [:orga, :projects]

--- a/spec/controllers/orga/projects_controller_spec.rb
+++ b/spec/controllers/orga/projects_controller_spec.rb
@@ -18,30 +18,40 @@ RSpec.describe Orga::ProjectsController do
       end
     end
 
-    shared_examples_for 'deals with proposals' do |action|
+  
+    describe 'PUT pending' do
+      it 'start review for accept or reject project' do
+        expect { put :pending, params: { id: project.to_param }}.
+          to change { project.reload.aasm_state }.to "pending"
+        expect(response).to redirect_to [:orga, :projects]
+        expect(flash[:notice]).to be_present
+      end
+    end
+
+    shared_examples_for 'deals with pending' do |action, state|
+      let(:project) { create :project, :pending }
 
       describe "PUT #{action}" do
-        context 'with an accepted record' do
-          let!(:project) { create :project, :"#{action}ed" }
+        context 'with an pending record' do
           it 'complains and redirects to show' do
             put action, params: { id: project.to_param }
             expect(response).to redirect_to [:orga, :projects]
-            expect(flash[:alert]).to be_present
+            expect(flash[:notice]).to be_present
           end
         end
 
         it "#{action}s and redirect to show" do
           expect {
             put action, params: { id: project.to_param }
-          }.to change { project.reload.aasm_state }.to "#{action}ed"
+          }.to change { project.reload.aasm_state }.to "#{state}"
           expect(response).to redirect_to [:orga, :projects]
           expect(flash[:notice]).to be_present
         end
       end
     end
 
-    it_behaves_like 'deals with proposals', :accept
-    it_behaves_like 'deals with proposals', :reject
+    it_behaves_like 'deals with pending', :accept, :accepted
+    it_behaves_like 'deals with pending', :reject, :rejected
 
     describe 'PUT lock' do
       it 'toggles the comments_locked boolean' do

--- a/spec/controllers/orga/projects_controller_spec.rb
+++ b/spec/controllers/orga/projects_controller_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Orga::ProjectsController do
     end
 
   
-    describe 'PUT pending' do
+    describe 'PUT start_review' do
       it 'start review before accept or reject a project' do
-        expect { put :pending, params: { id: project.to_param }}.
+        expect { put :start_review, params: { id: project.to_param }}.
           to change { project.reload.aasm_state }.to "pending"
         expect(response).to redirect_to [:orga, :projects]
         expect(flash[:notice]).to be_present

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -26,7 +26,5 @@ FactoryGirl.define do
     trait :in_current_season do
       season { Season.current }
     end
-
-    factory :project_pending, traits: [:pending]
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -11,16 +11,23 @@ FactoryGirl.define do
     description { FFaker::HipsterIpsum.paragraph }
     issues_and_features { FFaker::Internet.email }
     beginner_friendly true
-    trait :accepted do
-      after(:create) { |record| record.accept! }
-    end
 
     trait :pending do
       after(:create) { |record| record.start_review! }
     end
 
+    trait :accepted do
+      after(:create) do |record|
+        record.start_review!
+        record.accept!
+      end
+    end
+    
     trait :rejected do
-      after(:create) { |record| record.reject! }
+      after(:create) do |record|
+        record.start_review!
+        record.reject!
+      end
     end
 
     trait :in_current_season do

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -11,7 +11,6 @@ FactoryGirl.define do
     description { FFaker::HipsterIpsum.paragraph }
     issues_and_features { FFaker::Internet.email }
     beginner_friendly true
-
     trait :pending do
       after(:create) { |record| record.start_review! }
     end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -15,6 +15,10 @@ FactoryGirl.define do
       after(:create) { |record| record.accept! }
     end
 
+    trait :pending do
+      after(:create) { |record| record.start_review! }
+    end
+
     trait :rejected do
       after(:create) { |record| record.reject! }
     end
@@ -22,5 +26,7 @@ FactoryGirl.define do
     trait :in_current_season do
       season { Season.current }
     end
+
+    factory :project_pending, traits: [:pending]
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Project do
     end
 
     context 'with a pending project' do
-      subject { create :project_pending }
+      subject { create :project, :pending }
 
       it 'can be accepted' do
         expect(subject).to be_may_accept

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Project do
     context 'with a proposed project' do
       subject { create :project }
 
-      it 'can be start review' do 
+      it 'can be pending' do
         expect(subject).to be_may_start_review
         expect { subject.start_review! }.to \
           change { subject.pending? }.to true

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -47,8 +47,12 @@ RSpec.describe Project do
       it 'can be start review' do 
         expect(subject).to be_may_start_review
         expect { subject.start_review! }.to \
-          change { subject.pending?}.to true
+          change { subject.pending? }.to true
       end
+    end
+
+    context 'with a pending project' do
+      subject { create :project_pending }
 
       it 'can be accepted' do
         expect(subject).to be_may_accept

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe Project do
     context 'with a proposed project' do
       subject { create :project }
 
+      it 'can be start review' do 
+        expect(subject).to be_may_start_review
+        expect { subject.start_review! }.to \
+          change { subject.pending?}.to true
+      end
+
       it 'can be accepted' do
         expect(subject).to be_may_accept
         expect { subject.accept! }.to \


### PR DESCRIPTION
View before changes:
![before_changes](https://user-images.githubusercontent.com/15239141/27866203-d66cd89c-616b-11e7-86e6-8157b27909ba.png)

View after first changes:
![after_changes](https://user-images.githubusercontent.com/15239141/27916387-495ac17e-623f-11e7-8b39-116c69285ba1.png)


View after changing the action column to one:
![only_one_col](https://user-images.githubusercontent.com/15239141/27915621-45cdcb70-623d-11e7-8bee-a654c15f2397.png)


- Include a new state for the project's model (pending)
- Include a new action to change the project to this state (action pending in projects controller)
- Change the reject and accept states to transiting from pending (not from proposed)
- Change the project fixture to transiting to accept and reject only after start_review.