### PR TITLE
Clean up and lint travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,42 +3,41 @@ cache: bundler
 sudo: false
 dist: trusty
 rvm:
-- 2.4.2
+  - 2.4.2
 bundler_args: "-j4 --without development production --quiet"
 notifications:
-  notifications:
-    webhooks:
-      secure: AziQTqGNQCCe/673UZy3bW0XB0oGywiEAyxygTWs2Cki0lqNldgELlPg+eC+CgvCJpMXRY6PLS/MXWeu4eR/6iONnBo+So8l9wJSZasxrCwVWqI9UFZYaMXXzFTGlz2JmBJ7JigW5zxL/Y3ukqu+wjA3MytT8N5tuNdR5SYqy40=
+  webhooks:
+    secure: AziQTqGNQCCe/673UZy3bW0XB0oGywiEAyxygTWs2Cki0lqNldgELlPg+eC+CgvCJpMXRY6PLS/MXWeu4eR/6iONnBo+So8l9wJSZasxrCwVWqI9UFZYaMXXzFTGlz2JmBJ7JigW5zxL/Y3ukqu+wjA3MytT8N5tuNdR5SYqy40=
   slack:
     secure: pEbxQLQakbPpZkU2p+FdHxSOw7BlXHrOMdJlh8g7fK2oGiOMrpU0wbRUHUxNWzxTnkqWmwq37cIFXPGLel3yWkDzDO0+EuBBFPyoiQ2THxC8/pdpIO3I6jAuH7Zqra4jIdfHWw0UkN4Z+Yqnc+Y90rf9SC7mRGucbcy5aCGEIkY=
 before_script:
-- cp config/database.yml.travis config/database.yml
-- bundle exec rake db:create db:schema:load RAILS_ENV=test
-- npm install -g jshint
+  - cp config/database.yml.travis config/database.yml
+  - bundle exec rails db:create db:schema:load RAILS_ENV=test
+  - npm install -g jshint
 script:
-- bundle exec rubocop
-- jshint app/assets/javascripts
-- bundle exec rake spec
+  - bundle exec rubocop
+  - jshint app/assets/javascripts
+  - bundle exec rspec
 deploy:
-- provider: heroku
-  api_key:
-    secure: ZtYE7hK2EyNWYhkxWSGSrmCNvYZrT7dmxRvi4rg82uHFOtzbEiThjkmwKKD3EK75syGFos3fJszW8GRwJqY9Id6L1Ieg+GpHDMBYJqsLbSRqJ6Mj1vzxbDqV2XsDFkr2e3MTrgNPRX+qmcKnsP9PTwxtey8pAUZFQFTz0i0gxcc=
-  app: rgsoc-teams-staging
-  run:
-  - rake db:migrate
-  - restart
-  on:
-    repo: rails-girls-summer-of-code/rgsoc-teams
-- provider: heroku
-  api_key:
-    secure: ZtYE7hK2EyNWYhkxWSGSrmCNvYZrT7dmxRvi4rg82uHFOtzbEiThjkmwKKD3EK75syGFos3fJszW8GRwJqY9Id6L1Ieg+GpHDMBYJqsLbSRqJ6Mj1vzxbDqV2XsDFkr2e3MTrgNPRX+qmcKnsP9PTwxtey8pAUZFQFTz0i0gxcc=
-  app: rgsoc-teams-production
-  run:
-  - rake db:migrate
-  - restart
-  on:
-    repo: rails-girls-summer-of-code/rgsoc-teams
+  - provider: heroku
+    api_key:
+      secure: ZtYE7hK2EyNWYhkxWSGSrmCNvYZrT7dmxRvi4rg82uHFOtzbEiThjkmwKKD3EK75syGFos3fJszW8GRwJqY9Id6L1Ieg+GpHDMBYJqsLbSRqJ6Mj1vzxbDqV2XsDFkr2e3MTrgNPRX+qmcKnsP9PTwxtey8pAUZFQFTz0i0gxcc=
+    app: rgsoc-teams-staging
+    run:
+      - rails db:migrate
+      - restart
+    on:
+      repo: rails-girls-summer-of-code/rgsoc-teams
+  - provider: heroku
+    api_key:
+      secure: ZtYE7hK2EyNWYhkxWSGSrmCNvYZrT7dmxRvi4rg82uHFOtzbEiThjkmwKKD3EK75syGFos3fJszW8GRwJqY9Id6L1Ieg+GpHDMBYJqsLbSRqJ6Mj1vzxbDqV2XsDFkr2e3MTrgNPRX+qmcKnsP9PTwxtey8pAUZFQFTz0i0gxcc=
+    app: rgsoc-teams-production
+    run:
+      - rails db:migrate
+      - restart
+    on:
+      repo: rails-girls-summer-of-code/rgsoc-teams
 addons:
   postgresql: '9.5'
 after_success:
-- bundle exec codeclimate-test-reporter
+  - bundle exec codeclimate-test-reporter


### PR DESCRIPTION
This fixes some formatting problems in the `travis.yml` and adds classic yml-indentation to it for a better readability.

Background: While experimenting with Travis' pipeline feature in #861, I realized our `travis.yml` had some formatting problems, such as a duplicated "notifications" key with a weird nesting (wonder why it still worked..) 😉 