### PR TITLE
Prevent overload of errors on rake task to set project_id

### DIFF
--- a/lib/tasks/single_run.rake
+++ b/lib/tasks/single_run.rake
@@ -68,7 +68,7 @@ namespace :single_run do
 
   desc '2017-08-15: Change project_name to project_id'
   task add_project_id_to_team: :environment do
-    Team.where.not(project_name: [nil, '']).each do |team|
+    Team.accepted.where.not(project_name: [nil, '']).each do |team|
       begin
         team.project = Project.where(season_id: team.season_id).find_by!(name: team.project_name)
         team.save


### PR DESCRIPTION
Follow up on #816

<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->
Populating the new `project_id` on teams via the `team.project_name` will generate 'RecordNotFound' noise. Adding a scope to make the task running on accepted teams only should reduce some of that noise.



