### PR TITLE
Changed the gemfile instead of reverting commit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'uglifier'
 gem 'sprockets-rails'
 
 gem 'newrelic_rpm'
-gem 'aws-sdk-s3'
+gem 'aws-sdk'
 
 gem 'sentry-raven'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,18 +44,13 @@ GEM
     arel (8.0.0)
     autoprefixer-rails (7.1.4)
       execjs
-    aws-partitions (1.21.0)
-    aws-sdk-core (3.4.0)
-      aws-partitions (~> 1.0)
+    aws-sdk (2.10.29)
+      aws-sdk-resources (= 2.10.29)
+    aws-sdk-core (2.10.29)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.1.0)
-      aws-sdk-core (~> 3)
-      aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.2.0)
-      aws-sdk-core (~> 3)
-      aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.0)
+    aws-sdk-resources (2.10.29)
+      aws-sdk-core (= 2.10.29)
     aws-sigv4 (1.0.2)
     backports (3.8.0)
     bcrypt (3.1.11)
@@ -363,7 +358,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
-  aws-sdk-s3
+  aws-sdk
   better_errors
   binding_of_caller
   bootstrap-kaminari-views


### PR DESCRIPTION
Related issue #853 part 1: Quickfix: reverting the upgrade to avoid problems with the AWS gem v3.

Quickfix: downgrade the AWS v3 gem back to v2 to avoid problems with fetching images.
<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->