### PR TITLE
Conference/add link

### DIFF
--- a/app/views/teams/_conference_preference_fields.html.slim
+++ b/app/views/teams/_conference_preference_fields.html.slim
@@ -1,6 +1,7 @@
 .page-header
   h2 Conferences
   h3 Conference Preferences
+  = link_to 'More info about the conferences', conferences_path
 fieldset.conferences_fieldset
   = f.simple_fields_for :conference_preference do |c|
     = c.input :first_conference_id, collection: @conferences.group_by(&:region), as: :grouped_select, group_method: :last, label: "Primary choice", include_blank: "Conference"

--- a/app/views/teams/_conference_preference_fields.html.slim
+++ b/app/views/teams/_conference_preference_fields.html.slim
@@ -4,8 +4,8 @@
   = link_to 'More info about the conferences', conferences_path
 fieldset.conferences_fieldset
   = f.simple_fields_for :conference_preference do |c|
-    = c.input :first_conference_id, collection: @conferences.group_by(&:region), as: :grouped_select, group_method: :last, label: "Primary choice", include_blank: "Conference"
-    = c.input :second_conference_id, collection: @conferences.group_by(&:region), as: :grouped_select, group_method: :last, label: "Secondary choice", include_blank: "Conference"
+    = c.input :first_conference_id, collection: @conferences.group_by(&:region), as: :grouped_select, group_method: :last, label: "Primary choice", include_blank: "None"
+    = c.input :second_conference_id, collection: @conferences.group_by(&:region), as: :grouped_select, group_method: :last, label: "Secondary choice", include_blank: "None"
     .form-group.form-btn-group
       = link_to new_conference_path, data: { confirm: 'You are leaving the page, all , your alterations will be lost. Do you want to continue?' }, class: 'btn btn-primary col-sm-offset-3' do
         | We want to suggest another conference!
@@ -21,9 +21,9 @@ fieldset.conferences_fieldset
       .col-sm-9
         .checkbox
           label
-            = c.check_box :terms_of_ticket, checked: conference_exists_for?(@team)
+            = c.check_box :terms_of_ticket
             | We understand that RGSoC doesn't guarantee tickets to the conferences of our choice
         .checkbox
           label
-            = c.check_box :terms_of_travel, checked: conference_exists_for?(@team)
+            = c.check_box :terms_of_travel
             | We understand that all travel and accommodation costs will have to be covered by us; hereby we confirm that we are choosing conferences which we can afford


### PR DESCRIPTION
- Add a link to conference details into conference block
- Return the 'none' name to the conference edit page
- Remove the helper to check a terms checkbox