### PR TITLE
show url just when the field is not empty

### DIFF
--- a/app/views/conferences/_details.html.slim
+++ b/app/views/conferences/_details.html.slim
@@ -6,8 +6,8 @@
     dd = @conference.date_range
     dt Twitter
     dd = format_conference_twitter(@conference.twitter)
-    -if @conference.url
-      dt Homepage
+    dt Homepage
+    -if @conference.url.present?
       dd = link_to @conference.url, @conference.url
     dt Notes
     dd = @conference.notes

--- a/app/views/conferences/_details.html.slim
+++ b/app/views/conferences/_details.html.slim
@@ -6,7 +6,8 @@
     dd = @conference.date_range
     dt Twitter
     dd = format_conference_twitter(@conference.twitter)
-    dt Homepage
-    dd = link_to @conference.url, @conference.url
+    -if @conference.url
+      dt Homepage
+      dd = link_to @conference.url, @conference.url
     dt Notes
     dd = @conference.notes

--- a/app/views/conferences/_table.html.erb
+++ b/app/views/conferences/_table.html.erb
@@ -20,7 +20,7 @@
         <td><%= conference.city %></td>
         <td><%= conference.country %></td>
         <td><%= conference.region %></td>
-        <td><%= link_to conference.url, conference.url if conference.url %></td>
+        <td><%= link_to conference.url, conference.url if conference.url.present? %></td>
         <td><%= conference.notes %></td>
         <td><%= conference.gid %></td>
       </tr>

--- a/app/views/conferences/_table.html.erb
+++ b/app/views/conferences/_table.html.erb
@@ -20,7 +20,7 @@
         <td><%= conference.city %></td>
         <td><%= conference.country %></td>
         <td><%= conference.region %></td>
-        <td><%= link_to conference.url, conference.url %></td>
+        <td><%= link_to conference.url, conference.url if conference.url %></td>
         <td><%= conference.notes %></td>
         <td><%= conference.gid %></td>
       </tr>


### PR DESCRIPTION
PR related with the issue #792

conferences index - before change:
![conf_index_before](https://user-images.githubusercontent.com/15239141/28289035-9c1136a6-6b17-11e7-8b8e-59d2023d8841.png)

conferences index - after change:
![index_after](https://user-images.githubusercontent.com/15239141/28289058-a78b061a-6b17-11e7-9aa9-099146fdb3a3.png)

conference show - before change:
![conference_show_before](https://user-images.githubusercontent.com/15239141/28289086-bc9e2528-6b17-11e7-9e48-e124cf2d02c9.png)

conference show - after change:
![show_after](https://user-images.githubusercontent.com/15239141/28289106-c8201a32-6b17-11e7-9adc-f58d304ea8d2.png)


- verify if URL is present in a conference before display it.

## update in the view (let the label even if the field is empty):


![after_change_including_title](https://user-images.githubusercontent.com/15239141/28318055-bb8c55b4-6b9f-11e7-9e79-73d9e856905e.png)





