### PR TITLE
Refactor Team.by_season and TeamsController#index

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class TeamsController < ApplicationController
   before_action :set_team,  only: [:show, :edit, :update, :destroy]
   before_action :set_users, only: [:new, :edit]

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -6,21 +6,16 @@ class TeamsController < ApplicationController
   load_and_authorize_resource except: [:index, :show]
 
   def index
-    direction = params[:direction] == 'asc' ? 'ASC' : 'DESC'
-    year = params[:year]
+    direction  = params[:direction] == 'asc' ? 'ASC' : 'DESC'
+    base_scope = if year = params[:year].presence
+                   Team.by_season(year).accepted
+                 else
+                   Team.by_season_phase
+                 end
 
-    if year.present?
-      @teams = Team.by_season(year)
-                   .accepted
-                   .includes(:activities)
-                   .order("teams.kind, activities.created_at #{direction}")
-                   .references(:activities)
-    else
-      @teams = Team.by_season_phase
-                   .includes(:activities)
-                   .order("teams.kind, activities.created_at #{direction}")
-                   .references(:activities)
-    end
+    @teams = base_scope
+               .includes(:activities).references(:activities)
+               .order("teams.kind, activities.created_at #{direction}")
   end
 
   def show

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -46,9 +46,7 @@ class Team < ActiveRecord::Base
 
   scope :by_season, ->(year_or_season) do
     case year_or_season
-      when Integer
-        joins(:season).where('seasons.name': year_or_season)
-      when String
+      when Integer, String
         joins(:season).where('seasons.name': year_or_season)
       when Season
         where(season: year_or_season)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -51,7 +51,7 @@ class Team < ActiveRecord::Base
     when Season
       where(season: year_or_season)
     else
-      raise
+      none
     end
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -46,14 +46,14 @@ class Team < ActiveRecord::Base
 
   scope :by_season, ->(year_or_season) do
     case year_or_season
-      when Integer, String
-        joins(:season).where('seasons.name': year_or_season)
-      when Season
-        where(season: year_or_season)
-      else
-        raise
-      end
+    when Integer, String
+      joins(:season).where('seasons.name': year_or_season)
+    when Season
+      where(season: year_or_season)
+    else
+      raise
     end
+  end
 
   class << self
     def ordered(sort = {})

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -216,10 +216,7 @@ describe Team do
       let(:season2016) { create :season, name: '2016' }
       let(:teams2016) { create_list :team, 2, season: season2016 }
 
-      before do
-        season = create :season, name: '2015'
-        create :team, season: season
-      end
+      let!(:past_team) { create :team, season: create(:season, name: '2015') }
 
       it 'returns teams by season year' do
         expect(Team.by_season('2016')).to match_array(teams2016)

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -226,6 +226,10 @@ describe Team do
       it 'returns teams by season' do
         expect(Team.by_season(season2016)).to match_array(teams2016)
       end
+
+      it 'returns an empty relation when argument is not recognized' do
+        expect(described_class.by_season(Object.new)).to be_empty
+      end
     end
 
     describe '.without_recent_log_update' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -218,8 +218,9 @@ describe Team do
 
       let!(:past_team) { create :team, season: create(:season, name: '2015') }
 
-      it 'returns teams by season year' do
+      it 'returns teams by season year as string and integer' do
         expect(Team.by_season('2016')).to match_array(teams2016)
+        expect(Team.by_season(2016)).to match_array(teams2016)
       end
 
       it 'returns teams by season' do


### PR DESCRIPTION
Some refactorings post #814.

Well, strictly not entirely a refactoring PR as I removed the `raise` from `Team.by_season` to just return an empty relation.
