### PR TITLE
Project Page, second try

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -24,7 +24,11 @@ class ProjectsController < ApplicationController
   end
 
   def index
-    @projects = Project.in_current_season.where(aasm_state: %w(accepted proposed))
+    if Season.current.active?
+      @projects = Project.selected
+    else
+      @projects = Project.in_current_season.where(aasm_state: %w(accepted proposed))
+    end
   end
 
   def destroy

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,6 +31,11 @@ class Project < ActiveRecord::Base
     end
   end
 
+  def self.selected
+    project_names = Team.in_current_season.accepted.pluck(:project_name).uniq
+    Project.in_current_season.where(name: project_names)
+  end
+
   def taglist
     tags.join(', ')
   end


### PR DESCRIPTION
The query in the former PR #783 returned an empty table in production. Caused by querying the `applications` table for `project_id`. 
This query (by @klappradla ) does not use the applications table, so should work.
YOLO  