### PR TITLE
Fix/adapt tests for season transition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :production do
 end
 
 group :development, :test do
+  gem 'pry'
   gem 'rspec-rails'
   gem 'factory_girl_rails'
   gem 'database_cleaner'
@@ -53,7 +54,6 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
   # gem 'jazz_hands'
-  gem 'pry'
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'foreman'

--- a/spec/controllers/mentor/applications_controller_spec.rb
+++ b/spec/controllers/mentor/applications_controller_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe Mentor::ApplicationsController do
 
   let(:user) { create(:user) }
 
+  # Make sure the current season did not end yet
+  before do
+    allow(Season).to receive(:transition?) { false }
+  end
+
   describe 'GET index' do
     context 'as an unauthenticated user' do
       it 'redirects to the landing page' do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProjectsController do
     end
 
     context 'during active Season' do
-      before { allow(Season).to receive(:active?) { true } }
+      before { Timecop.travel Season.current.starts_at }
 
       let!(:proposed) { FactoryGirl.create(:project, season: Season.succ, name: 'proposed project') }
       let!(:selected) { FactoryGirl.create(:project, :accepted, :in_current_season, name: "selected by a team") }


### PR DESCRIPTION
This adapts the tests to work regardless if the current season ended or not.

Background: some controller tests were under the hood tied to the fact that the current season is still on and not already transitioning to the next. So I put in some before hooks making sure tests which are meant to target a non-transition phase also work when run during a "real" transition phase 😉 