### PR TITLE
Stop truncating the latest status update 

### DIFF
--- a/app/views/supervisor/dashboard/index.html.slim
+++ b/app/views/supervisor/dashboard/index.html.slim
@@ -53,7 +53,7 @@ div.row
           - if t.activities.any?
             p = "Their latest update is from #{ time_ago_in_words(t.last_activity.created_at) } ago."
             h5 = t.last_activity.title
-            p = (t.last_activity.content).html_safe
+            p = t.last_activity.content.html_safe
             = link_to "Show all", activities_path(team_id: t.id)
           - else
             p Your team hasn't written any status updates yet.

--- a/app/views/supervisor/dashboard/index.html.slim
+++ b/app/views/supervisor/dashboard/index.html.slim
@@ -53,7 +53,7 @@ div.row
           - if t.activities.any?
             p = "Their latest update is from #{ time_ago_in_words(t.last_activity.created_at) } ago."
             h5 = t.last_activity.title
-            p = truncate((t.last_activity.content).html_safe, length: 220)
-              = link_to " Show all", activities_path(team_id: t.id)
+            p = (t.last_activity.content).html_safe
+            = link_to "Show all", activities_path(team_id: t.id)
           - else
             p Your team hasn't written any status updates yet.


### PR DESCRIPTION
Supervisors reported: not happy that we need to click to  read the latest update.
Solved by removing the truncation on the latest updated.

<img width="1194" alt="screen shot 2017-07-21 at 14 14 02" src="https://user-images.githubusercontent.com/6314687/28463306-0ef20faa-6e20-11e7-8265-2ddf84cd8d20.png">