### PR TITLE
Sends email to users that were added to a team with any role

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -20,7 +20,7 @@ class Role < ActiveRecord::Base
   validates :user_id, uniqueness: { scope: [:name, :team_id] }
 
   before_create :set_confirmation_token
-  after_commit :send_notification, on: :create, if: -> { GUIDE_ROLES.include?(name) }
+  after_commit :send_notification, on: :create
 
   after_create do |role|
     role.confirm! unless role.name == 'coach'

--- a/app/views/role_mailer/user_added_to_team.html.slim
+++ b/app/views/role_mailer/user_added_to_team.html.slim
@@ -13,8 +13,13 @@ html
       a href=team_url(@role.team) Team #{@role.team.name}
       |  as a #{@role.name}.
 
-      - if @role.name == 'coach'
-        p
-          ' Please confirm that you are indeed willing to join the team as their coach.
-          ' You can do so on the team's overview page listed above (make sure you are
-          ' logged in using your Github account).
+    - if @role.name == 'coach'
+      p
+        ' Please confirm that you are indeed willing to join the team as their coach.
+        ' You can do so on the team's overview page listed above (make sure you are
+        ' logged in using your Github account).
+
+    p
+      ' Please complete your profile
+      a href=edit_user_url(@role.user_id) here
+      '  and be sure to confirm your email address.

--- a/app/views/role_mailer/user_added_to_team.text.erb
+++ b/app/views/role_mailer/user_added_to_team.text.erb
@@ -7,3 +7,6 @@ Please confirm that you are indeed willing to join the team as their coach.
 You can do so on the team's overview page listed above (make sure you are
 logged in using your Github account).
 <% end %>
+
+Please complete your profile at <%= edit_user_url(@role.user_id) %> 
+and be sure to confirm your email address.

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -79,8 +79,9 @@ RSpec.describe Role do
     context 'when the user is added as a student' do
       let(:role_name) { 'student' }
 
-      it 'does not send a notification' do
-        expect(RoleMailer).to_not have_received(:user_added_to_team).with(subject)
+      it 'sends a notification to the user' do
+        expect(RoleMailer).to have_received(:user_added_to_team).with(subject)
+        expect(mailer).to have_received(:deliver_later)
       end
     end
 


### PR DESCRIPTION
Related issue #618 

 - Sends an email to any user that has been added to a team, with any role (not only coaches) 
 - Includes a line on the email asking the user to fill out profile and confirm email
