### PR TITLE
Add formating of orga comments to conference offers

### DIFF
--- a/app/views/teams/_conference_info.html.slim
+++ b/app/views/teams/_conference_info.html.slim
@@ -30,7 +30,7 @@ h3 Conferences
         - if conference_attendance.orga_comment.present?
           .orgaComment
             |Orga Comment:
-            p = conference_attendance.orga_comment
+            p = render_markdown(conference_attendance.orga_comment).html_safe
 
           - if can? :accept_or_reject_conference_offer, @team
               ul.attendance.list-inline


### PR DESCRIPTION
No related issue

This is a micro PR which changes the way Orga Comments to Conference Offers look like by adding some formatting.

**Before:**
![8865e79550](https://user-images.githubusercontent.com/1745735/30080561-705aec48-929d-11e7-9193-42e32be5d1d4.png)

**After:**
![4a2a4b5d86](https://user-images.githubusercontent.com/1745735/30080560-7058a1fe-929d-11e7-9c1a-23bb850b84ab.png)


