### PR TITLE
Conferences/add new conference

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -3,7 +3,6 @@ class ConferencesController < ApplicationController
   before_action :confirm_role, except: [:index, :show]
 
   def new
-    @team_id = params[:team_id]
     @conference = Conference.new
   end
 
@@ -16,7 +15,7 @@ class ConferencesController < ApplicationController
   end
 
   def create
-    team = Team.find(params[:team_id])
+    team = current_user.student_team
     @conference = Conference.new(conference_params)
     @conference.season_id = current_season.id
     @conference.gid = generate_gid(team)

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -1,5 +1,6 @@
 class ConferencesController < ApplicationController
- before_action :redirect, except: [:index, :show, :new, :create]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :confirm_role, except: [:index, :show]
 
   def new
     @conference = Conference.new
@@ -46,6 +47,10 @@ class ConferencesController < ApplicationController
     params.require(:conference).permit(
       :name, :twitter, :starts_on, :ends_on, :notes, :country, :region, :location, :city, :url, :season_id
     )
+  end
+
+  def confirm_role
+    redirect unless current_user.admin? || current_user.student?
   end
 
   def sort_params

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -35,8 +35,8 @@ class ConferencesController < ApplicationController
 
   private
 
-  def generate_gid(conference)
-    conference.gid = Time.now.getutc
+  def generate_gid(team)
+    "2017-#{Time.now.getutc.to_i}-#{team.id}"
   end
  
   def conferences

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -3,6 +3,7 @@ class ConferencesController < ApplicationController
   before_action :confirm_role, except: [:index, :show]
 
   def new
+    @team_id = params[:team]
     @conference = Conference.new
   end
 
@@ -17,11 +18,12 @@ class ConferencesController < ApplicationController
   def create
     @conference = Conference.new(conference_params)
     generate_gid(@conference)
+    @team = Team.find(params[:team_id])
 
     respond_to do |format|
       if @conference.save
-        format.html { redirect_to params[:redirect_to].presence || @conference, notice: 'Conference was successfully created.' }
-        format.json { render action: :show, status: :created, location: @conference }
+        format.html { redirect_to params[:redirect_to].presence || edit_team_path(@team), notice: 'Conference was successfully created.' }
+        format.json { render action: :edit, status: :created, location: @team }
       else
         format.html { render action: :new }
         format.json { render json: @conference.errors, status: :unprocessable_entity }

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -18,6 +18,7 @@ class ConferencesController < ApplicationController
   def create
     team = Team.find(params[:team_id])
     @conference = Conference.new(conference_params)
+    @conference.season_id = current_season.id
     @conference.gid = generate_gid(team)
 
     if @conference.save
@@ -44,7 +45,7 @@ class ConferencesController < ApplicationController
 
   def conference_params
     params.require(:conference).permit(
-      :name, :twitter, :starts_on, :ends_on, :notes, :country, :region, :location, :city, :url, :season_id
+      :name, :twitter, :starts_on, :ends_on, :notes, :country, :region, :location, :city, :url
     )
   end
 

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -23,7 +23,6 @@ class ConferencesController < ApplicationController
     if @conference.save
       redirect_to edit_team_path(team), notice: 'Conference was successfully created.'
     else
-      @team_id = team.id
       render action: :new
     end
   end

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -34,7 +34,7 @@ class ConferencesController < ApplicationController
   private
 
   def generate_gid(team)
-    "2017-#{Time.now.getutc.to_i}-#{team.id}"
+    "#{Season.current.name}-#{Time.now.getutc.to_i}-#{team.id}"
   end
  
   def conferences

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -16,13 +16,14 @@ class ConferencesController < ApplicationController
   end
 
   def create
+    team = Team.find(params[:team_id])
     @conference = Conference.new(conference_params)
-    generate_gid(@conference)
-    @team = Team.find(params[:team_id])
+    @conference.gid = generate_gid(team)
 
     if @conference.save
-      redirect_to edit_team_path(@team), notice: 'Conference was successfully created.'
+      redirect_to edit_team_path(team), notice: 'Conference was successfully created.'
     else
+      @team_id = team.id
       render action: :new
     end
   end

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -1,5 +1,5 @@
 class ConferencesController < ApplicationController
- before_action :redirect, except: [:index, :show, :new]
+ before_action :redirect, except: [:index, :show, :new, :create]
 
   def new
     @conference = Conference.new
@@ -13,14 +13,37 @@ class ConferencesController < ApplicationController
     @conference = Conference.find(params[:id])
   end
 
+  def create
+    @conference = Conference.new(conference_params)
+    respond_to do |format|
+      if @conference.save
+        format.html { redirect_to params[:redirect_to].presence || @conference, notice: 'Conference was successfully created.' }
+        format.json { render action: :show, status: :created, location: @conference }
+      else
+        format.html { render action: :new }
+        format.json { render json: @conference.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
   def redirect
     redirect_to orga_conferences_path
   end
 
   private
+
+  def generate_gid(conference)
+    conference.gid = year + 
+  end
  
   def conferences
     Conference.ordered(sort_params).in_current_season
+  end
+
+  def conference_params
+    params.require(:conference).permit(
+      :name, :twitter, :starts_on, :ends_on, :notes, :country, :region, :location, :city, :url
+    )
   end
 
   def sort_params

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -43,7 +43,6 @@ class ConferencesController < ApplicationController
   end
 
   def conference_params
-    byebug
     params.require(:conference).permit(
       :name, :twitter, :starts_on, :ends_on, :notes, :country, :region, :location, :city, :url, :season_id
     )

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -3,7 +3,7 @@ class ConferencesController < ApplicationController
   before_action :confirm_role, except: [:index, :show]
 
   def new
-    @team_id = params[:team]
+    @team_id = params[:team_id]
     @conference = Conference.new
   end
 

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -15,6 +15,8 @@ class ConferencesController < ApplicationController
 
   def create
     @conference = Conference.new(conference_params)
+    generate_gid(@conference)
+
     respond_to do |format|
       if @conference.save
         format.html { redirect_to params[:redirect_to].presence || @conference, notice: 'Conference was successfully created.' }
@@ -33,7 +35,7 @@ class ConferencesController < ApplicationController
   private
 
   def generate_gid(conference)
-    conference.gid = year + 
+    conference.gid = Time.now.getutc
   end
  
   def conferences
@@ -41,8 +43,9 @@ class ConferencesController < ApplicationController
   end
 
   def conference_params
+    byebug
     params.require(:conference).permit(
-      :name, :twitter, :starts_on, :ends_on, :notes, :country, :region, :location, :city, :url
+      :name, :twitter, :starts_on, :ends_on, :notes, :country, :region, :location, :city, :url, :season_id
     )
   end
 

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -1,7 +1,8 @@
 class ConferencesController < ApplicationController
- before_action :redirect, except: [:index, :show]
+ before_action :redirect, except: [:index, :show, :new]
 
   def new
+    @conference = Conference.new
   end
 
   def index

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -20,14 +20,10 @@ class ConferencesController < ApplicationController
     generate_gid(@conference)
     @team = Team.find(params[:team_id])
 
-    respond_to do |format|
-      if @conference.save
-        format.html { redirect_to params[:redirect_to].presence || edit_team_path(@team), notice: 'Conference was successfully created.' }
-        format.json { render action: :edit, status: :created, location: @team }
-      else
-        format.html { render action: :new }
-        format.json { render json: @conference.errors, status: :unprocessable_entity }
-      end
+    if @conference.save
+      redirect_to edit_team_path(@team), notice: 'Conference was successfully created.'
+    else
+      render action: :new
     end
   end
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -12,7 +12,8 @@ class Conference < ActiveRecord::Base
     "Asia Pacific"
   ]
 
-  validates :name, presence: true
+  validates :name, :url, :city, :country, :region, presence: true
+
   validate :chronological_dates, if: proc { |conf| conf.starts_on && conf.ends_on }
 
   accepts_nested_attributes_for :conference_preferences

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -4,6 +4,14 @@ class Conference < ActiveRecord::Base
 
   has_many :conference_preferences, dependent: :destroy
   has_many :attendees, through: :conference_preferences, source: :team
+  REGION_LIST = [
+    "Africa",
+    "South America",
+    "North America",
+    "Europe",
+    "Asia Pacific"
+  ]
+
   validates :name, presence: true
   validate :chronological_dates, if: proc { |conf| conf.starts_on && conf.ends_on }
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,9 +1,5 @@
 require 'csv'
 class Conference < ActiveRecord::Base
-  include HasSeason
-
-  has_many :conference_preferences, dependent: :destroy
-  has_many :attendees, through: :conference_preferences, source: :team
   REGION_LIST = [
     "Africa",
     "South America",
@@ -11,6 +7,11 @@ class Conference < ActiveRecord::Base
     "Europe",
     "Asia Pacific"
   ]
+
+  include HasSeason
+
+  has_many :conference_preferences, dependent: :destroy
+  has_many :attendees, through: :conference_preferences, source: :team
 
   validates :name, :url, :city, :country, :region, presence: true
 

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -17,7 +17,6 @@ h1.page-header Create a new conference
   .page-header
    h2 Conference info
   fieldset
-   = hidden_field_tag :team_id, @team_id
    = f.input :name, required: true,placeholder: 'Conference name', wrapper_html: { class: 'col-md-12' }
    = f.input :url, required: true, placeholder: 'Conference website', wrapper_html: { class: 'col-md-12' }
    = f.input :twitter, placeholder: '@', wrapper_html: { class: 'col-md-12' }

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -3,9 +3,6 @@ nav.page
     ul
       li = icon('chevron-left')
       li = link_to 'Back', class: 'back'
-nav.actions
-  ul.list-inline
-    li = link_to 'Cancel', class: 'btn btn-default btn-sm'
 
 h1.page-header Create a new conference
 
@@ -29,10 +26,11 @@ h1.page-header Create a new conference
   .page-header
    h2 Conference location
   fieldset
-    = f.input :location, placeholder: 'Conference location', wrapper_html: { class: 'col-md-6' }
-    = f.input :city, placeholder: 'Conference city', wrapper_html: { class: 'col-md-6' }
     = f.input :country, required: true, as: :country, prompt: "Select the country", wrapper_html: { class: 'col-md-6' }
-    = f.input :region, placeholder: 'Conference region', wrapper_html: { class: 'col-md-6' }
+    = f.input :region, required: true, collection: Conference::REGION_LIST, prompt: 'Select the conference region', wrapper_html: { class: 'col-md-6' }
+    = f.input :location, required: true, placeholder: 'Conference location', wrapper_html: { class: 'col-md-6' }
+    = f.input :city, required: true, placeholder: 'Conference city', wrapper_html: { class: 'col-md-6' }
+   
 
   .page-header
    h2 Conference details

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -18,7 +18,6 @@ h1.page-header Create a new conference
    h2 Conference info
   fieldset
    = hidden_field_tag :team_id, @team_id
-   = f.hidden_field :season_id, value: current_season.id
    = f.input :name, required: true,placeholder: 'Conference name', wrapper_html: { class: 'col-md-12' }
    = f.input :url, required: true, placeholder: 'Conference website', wrapper_html: { class: 'col-md-12' }
    = f.input :twitter, placeholder: '@', wrapper_html: { class: 'col-md-12' }

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -17,6 +17,7 @@ h1.page-header Create a new conference
   .page-header
    h2 Conference info
   fieldset
+   = f.hidden_field :season_id, value: current_season.id
    = f.input :name, wrapper_html: { class: 'col-md-6' }
    = f.input :twitter, placeholder: '@', wrapper_html: { class: 'col-md-6' }
    = f.input :starts_on, as: :string, input_html: {type: :date}, label: 'Conference start date', wrapper_html: { class: 'col-md-6' }

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -1,0 +1,45 @@
+nav.page
+  .back-nav
+    ul
+      li = icon('chevron-left')
+      li = link_to 'Back', class: 'back'
+nav.actions
+  ul.list-inline
+    li = link_to 'Cancel', class: 'btn btn-default btn-sm'
+
+h1.page-header Create a new conference
+
+= simple_nested_form_for @conference do |f|
+  - if @conference.errors.any?
+    .alert.alert-danger
+      h4 = "#{pluralize(@conference.errors.count, "error")} prohibited this conference from being saved:"
+      ul
+        - @conference.errors.full_messages.each do |message|
+          li = message
+
+  .page-header
+   h2 Conference info
+  fieldset
+   = f.input :name, wrapper_html: { class: 'col-md-6' }
+   = f.input :twitter, placeholder: '@', wrapper_html: { class: 'col-md-6' }
+   = f.input :starts_on, as: :string, input_html: {type: :date}, label: 'Conference start date', wrapper_html: { class: 'col-md-6' }
+   = f.input :ends_on, as: :string, input_html: {type: :date}, label: 'Conference end date', wrapper_html: { class: 'col-md-6' }
+   = f.input :notes, placeholder: 'Conference notes', label: 'Conference notes', wrapper_html: { class: 'col-md-12' }
+
+  .page-header
+   h2 Conference location
+  fieldset
+    = f.input :location, placeholder: 'Conference location', wrapper_html: { class: 'col-md-6' }
+    = f.input :city, placeholder: 'Conference city', wrapper_html: { class: 'col-md-6' }
+    = f.input :country, required: true, as: :country, prompt: "Select the country", wrapper_html: { class: 'col-md-6' }
+    = f.input :region, placeholder: 'Conference region', wrapper_html: { class: 'col-md-6' }
+
+  .page-header
+   h2 Conference details
+  fieldset
+   = f.input :url, placeholder: 'Conference page', wrapper_html: { class: 'col-md-12' }
+
+  .actions
+    ul.list-inline
+      li = f.submit 'Save', class: 'btn btn-success'
+      li = link_to 'Cancel', @conference, class: 'btn btn-default'

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -2,7 +2,7 @@ nav.page
   .back-nav
     ul
       li = icon('chevron-left')
-      li = link_to 'Back', class: 'back'
+      li = link_to 'Conferences', class: 'back'
 
 h1.page-header Create a new conference
 

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -35,4 +35,3 @@ h1.page-header Create a new conference
   .actions
     ul.list-inline
       li = f.submit 'Save', class: 'btn btn-success'
-      li = link_to 'Cancel', @conference, class: 'btn btn-default'

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -17,6 +17,7 @@ h1.page-header Create a new conference
   .page-header
    h2 Conference info
   fieldset
+   = hidden_field_tag :team_id, @team_id
    = f.hidden_field :season_id, value: current_season.id
    = f.input :name, required: true,placeholder: 'Conference name', wrapper_html: { class: 'col-md-12' }
    = f.input :url, required: true, placeholder: 'Conference website', wrapper_html: { class: 'col-md-12' }

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -18,10 +18,10 @@ h1.page-header Create a new conference
    h2 Conference info
   fieldset
    = f.hidden_field :season_id, value: current_season.id
-   = f.input :name, wrapper_html: { class: 'col-md-6' }
-   = f.input :twitter, placeholder: '@', wrapper_html: { class: 'col-md-6' }
-   = f.input :starts_on, as: :string, input_html: {type: :date}, label: 'Conference start date', wrapper_html: { class: 'col-md-6' }
-   = f.input :ends_on, as: :string, input_html: {type: :date}, label: 'Conference end date', wrapper_html: { class: 'col-md-6' }
+   = f.input :name, required: true, wrapper_html: { class: 'col-md-12' }
+   = f.input :twitter, placeholder: '@', wrapper_html: { class: 'col-md-12' }
+   = f.input :starts_on, as: :date, html5: true, required: true, label: 'Conference start date', wrapper_html: { class: 'col-md-6' }
+   = f.input :ends_on, as: :date, html5: true, required: true, label: 'Conference end date', wrapper_html: { class: 'col-md-6' }
    = f.input :notes, placeholder: 'Conference notes', label: 'Conference notes', wrapper_html: { class: 'col-md-12' }
 
   .page-header

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -2,7 +2,7 @@ nav.page
   .back-nav
     ul
       li = icon('chevron-left')
-      li = link_to 'Conferences', class: 'back'
+      li = link_to 'Conferences', conferences_path, class: 'back'
 
 h1.page-header Create a new conference
 

--- a/app/views/conferences/new.html.slim
+++ b/app/views/conferences/new.html.slim
@@ -18,26 +18,20 @@ h1.page-header Create a new conference
    h2 Conference info
   fieldset
    = f.hidden_field :season_id, value: current_season.id
-   = f.input :name, required: true, wrapper_html: { class: 'col-md-12' }
+   = f.input :name, required: true,placeholder: 'Conference name', wrapper_html: { class: 'col-md-12' }
+   = f.input :url, required: true, placeholder: 'Conference website', wrapper_html: { class: 'col-md-12' }
    = f.input :twitter, placeholder: '@', wrapper_html: { class: 'col-md-12' }
    = f.input :starts_on, as: :date, html5: true, required: true, label: 'Conference start date', wrapper_html: { class: 'col-md-6' }
    = f.input :ends_on, as: :date, html5: true, required: true, label: 'Conference end date', wrapper_html: { class: 'col-md-6' }
-   = f.input :notes, placeholder: 'Conference notes', label: 'Conference notes', wrapper_html: { class: 'col-md-12' }
+   = f.input :notes, label: 'Conference notes', wrapper_html: { class: 'col-md-12' }
 
   .page-header
    h2 Conference location
   fieldset
-    = f.input :country, required: true, as: :country, prompt: "Select the country", wrapper_html: { class: 'col-md-6' }
-    = f.input :region, required: true, collection: Conference::REGION_LIST, prompt: 'Select the conference region', wrapper_html: { class: 'col-md-6' }
-    = f.input :location, required: true, placeholder: 'Conference location', wrapper_html: { class: 'col-md-6' }
-    = f.input :city, required: true, placeholder: 'Conference city', wrapper_html: { class: 'col-md-6' }
+    = f.input :country, required: true, as: :country, prompt: "Conference country", wrapper_html: { class: 'col-md-12' }
+    = f.input :region, required: true, collection: Conference::REGION_LIST, prompt: 'Conference region', wrapper_html: { class: 'col-md-12' }
+    = f.input :city, required: true, placeholder: 'Conference city', wrapper_html: { class: 'col-md-12' }
    
-
-  .page-header
-   h2 Conference details
-  fieldset
-   = f.input :url, placeholder: 'Conference page', wrapper_html: { class: 'col-md-12' }
-
   .actions
     ul.list-inline
       li = f.submit 'Save', class: 'btn btn-success'

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -77,7 +77,7 @@
       = f.simple_fields_for :conference_preferences, f.object.conference_preferences.sort{ |a,b| a.option <=> b.option} do |c|
         = c.hidden_field :option, value: c.object.option
         = c.input :conference_id, collection: @conferences.group_by(&:region), as: :grouped_select, group_method: :last, label: c.object.option == 1 ? "Primary choice" : "Secondary Choice", prompt: "Conference", wrapper_html: { class: 'col-md-8' }
-    = link_to 'I want to suggest another conference!', new_conference_path(team: @team.id), class: 'btn btn-primary col-sm-offset-3'
+    = link_to 'I want to suggest another conference!', new_conference_path(team_id: @team.id), data: { confirm: 'You are leaving the page, all your alterations will be lost. Do you want to continue?' }, class: 'btn btn-primary col-sm-offset-3'
 
   .actions
     ul.list-inline

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -77,7 +77,7 @@
       = f.simple_fields_for :conference_preferences, f.object.conference_preferences.sort{ |a,b| a.option <=> b.option} do |c|
         = c.hidden_field :option, value: c.object.option
         = c.input :conference_id, collection: @conferences.group_by(&:region), as: :grouped_select, group_method: :last, label: c.object.option == 1 ? "Primary choice" : "Secondary Choice", prompt: "Conference", wrapper_html: { class: 'col-md-8' }
-    = link_to 'I want to suggest another conference!', new_conference_path(team_id: @team.id), data: { confirm: 'You are leaving the page, all your alterations will be lost. Do you want to continue?' }, class: 'btn btn-primary col-sm-offset-3'
+    = link_to 'I want to suggest another conference!', new_conference_path, data: { confirm: 'You are leaving the page, all your alterations will be lost. Do you want to continue?' }, class: 'btn btn-primary col-sm-offset-3'
 
   .actions
     ul.list-inline

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -77,6 +77,7 @@
       = f.simple_fields_for :conference_preferences, f.object.conference_preferences.sort{ |a,b| a.option <=> b.option} do |c|
         = c.hidden_field :option, value: c.object.option
         = c.input :conference_id, collection: @conferences.group_by(&:region), as: :grouped_select, group_method: :last, label: c.object.option == 1 ? "Primary choice" : "Secondary Choice", prompt: "Conference", wrapper_html: { class: 'col-md-8' }
+    = link_to 'I want to suggest another conference!', new_conference_path, class: 'btn btn-primary col-sm-offset-3'
 
   .actions
     ul.list-inline

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -77,7 +77,7 @@
       = f.simple_fields_for :conference_preferences, f.object.conference_preferences.sort{ |a,b| a.option <=> b.option} do |c|
         = c.hidden_field :option, value: c.object.option
         = c.input :conference_id, collection: @conferences.group_by(&:region), as: :grouped_select, group_method: :last, label: c.object.option == 1 ? "Primary choice" : "Secondary Choice", prompt: "Conference", wrapper_html: { class: 'col-md-8' }
-    = link_to 'I want to suggest another conference!', new_conference_path, class: 'btn btn-primary col-sm-offset-3'
+    = link_to 'I want to suggest another conference!', new_conference_path(team: @team.id), class: 'btn btn-primary col-sm-offset-3'
 
   .actions
     ul.list-inline

--- a/app/views/teams/_table.html.slim
+++ b/app/views/teams/_table.html.slim
@@ -7,8 +7,6 @@ table.table.table-striped.table-bordered.table-condensed
     th Name
     - @display_roles.each do |role|
       th = role.capitalize
-    - if current_season.active?
-      th Conferences
     th Location
     - if current_user.try :admin?
       th Last checked
@@ -27,8 +25,6 @@ table.table.table-striped.table-bordered.table-condensed
               li.user
                 = avatar_url(user, size: 20)
                 = link_to(user.name_or_handle, user)
-      - if current_season.active?
-        td = links_to_conferences(team.conferences.in_current_season).join(', ').html_safe
       td = team.students_location
       - if current_user.try :admin?
         td = format_date(team.last_checked_at)

--- a/db/migrate/20170727145559_change_data_type_for_gid.rb
+++ b/db/migrate/20170727145559_change_data_type_for_gid.rb
@@ -1,0 +1,12 @@
+class ChangeDataTypeForGid < ActiveRecord::Migration[5.1]
+  def self.up
+    change_table :conferences do |t|
+      t.change :gid, :string
+    end
+  end
+  def self.down
+    change_table :conferences do |t|
+      t.change :gid, :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170720135154) do
+ActiveRecord::Schema.define(version: 20170727145559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 20170720135154) do
     t.integer "round", default: 1
     t.boolean "lightningtalkslots"
     t.integer "season_id"
-    t.integer "gid"
+    t.string "gid"
     t.string "city"
     t.string "country"
     t.string "region"

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -24,10 +24,30 @@ RSpec.describe ConferencesController do
   end
 
   describe 'new' do
-    it 'redirects unauthorized users' do
-      get :new
-      expect(response).to redirect_to orga_conferences_path
-      expect(Conference).to_not receive(:create)
+    context 'unauthenticated users' do
+      it 'cannot create new conference' do
+        get :new
+        expect(response).to redirect_to(root_url)
+      end
+    end
+
+    context 'student logged in' do
+      let!(:student) { FactoryGirl.create(:student) }
+      before :each do
+        sign_in student
+      end
+
+      it 'are allowed to visit a new conference view' do
+        get :new
+        expect(response).to render_template("new")
+      end
+
+      it 'are allowed to create a new conference' do
+        expect{
+          post :create, params: { conference: {name: 'name', country: 'country', region: 'region', location: 'location', city: 'city', season_id:'1'}}
+        }.to change { Conference.count }.by(1)
+        expect(response).to redirect_to(conference_path(1))
+      end
     end
   end
 end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe ConferencesController do
 
     context 'student logged in' do
       let!(:student) { FactoryGirl.create(:student) }
+      let(:team) { student.student_team }
       before :each do
         sign_in student
       end
@@ -44,9 +45,9 @@ RSpec.describe ConferencesController do
 
       it 'are allowed to create a new conference' do
         expect{
-          post :create, params: { conference: {name: 'name', country: 'country', region: 'region', location: 'location', city: 'city', season_id:'1'}}
+          post :create, params: { team_id: team.id ,conference: {name: 'name', country: 'country', region: 'region', location: 'location', city: 'city', season_id:'1'}}
         }.to change { Conference.count }.by(1)
-        expect(response).to redirect_to(conference_path(1))
+        expect(response).to redirect_to(edit_team_path(team.id))
       end
     end
   end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -45,7 +45,13 @@ RSpec.describe ConferencesController do
 
       it 'are allowed to create a new conference' do
         expect{
-          post :create, params: { team_id: team.id ,conference: {name: 'name', country: 'country', region: 'region', location: 'location', city: 'city', season_id:'1'}}
+          post :create,
+          params: {
+            team_id: team.id,
+            conference: {
+              name: 'name', country: 'country', region: 'region', location: 'location', city: 'city', season_id:'1', url: 'www.conference.com'
+              }
+            }
         }.to change { Conference.count }.by(1)
         expect(response).to redirect_to(edit_team_path(team.id))
       end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe ConferencesController do
     context 'student logged in' do
       let!(:student) { FactoryGirl.create(:student) }
       let(:team) { student.student_team }
+      let(:params) { { name: 'name', country: 'country', region: 'region', location: 'location', city: 'city', season_id:'1', url: 'www.conference.com' } }
+
       before :each do
         sign_in student
       end
@@ -46,12 +48,7 @@ RSpec.describe ConferencesController do
       it 'are allowed to create a new conference' do
         expect{
           post :create,
-          params: {
-            team_id: team.id,
-            conference: {
-              name: 'name', country: 'country', region: 'region', location: 'location', city: 'city', season_id:'1', url: 'www.conference.com'
-              }
-            }
+          params: { conference: params }
         }.to change { Conference.count }.by(1)
         expect(response).to redirect_to(edit_team_path(team.id))
       end

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -1,8 +1,12 @@
 FactoryGirl.define do
   factory :conference do
     name { [FFaker::CheesyLingo.title, 'Conf'].join ' ' }
+    url { FFaker::Internet.http_url }
     starts_on { Time.utc(Date.today.year, 7, 7) }
     ends_on { Time.utc(Date.today.year, 7, 15) }
+    city { FFaker::Address.city }
+    country { FFaker::Address.country }
+    region { 'Africa' }
     round 1
 
     trait :in_current_season do

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     ends_on { Time.utc(Date.today.year, 7, 15) }
     city { FFaker::Address.city }
     country { FFaker::Address.country }
-    region { 'Africa' }
+    region 'Africa'
     round 1
 
     trait :in_current_season do

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Conference do
   it { is_expected.to have_many(:conference_preferences).dependent(:destroy) }
   it { is_expected.to have_many(:attendees) }
   it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:url) }
+  it { is_expected.to validate_presence_of(:city) }
+  it { is_expected.to validate_presence_of(:country) }
+  it { is_expected.to validate_presence_of(:region) }
 
   describe 'validates chronological dates' do
     subject { FactoryGirl.build(:conference) }


### PR DESCRIPTION
PR related with the issue #766 - Allow student to add a new conference in the conference long list

- Include a form for conference/new
- Include actions new and create in conference controller
- Remove the redirect (before action)
- Include authentication and confirm the allowed roles to include new conference (before action)
- Include controller tests

## New conference form:
![conference_new](https://user-images.githubusercontent.com/15239141/28579327-b90c6cf0-7132-11e7-9c96-345a3f0d9bd7.png)

## Edit team page with a button to add new conference:

![link_to_add_conf](https://user-images.githubusercontent.com/15239141/28579343-ca1b137a-7132-11e7-90c8-6a0b01fa24dc.png)

