### PR TITLE
Change import format from .csv to .tsv

### DIFF
--- a/app/models/conference/importer.rb
+++ b/app/models/conference/importer.rb
@@ -3,18 +3,19 @@ class Conference::Importer
 
   ## This importer is depending on agreed-upon input format.
   ## Input file:
+  # - Input format should be .tsv tab separated values
   # - Dates should be formatted with dd mm yyyy
   # - UID should be unique and formatted with season + id: 2017001
-  # - The headers should not be changed
+  # - The column names should not be changed (extra columns are neglected)
   # Output:
   # - Conferences will be updated or created
-  # - Conferences deleted in the input file, are not removed from the table
-  # - Import errors are logged in a Rails Logger
+  # - Conferences deleted in the input file, will not be removed from the table
+  # - Import errors are logged in Rails Logger
   # - UID is mapped to 'gid' ('google-id' LOL), and has the format: 2017001
 
   class << self
     def call(filename, content_type:)
-      raise ArgumentError, "Oops! I can upload .csv only :-(" unless content_type == "text/csv"
+      raise ArgumentError, "Oops! I can upload .tsv only :-(" unless content_type == "text/tab-separated-values"
       new(filename)
     end
 
@@ -49,7 +50,7 @@ class Conference::Importer
   end
 
   def process_csv
-    CSV.foreach(filename, headers: true, col_sep: ';' ) do |row|
+    CSV.foreach(filename, headers: true, col_sep: '/t' ) do |row|
       begin
         conference = Conference.find_or_initialize_by(gid: row['UID'])
         conference_attributes = {

--- a/app/models/conference/importer.rb
+++ b/app/models/conference/importer.rb
@@ -50,7 +50,7 @@ class Conference::Importer
   end
 
   def process_csv
-    CSV.foreach(filename, headers: true, col_sep: '/t' ) do |row|
+    CSV.foreach(filename, headers: true, col_sep: "\t" ) do |row|
       begin
         conference = Conference.find_or_initialize_by(gid: row['UID'])
         conference_attributes = {

--- a/app/views/orga/conferences/_form.html.erb
+++ b/app/views/orga/conferences/_form.html.erb
@@ -1,7 +1,7 @@
-<h1>Import conferences (.csv only)</h1>
+<h1>Import conferences (.tsv only)</h1>
 <p>Importing will update existing conferences with the data from the csv file</p>
 
 <%= form_tag import_orga_conferences_path, multipart: true, class: "form-inline" do %>
-  <%= file_field_tag :file, accept: '.csv' %>
-  <%= submit_tag "Import csv file", class: "btn btn-default btn-small"  %>
+  <%= file_field_tag :file, accept: '.tsv' %>
+  <%= submit_tag "Import .tsv file", class: "btn btn-default btn-small"  %>
 <% end %>

--- a/spec/controllers/orga/conferences_controller_spec.rb
+++ b/spec/controllers/orga/conferences_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Orga::ConferencesController do
 
     describe 'POST import' do
 
-      let(:file) { fixture_file_upload("spec/fixtures/files/test.csv", 'text/csv') }
+      let(:file) { fixture_file_upload("spec/fixtures/files/test.tsv", 'text/tab-separated-values') }
 
       it 'posts a .csv file' do
         post :import, params: { file: file  }

--- a/spec/fixtures/files/test.csv
+++ b/spec/fixtures/files/test.csv
@@ -1,6 +1,6 @@
 UID;Name;Start date;End date;City;Country;Region;Website;Notes
 2017001;Deccan RubyConf 2017;Aug 12, 17;Aug 12, 17;Gent;Belgium;Europe;http://www.deccanrubyconf.org/;
-2017002;JSFoo 2017;Sep 15, 17;Sep 16, 17;Bangalore;India;Asia Pacific;https://jsfoo.in/2017/;
+2017002;JSFoo 2017;Sep 15, 2017;Sep 16, 2017;Bangalore;India;Asia Pacific;https://jsfoo.in/2017/;
 2017003;;;;Delhi;India;Asia Pacific;https://in.pycon.org/;1st week of Nov (dates are to be defined)
 2017004;GHC India 2017;17/11/2017;15/11/2017;Bangalore;India;Asia Pacific;https://ghcindia.anitaborg.org/;They have student scholarship applications. Deadline: June 30, 2017
 2018005;PyCon Pune 2018;;;Pune;India;Asia Pacific;https://pune.pycon.org/;Dates are to be defined

--- a/spec/fixtures/files/test.tsv
+++ b/spec/fixtures/files/test.tsv
@@ -1,7 +1,7 @@
-UID/tName/tStart date/tEnd date/tCity/tCountry/tRegion/tWebsite/tNotes
-2017001/tDeccan RubyConf 2017/tAug 12, 17/tAug 12, 17/tGent/tBelgium/tEurope/thttp://www.deccanrubyconf.org//t
-2017002/tJSFoo 2017/tSep 15, 17/tSep 16, 17/tBangalore/tIndia/tAsia Pacific/thttps://jsfoo.in/2017//t
-2017003/t/t/t/tDelhi/tIndia/tAsia Pacific/thttps://in.pycon.org//t1st week of Nov (dates are to be defined)
-2017004/tGHC India 2017/t17/11/2017/t15/11/2017/tBangalore/tIndia/tAsia Pacific/thttps://ghcindia.anitaborg.org//tThey have student scholarship applications. Deadline: June 30, 2017
-2018005/tPyCon Pune 2018/t/t/tPune/tIndia/tAsia Pacific/thttps://pune.pycon.org//tDates are to be defined
-2017006/tCheesyRuby/t07/07/2017/t15/07/2017/tAmsterdam/tNL/tEurope/twww.example.com/tDuly Noted
+UID	Name	Start date	End date	City	Country	Region	Website	Notes
+2017001	Deccan RubyConf 2017	Aug 12, 2017	Aug 12, 2017	Gent	Belgium	Europe	http://www.deccanrubyconf.org/
+2017002	JSFoo 2017	Sep 15, 2017	Sep 16, 2017	Bangalore	India	Asia Pacific	https://jsfoo.in/2017/
+2017003				Delhi	India	Asia Pacific	https://in.pycon.org/	1st week of Nov (dates are to be defined)
+2017004	GHC India 2017	17/11/2017	15/11/2017	Bangalore	India	Asia Pacific	https://ghcindia.anitaborg.org/	They have student scholarship applications. Deadline: June 30, 2017
+2018005	PyCon Pune 2018			Pune	India	Asia Pacific	https://pune.pycon.org/	Dates are to be defined
+2017006	CheesyRuby	07/07/2017	15/07/2017	Amsterdam	NL	Europe	www.example.com	Duly Noted

--- a/spec/fixtures/files/test.tsv
+++ b/spec/fixtures/files/test.tsv
@@ -1,0 +1,7 @@
+UID/tName/tStart date/tEnd date/tCity/tCountry/tRegion/tWebsite/tNotes
+2017001/tDeccan RubyConf 2017/tAug 12, 17/tAug 12, 17/tGent/tBelgium/tEurope/thttp://www.deccanrubyconf.org//t
+2017002/tJSFoo 2017/tSep 15, 17/tSep 16, 17/tBangalore/tIndia/tAsia Pacific/thttps://jsfoo.in/2017//t
+2017003/t/t/t/tDelhi/tIndia/tAsia Pacific/thttps://in.pycon.org//t1st week of Nov (dates are to be defined)
+2017004/tGHC India 2017/t17/11/2017/t15/11/2017/tBangalore/tIndia/tAsia Pacific/thttps://ghcindia.anitaborg.org//tThey have student scholarship applications. Deadline: June 30, 2017
+2018005/tPyCon Pune 2018/t/t/tPune/tIndia/tAsia Pacific/thttps://pune.pycon.org//tDates are to be defined
+2017006/tCheesyRuby/t07/07/2017/t15/07/2017/tAmsterdam/tNL/tEurope/twww.example.com/tDuly Noted

--- a/spec/models/conference/importer_spec.rb
+++ b/spec/models/conference/importer_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Conference::Importer do
     # valid: 2017001, 2017002, *2018*005 and 2017006 .
     # invalid: 2017003: no name, 2017004: start date later than end date
 
-    let!(:file) { "spec/fixtures/files/test.csv" }
+    let!(:file) { "spec/fixtures/files/test.tsv" }
 
     subject { described_class.call(file, content_type: content_type) }
 
     context 'with valid file' do
-      let(:content_type) { 'text/csv' }
+      let(:content_type) { 'text/tab-separated-values' }
 
       it 'imports the valid conferences' do
         expect{subject}.to change { Conference.count }.from(0).to(4)
@@ -53,7 +53,7 @@ RSpec.describe Conference::Importer do
       end
     end
 
-    context 'with non-csv file' do
+    context 'with non-tsv file' do
       let(:content_type) { 'application/json' }
 
       it 'raises an error with other mime_type' do


### PR DESCRIPTION
Maria reported problems with uploading a .csv file in production., from a Google Spreadsheet export.
Google doesn't allow to override the column separator, other than choosing 'csv' or 'tsv'.
After changing the `col_sep` option to `','` , for Maria the date format with comma's inside ('Aug 7, 2017') did not cause problems, but on my computer, the comma inside was read as an extra separator. 

The safest solution is to use the tab separated values content type.

@carpodaster Do you agree?
(And look how easy the `content_type` changes were!  🙏  )