### PR TITLE
Improve projects page (step 1)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -37,8 +37,8 @@ class Project < ActiveRecord::Base
   end
 
   def self.selected
-    project_names = Team.in_current_season.accepted.pluck(:project_name).uniq
-    Project.in_current_season.where(name: project_names)
+    project_names = Team.in_current_season.accepted.pluck(:project_name)
+    Project.in_current_season.accepted.where(name: project_names)
   end
 
   def taglist

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe ProjectsController do
       before { allow(Season).to receive(:active?) { true } }
 
       let!(:proposed) { FactoryGirl.create(:project, season: Season.succ, name: 'proposed project') }
-      let!(:selected) { FactoryGirl.create(:project, :accepted, season: Season.current, name: "selected by a team") }
-      let!(:no_team) { FactoryGirl.create(:project, :in_current_season, :accepted, name: "project without team") }
+      let!(:selected) { FactoryGirl.create(:project, :accepted, :in_current_season, name: "selected by a team") }
+      let!(:no_team) { FactoryGirl.create(:project, :accepted, :in_current_season, name: "project without team") }
       let!(:team) { FactoryGirl.create(:team, :in_current_season, project_name: selected.name) }
 
-      it 'shows selected projects during active Season (≈ May - Sept)' do
+      it 'shows selected projects only' do
         get :index
         expect(response).to be_success
         expect(response.body).to include "selected by a team"


### PR DESCRIPTION
Solves the first part of #784 (Projects Page)
This should provide a robust query for the Projects Page.

doublecheck: 
The ‘new’ projects page uses a filter to only show the projects that students are working on. This filter works during the ‘active’ season, i.e. from the day the acceptance letters are sent, to the end of the coding summer (≈ May through Sept).
The rest of the year the page shows the regular selection, as it was before, i.e. proposed and accepted projects.
- [ ] Is this the behaviour we want? 

ToDO:
- [ ] Remove project_id from applications table => move to separate issue