### PR TITLE
Fix flaky controller spec

### DIFF
--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -25,8 +25,7 @@ describe CommentsController do
         it 'redirects to comment on project page' do
           post :create, params: { comment: params.merge(valid_attributes) }
           comment = assigns(:comment)
-          anchor  = "comment_#{comment.id}"
-          expect(response).to redirect_to [project, anchor: anchor]
+          expect(response).to redirect_to [project, anchor: "comment_#{comment.id}"]
         end
       end
       context 'with invalid params (no text)' do

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -10,7 +10,7 @@ describe CommentsController do
     sign_in user
   end
 
-  describe 'POST create' do
+  describe 'POST create', :wip do
     describe 'project comment' do
       let(:project) { create :project }
       let(:params) { { commentable_id: project.id, commentable_type: 'Project' } }
@@ -24,7 +24,9 @@ describe CommentsController do
 
         it 'redirects to comment on project page' do
           post :create, params: { comment: params.merge(valid_attributes) }
-          expect(response).to redirect_to [project, anchor: 'comment_1']
+          comment = assigns(:comment)
+          anchor  = "comment_#{comment.id}"
+          expect(response).to redirect_to [project, anchor: anchor]
         end
       end
       context 'with invalid params (no text)' do


### PR DESCRIPTION
This attempts to fix (and while that not slow down the test suite...) a test that at least for me frequently failed on CI. It was basically hardcoding an ID which did not always work out right.

I switched it to use RSpec's `assigns` to get the assigned object from within the controller. Doing something like
```ruby
comment = Comment.last
```
would have been another option, but I thought we could spare another hit to the DB for this example.