### PR TITLE
Stops trying to sign in user after email confirmation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,7 +88,7 @@ class ApplicationController < ActionController::Base
   # we are using devise with OmniAuth without other authentications, so we need to define this ourselfes
   # https://github.com/plataformatec/devise/wiki/OmniAuth%3A-Overview#using-omniauth-without-other-authentications
   def new_session_path(scope)
-    user_github_omniauth_authorize_path
+    root_path
   end
 
   # Sentry config

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,7 +3,7 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your account was successfully confirmed. You are now signed in."
+      confirmed: "Your account was successfully confirmed."
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
     failure:


### PR DESCRIPTION
Related issue #642 

 - Fixes the workflow of email confirmation when user is not logged in. Instead of redirecting the user to the sign in path, it redirects now to the root. This might be a better approach, as it complies with devise's default behavior and security, as discussed in this stackoverflow issue: https://stackoverflow.com/questions/18655334/avoid-sign-in-after-confirmation-link-click-using-devise-gem 
 
