### PR TITLE
adds project link to nav bar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,7 +428,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.4.2p198
 
 BUNDLED WITH
    1.16.0.pre.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,7 +428,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.2

--- a/app/views/application/_nav_right.html.slim
+++ b/app/views/application/_nav_right.html.slim
@@ -15,6 +15,7 @@ ul.nav.navbar-nav.navbar-right
       - if current_season.started?
         li.divider.hidden-xs
         li class=active?(:conferences) = link_to 'Conferences',  conferences_path
+        li class=active?(:projects) = link_to 'Projects', projects_path
       li.divider.hidden-xs
       li class=active?(:teams) = link_to 'Teams', teams_path
       li class=active?(:users) = link_to 'Community', community_index_path

--- a/app/views/application/_nav_right.html.slim
+++ b/app/views/application/_nav_right.html.slim
@@ -8,6 +8,7 @@ ul.nav.navbar-nav.navbar-right
       - if Season.projects_proposable?
         li.divider.hidden-xs
         li class=active?(:projects) = link_to 'Submit your Project', new_project_path
+        li class=active?(:projects) = link_to 'Projects', projects_path      
       - if show_application_link?
         li.divider.hidden-xs
         li class=active?(:application_drafts) = application_disambiguation_link

--- a/spec/requests/navigation_spec.rb
+++ b/spec/requests/navigation_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Navigation', type: :request do
         expect(response.body).to include activities_path
         expect(response.body).to include teams_path
         expect(response.body).to include conferences_path
+        expect(response.body).to include projects_path
         expect(response.body).to include users_path
         expect(response.body).to include page_path(:help)
         expect(response.body).to include user_path(user)
@@ -167,6 +168,7 @@ RSpec.describe 'Navigation', type: :request do
     shared_examples :user_nav_during_application_phase do
       it 'displays sign in and links relevant for the phase' do
         expect(response.body).to include activities_path
+        expect(response.body).to include projects_path
         expect(response.body).to include apply_path
         expect(response.body).to include users_path
         expect(response.body).to include page_path(:help)

--- a/spec/requests/navigation_spec.rb
+++ b/spec/requests/navigation_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Navigation', type: :request do
         expect(response.body).to include activities_path
         expect(response.body).to include teams_path
         expect(response.body).to include conferences_path
+        expect(response.body).to include projects_path        
         expect(response.body).to include users_path
         expect(response.body).to include page_path(:help)
         expect(response.body).to include user_github_omniauth_authorize_path
@@ -192,6 +193,7 @@ RSpec.describe 'Navigation', type: :request do
         expect(response.body).to include apply_path
         expect(response.body).to include teams_path
         expect(response.body).to include users_path
+        expect(response.body).to include projects_path        
         expect(response.body).to include page_path(:help)
         expect(response.body).to include user_github_omniauth_authorize_path
       end

--- a/spec/requests/navigation_spec.rb
+++ b/spec/requests/navigation_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Navigation', type: :request do
         expect(response.body).to include activities_path
         expect(response.body).to include teams_path
         expect(response.body).to include conferences_path
-        expect(response.body).to include projects_path        
+        expect(response.body).to include projects_path
         expect(response.body).to include users_path
         expect(response.body).to include page_path(:help)
         expect(response.body).to include user_github_omniauth_authorize_path
@@ -193,7 +193,7 @@ RSpec.describe 'Navigation', type: :request do
         expect(response.body).to include apply_path
         expect(response.body).to include teams_path
         expect(response.body).to include users_path
-        expect(response.body).to include projects_path        
+        expect(response.body).to include projects_path
         expect(response.body).to include page_path(:help)
         expect(response.body).to include user_github_omniauth_authorize_path
       end


### PR DESCRIPTION
Related issue #834 

 - What feature does it add, which bug does it fix? 
Adds a link to projects#index to the drop down 'Summer of Code' nav bar section.

<img width="556" alt="projectsss" src="https://user-images.githubusercontent.com/24966769/30602469-dfb8caf4-9d21-11e7-8c94-8b4af928ba7a.png">


