### PR TITLE
Move to "short" FactoryBot syntax 🐣

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,38 +1,38 @@
 # Teams
-FactoryBot.create_list(:team, 5, :in_current_season, kind: "sponsored")
-FactoryBot.create(:team, :in_current_season, kind: "voluntary")
-FactoryBot.create(:team, :in_current_season) # not accepted
+create_list(:team, 5, :in_current_season, kind: "sponsored")
+create(:team, :in_current_season, kind: "voluntary")
+create(:team, :in_current_season) # not accepted
 
-FactoryBot.create(:team, :last_season, kind: "sponsored")
-FactoryBot.create(:team, :last_season, kind: "voluntary")
+create(:team, :last_season, kind: "sponsored")
+create(:team, :last_season, kind: "voluntary")
 
 # Users with different roles
-FactoryBot.create_list(:student, 12)
-FactoryBot.create_list(:coach, 3)
-FactoryBot.create_list(:organizer, 2)
-FactoryBot.create(:mentor)
-FactoryBot.create(:supervisor)
+create_list(:student, 12)
+create_list(:coach, 3)
+create_list(:organizer, 2)
+create(:mentor)
+create(:supervisor)
 
 # To explore use cases where user has no role yet
-FactoryBot.create_list(:user, 3)
+create_list(:user, 3)
 
 # Status updates for different teams
 5.times do
-  FactoryBot.create(:status_update, published_at: Time.now, team: Team.all.sample)
+  create(:status_update, published_at: Time.now, team: Team.all.sample)
 end
 
 # Applications and their projects
-FactoryBot.create(:application_draft)
-FactoryBot.create(:application_draft, :appliable)
+create(:application_draft)
+create(:application_draft, :appliable)
 
-FactoryBot.create(:project, :in_current_season) # proposed
-FactoryBot.create_list(:project, 3, :accepted, :in_current_season)
-FactoryBot.create(:project, :rejected, :in_current_season)
+create(:project, :in_current_season) # proposed
+create_list(:project, 3, :accepted, :in_current_season)
+create(:project, :rejected, :in_current_season)
 
 # Conferences
 6.times do
   random_date = rand(1.year).seconds.from_now
-  FactoryBot.create(:conference, :in_current_season,
+  create(:conference, :in_current_season,
     location: FFaker::Venue.name,
     region: ["Africa", "South America", "North America", "Europe", "Asia Pacific"].sample,
     starts_on: random_date,

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ApplicationDraftsController do
 
   context 'as a not confirmed user' do
     describe 'GET new' do
-      let(:user) { FactoryBot.create(:user, confirmed_at: nil) }
+      let(:user) { create(:user, confirmed_at: nil) }
 
       before do
         allow(controller).to receive_messages(signed_in?: true)
@@ -36,7 +36,7 @@ RSpec.describe ApplicationDraftsController do
   end
 
   context 'as an authenticated user' do
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { create(:user) }
 
     shared_examples_for 'application period is over' do
       it 'new renders applications_end template when over' do
@@ -54,8 +54,8 @@ RSpec.describe ApplicationDraftsController do
     end
 
     describe 'GET index' do
-      let!(:student_role) { FactoryBot.create :student_role, user: user, team: team }
-      let!(:drafts) { FactoryBot.create_list(:application_draft, 1, team: team) }
+      let!(:student_role) { create :student_role, user: user, team: team }
+      let!(:drafts) { create_list(:application_draft, 1, team: team) }
 
       it "redirects to the existing application draft's edit action" do
         get :index
@@ -210,12 +210,12 @@ RSpec.describe ApplicationDraftsController do
     end
 
     describe 'PUT apply' do
-      let(:team)  { FactoryBot.create(:team, :applying_team, :in_current_season) }
-      let(:draft) { FactoryBot.create(:application_draft, :appliable, team: team) }
+      let(:team)  { create(:team, :applying_team, :in_current_season) }
+      let(:draft) { create(:application_draft, :appliable, team: team) }
       let(:application) { Application.last }
 
       context 'as a student' do
-        let!(:student_role) { FactoryBot.create(:student_role, user: user, team: team) }
+        let!(:student_role) { create(:student_role, user: user, team: team) }
 
         context 'coaches confirmed' do
           it 'creates a new application' do

--- a/spec/controllers/community_controller_spec.rb
+++ b/spec/controllers/community_controller_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe CommunityController do
 
   describe "GET index" do
     it "assigns all users that have any roles assigned as @users" do
-      student = FactoryBot.create(:student)
-      coach = FactoryBot.create(:coach)
+      student = create(:student)
+      coach = create(:coach)
       get :index
       expect(assigns(:users).to_a).to include(coach) && include(student)
     end
 
     it 'will not show email addresses for guests' do
-      user = FactoryBot.create(:user, hide_email: false)
+      user = create(:user, hide_email: false)
       get :index
       expect(response.body).not_to include user.email
     end
@@ -28,26 +28,26 @@ RSpec.describe CommunityController do
 
     context 'with user logged in' do
       before(:each) do
-        sign_in FactoryBot.create(:student)
+        sign_in create(:student)
       end
 
       it 'will not show email addresses of those who opted out' do
-        user = FactoryBot.create(:student, hide_email: false)
-        user_opted_out = FactoryBot.create(:user, hide_email: true)
+        user = create(:student, hide_email: false)
+        user_opted_out = create(:user, hide_email: true)
         get :index
         expect(response.body).to include user.email
         expect(response.body).not_to include user_opted_out.email
       end
 
       it 'shows user impersonation links when in development' do
-        other_user = FactoryBot.create(:student)
+        other_user = create(:student)
         get :index
         expect(response.body).to include impersonate_user_path(other_user)
       end
 
       it 'does not show user impersonation links when in production' do
         allow(Rails).to receive(:env).and_return('production'.inquiry)
-        other_user = FactoryBot.create(:student)
+        other_user = create(:student)
         get :index
         expect(response.body).not_to include impersonate_user_path(other_user)
       end
@@ -55,8 +55,8 @@ RSpec.describe CommunityController do
 
     context 'when impersonating' do
       it 'shows a Stop Impersonation link instead of Sign out' do
-        sign_in FactoryBot.create(:student)
-        other_user = FactoryBot.create(:student)
+        sign_in create(:student)
+        other_user = create(:student)
         controller.impersonate_user(other_user)
         get :index
         expect(response.body).not_to include sign_out_path

--- a/spec/controllers/concerns/ordered_conferences_spec.rb
+++ b/spec/controllers/concerns/ordered_conferences_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe OrderedConferences do
       end
     end
 
-    let!(:conference)        { FactoryBot.create :conference, :in_current_season }
-    let!(:conference_europe) { FactoryBot.create :conference_europe, :in_current_season }
-    let!(:conference_na)     { FactoryBot.create :conference_na, :in_current_season }
+    let!(:conference)        { create :conference, :in_current_season }
+    let!(:conference_europe) { create :conference_europe, :in_current_season }
+    let!(:conference_na)     { create :conference_na, :in_current_season }
 
     it 'returns an ordered list of conferences' do
       expect(subject).to eq [conference, conference_europe, conference_na]

--- a/spec/controllers/conference_attendances_controller_spec.rb
+++ b/spec/controllers/conference_attendances_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe ConferenceAttendancesController do
-  let(:team) { FactoryBot.create(:team, :in_current_season) }
-  let(:student) { FactoryBot.create(:student, team: team)}
-  let(:attendance) { FactoryBot.create(:conference_attendance, team: team )}
+  let(:team) { create(:team, :in_current_season) }
+  let(:student) { create(:student, team: team)}
+  let(:attendance) { create(:conference_attendance, team: team )}
 
   before do
     sign_in student

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ConferencesController do
     end
 
     context 'student logged in' do
-      let!(:student) { FactoryBot.create(:student) }
+      let!(:student) { create(:student) }
 
       before do
         sign_in student
@@ -64,7 +64,7 @@ RSpec.describe ConferencesController do
     end
 
     context 'with user logged in' do
-      let(:student) { FactoryBot.create(:student) }
+      let(:student) { create(:student) }
       let(:conference_attrs) { attributes_for :conference }
 
       before do

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -54,7 +54,7 @@ describe OmniauthCallbacksController do
     # in again, we want to show that user the edit page to
     # let her/him complete the registration
     it 'redirects to the edit page if the profile is not valid' do
-      user = FactoryBot.build(:user, country: nil)
+      user = build(:user, country: nil)
       user.github_import = true
       user.save
 

--- a/spec/controllers/orga/mailings_controller_spec.rb
+++ b/spec/controllers/orga/mailings_controller_spec.rb
@@ -5,7 +5,7 @@ describe Orga::MailingsController do
 
   it_behaves_like 'redirects for non-admins'
 
-  let(:mailing) { FactoryBot.create(:mailing) }
+  let(:mailing) { create(:mailing) }
 
   context 'with admin logged in' do
     include_context 'with admin logged in'

--- a/spec/controllers/orga/teams_controller_spec.rb
+++ b/spec/controllers/orga/teams_controller_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Orga::TeamsController do
       before { sign_in user}
 
       context "assign conference attendance" do
-        let(:offer) { FactoryBot.create(:conference_attendance) }
+        let(:offer) { create(:conference_attendance) }
         let(:team) { offer.team }
         let!(:team_params) do
           build(:team).attributes.merge(conference_attendances_attributes: {

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -3,16 +3,16 @@ require 'spec_helper'
 RSpec.describe ProjectsController do
   render_views
 
-  let(:project) { FactoryBot.create(:project) }
+  let(:project) { create(:project) }
 
   describe 'GET index' do
 
     context 'between seasons' do
       before { Timecop.travel Date.parse('2015-12-15') }
 
-      let!(:proposed) { FactoryBot.create(:project, season: Season.succ, name: 'proposed project') }
-      let!(:accepted) { FactoryBot.create(:project, :accepted, season: Season.succ, name: 'accepted project') }
-      let!(:rejected) { FactoryBot.create(:project, :rejected, season: Season.succ, name: 'rejected project') }
+      let!(:proposed) { create(:project, season: Season.succ, name: 'proposed project') }
+      let!(:accepted) { create(:project, :accepted, season: Season.succ, name: 'accepted project') }
+      let!(:rejected) { create(:project, :rejected, season: Season.succ, name: 'rejected project') }
 
       it 'hides rejected projects' do
         get :index
@@ -26,10 +26,10 @@ RSpec.describe ProjectsController do
     context 'during active Season' do
       before { Timecop.travel Season.current.starts_at }
 
-      let!(:proposed) { FactoryBot.create(:project, season: Season.succ, name: 'proposed project') }
-      let!(:selected) { FactoryBot.create(:project, :accepted, :in_current_season, name: "selected by a team") }
-      let!(:no_team) { FactoryBot.create(:project, :accepted, :in_current_season, name: "project without team") }
-      let!(:team) { FactoryBot.create(:team, :in_current_season, project_name: selected.name) }
+      let!(:proposed) { create(:project, season: Season.succ, name: 'proposed project') }
+      let!(:selected) { create(:project, :accepted, :in_current_season, name: "selected by a team") }
+      let!(:no_team) { create(:project, :accepted, :in_current_season, name: "project without team") }
+      let!(:team) { create(:team, :in_current_season, project_name: selected.name) }
 
       it 'shows selected projects only' do
         get :index
@@ -84,10 +84,10 @@ RSpec.describe ProjectsController do
   end
 
   describe 'PATCH update' do
-    let!(:project) { FactoryBot.create(:project, submitter: current_user) }
+    let!(:project) { create(:project, submitter: current_user) }
     context 'with user logged in' do
       include_context 'with user logged in'
-      let(:current_user) { FactoryBot.create(:user) }
+      let(:current_user) { create(:user) }
 
       it 'creates a project and redirects to list' do
         patch :update, params: { id: project.to_param, project: { name: "This is an updated name!" } }
@@ -178,8 +178,8 @@ RSpec.describe ProjectsController do
   describe 'DELETE destroy' do
     context 'with user logged in' do
       include_context 'with user logged in'
-      let(:current_user) { FactoryBot.create(:user) }
-      let!(:project) { FactoryBot.create(:project, submitter: current_user) }
+      let(:current_user) { create(:user) }
+      let!(:project) { create(:project, submitter: current_user) }
 
       it 'deletes the project' do
         expect { delete :destroy, params: { id: project.to_param } }.to \

--- a/spec/controllers/rating/applications_controller_spec.rb
+++ b/spec/controllers/rating/applications_controller_spec.rb
@@ -6,7 +6,7 @@ describe Rating::ApplicationsController do
   describe 'GET index' do
     context 'as a non reviewer' do
       before do
-        sign_in FactoryBot.create(:user)
+        sign_in create(:user)
         get :index
       end
 
@@ -16,9 +16,9 @@ describe Rating::ApplicationsController do
     end
 
     context 'as a reviewer' do
-      let(:applications) { FactoryBot.build_list(:application, 3) }
+      let(:applications) { build_list(:application, 3) }
 
-      before { sign_in FactoryBot.create(:reviewer) }
+      before { sign_in create(:reviewer) }
 
       it 'assigns an application table and renders the index view' do
         expect(Application).to receive(:rateable)
@@ -64,12 +64,12 @@ describe Rating::ApplicationsController do
   end
 
   describe 'GET show' do
-    let(:application) { FactoryBot.create(:application) }
+    let(:application) { create(:application) }
 
     before do
       # create students for teams
-      FactoryBot.create(:student, team: application.team)
-      FactoryBot.create(:student, team: application.team)
+      create(:student, team: application.team)
+      create(:student, team: application.team)
     end
 
     it 'requires login' do

--- a/spec/controllers/rating/todos_controller_spec.rb
+++ b/spec/controllers/rating/todos_controller_spec.rb
@@ -11,15 +11,15 @@ describe Rating::TodosController, type: :controller do
     end
 
     it 'requires reviewer role' do
-      sign_in FactoryBot.create(:organizer)
+      sign_in create(:organizer)
       get :index
       expect(response).to redirect_to root_path
       expect(flash[:alert]).to be_present
     end
 
     context 'when reviewer' do
-      let(:user)  { FactoryBot.create :reviewer }
-      let(:todos) { FactoryBot.build_list(:todo, 10, user: user) }
+      let(:user)  { create :reviewer }
+      let(:todos) { build_list(:todo, 10, user: user) }
 
       before do
         sign_in user

--- a/spec/controllers/supervisor/comments_controller_spec.rb
+++ b/spec/controllers/supervisor/comments_controller_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Supervisor::CommentsController do
   render_views
   let(:valid_attributes) { { "text" => FFaker::Lorem.paragraph } }
-  let(:user) { FactoryBot.create(:user) }
-  let(:team) { FactoryBot.create(:team) }
+  let(:user) { create(:user) }
+  let(:team) { create(:team) }
 
   describe 'POST create' do
     describe 'with valid params' do
@@ -60,7 +60,7 @@ describe Supervisor::CommentsController do
     end
 
     describe "with another team's supervisor" do
-      let(:anotherteam) { FactoryBot.create(:team) }
+      let(:anotherteam) { create(:team) }
       let(:comment) { anotherteam.comments.last }
 
       before do

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe TeamsController do
 
   include_context 'with user logged in'
 
-  let(:user) { FactoryBot.create(:user) }
-  let(:team) { FactoryBot.create(:team) }
+  let(:user) { create(:user) }
+  let(:team) { create(:team) }
   let(:current_user) { user }
 
   let(:valid_attributes) { build(:team).attributes.merge(roles_attributes: [{ name: 'coach', github_handle: 'tobias' }]) }
@@ -80,7 +80,7 @@ RSpec.describe TeamsController do
   end
 
   describe "GET show" do
-    let!(:preference) { FactoryBot.create :conference_preference, :student_preference, :with_terms_checked }
+    let!(:preference) { create :conference_preference, :student_preference, :with_terms_checked }
     let(:team) { preference.team }
 
     it "assigns the requested team as @team" do
@@ -105,7 +105,7 @@ RSpec.describe TeamsController do
 
   describe "GET edit" do
     context "their own team" do
-      let(:team) { FactoryBot.create(:team) }
+      let(:team) { create(:team) }
 
       it "assigns the requested team as @team" do
         get :edit, params: { id: team.to_param }
@@ -115,7 +115,7 @@ RSpec.describe TeamsController do
     end
 
     context "someone else's team" do
-      let(:another_team) { FactoryBot.create(:team) }
+      let(:another_team) { create(:team) }
 
       it "redirects to the homepage" do
         get :edit, params: { id: another_team.to_param }
@@ -150,9 +150,9 @@ RSpec.describe TeamsController do
       end
 
       context 'given the team is comprised of two students' do
-        let(:first_student) { FactoryBot.create(:user) }
-        let(:second_student) { FactoryBot.create(:user) }
-        let(:team) { FactoryBot.create(:team) }
+        let(:first_student) { create(:user) }
+        let(:second_student) { create(:user) }
+        let(:team) { create(:team) }
         let(:current_user) { first_student }
 
         let(:valid_attributes) { build(:team).attributes.merge(roles_attributes: [{ name: 'student', github_handle: first_student.github_handle }, { name: 'student', github_handle: second_student.github_handle }]) }
@@ -169,7 +169,7 @@ RSpec.describe TeamsController do
     before { sign_in user }
 
     context "their own team" do
-      let(:team) { FactoryBot.create(:team) }
+      let(:team) { create(:team) }
 
       describe "with valid params" do
         it "updates the requested team" do
@@ -215,8 +215,8 @@ RSpec.describe TeamsController do
         end
 
         context 'selecting the conference options' do
-          let(:conference_1) { FactoryBot.create(:conference, :in_current_season)}
-          let(:conference_2) { FactoryBot.create(:conference, :in_current_season)}
+          let(:conference_1) { create(:conference, :in_current_season)}
+          let(:conference_2) { create(:conference, :in_current_season)}
           let(:team_params) do
             build(:team).attributes.merge(conference_preference_attributes: {
               first_conference_id: conference_1.id,
@@ -252,7 +252,7 @@ RSpec.describe TeamsController do
       end
 
       context "another team" do
-        let(:another_team) { FactoryBot.create(:team) }
+        let(:another_team) { create(:team) }
 
         it "does not update the requested team" do
           expect_any_instance_of(Team).not_to receive(:update_attributes)
@@ -284,7 +284,7 @@ RSpec.describe TeamsController do
     end
 
     context "another team's profile" do
-      let(:another_team) { FactoryBot.create(:team) }
+      let(:another_team) { create(:team) }
       let(:params)       { { id: another_team.to_param } }
 
       it "doesn't destroy the requested team" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe UsersController do
 
   describe "GET show" do
     it "assigns the requested user as @user" do
-      user = FactoryBot.create(:user)
+      user = create(:user)
       get :show, params: { id: user.to_param }
       expect(assigns(:user)).to eq(user)
     end
 
     context 'with conferences' do
-      let!(:preference) { FactoryBot.create :conference_preference, :student_preference, :with_terms_checked }
+      let!(:preference) { create :conference_preference, :student_preference, :with_terms_checked }
       let(:user)        { preference.team.students.first }
       let(:conference)  { preference.first_conference }
 
       context 'with conferences preferences orphans' do
-        let!(:orphan) { FactoryBot.create :conference_preference, :student_preference, :with_terms_checked }
+        let!(:orphan) { create :conference_preference, :student_preference, :with_terms_checked }
         let!(:conference) { orphan.first_conference }
         let!(:user) { preference.team.members.first }
 
@@ -36,18 +36,18 @@ RSpec.describe UsersController do
 
     context 'with user logged in' do
       before(:each) do
-        sign_in FactoryBot.create(:student)
+        sign_in create(:student)
       end
 
       it 'shows the user impersonation link when in development' do
-        other_user = FactoryBot.create(:user)
+        other_user = create(:user)
         get :show, params: { id: other_user.to_param }
         expect(response.body).to include impersonate_user_path(other_user)
       end
 
       it 'does not show the user impersonation link when in production' do
         allow(Rails).to receive(:env).and_return('production'.inquiry)
-        other_user = FactoryBot.create(:user)
+        other_user = create(:user)
         get :show, params: { id: other_user.to_param }
         expect(response.body).not_to include impersonate_user_path(other_user)
       end
@@ -55,7 +55,7 @@ RSpec.describe UsersController do
   end
 
   describe "GET edit" do
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { create(:user) }
     before :each do
       sign_in user
     end
@@ -68,7 +68,7 @@ RSpec.describe UsersController do
     end
 
     context "another user's profile" do
-      let(:another_user) { FactoryBot.create(:user) }
+      let(:another_user) { create(:user) }
 
       it "redirects to the homepage" do
         get :edit, params: { id: another_user.to_param }
@@ -78,7 +78,7 @@ RSpec.describe UsersController do
   end
 
   describe "PUT update" do
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { create(:user) }
     before :each do
       sign_in user
     end
@@ -87,7 +87,7 @@ RSpec.describe UsersController do
       describe "with valid params" do
 
         context "and unconfirmed user" do
-          let(:user) { FactoryBot.create(:user, confirmed_at: nil) }
+          let(:user) { create(:user, confirmed_at: nil) }
 
           it "sends an confirmation email if the user isn't confirmed yet and the email wasn't changed" do
             expect {
@@ -133,7 +133,7 @@ RSpec.describe UsersController do
       end
 
       context "another user's profile" do
-        let!(:another_user) { FactoryBot.create(:user) }
+        let!(:another_user) { create(:user) }
 
         it "does not update the requested user" do
           expect_any_instance_of(User).not_to receive(:update_attributes)
@@ -152,7 +152,7 @@ RSpec.describe UsersController do
 
     let(:valid_attributes) { { application_about: "lorem ipsum" } }
 
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { create(:user) }
     before { sign_in user }
 
     context 'their own profile' do
@@ -164,7 +164,7 @@ RSpec.describe UsersController do
   end
 
   describe "DELETE destroy" do
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { create(:user) }
     before :each do
       sign_in user
     end
@@ -183,7 +183,7 @@ RSpec.describe UsersController do
     end
 
     context "another user's profile" do
-      let(:another_user) { FactoryBot.create(:user) }
+      let(:another_user) { create(:user) }
 
       it "doesn't destroy the requested user" do
         expect {
@@ -199,8 +199,8 @@ RSpec.describe UsersController do
   end
 
   describe 'POST impersonate' do
-    let(:user) { FactoryBot.create(:user) }
-    let(:impersonated_user) { FactoryBot.create(:user) }
+    let(:user) { create(:user) }
+    let(:impersonated_user) { create(:user) }
     before { sign_in user }
 
     it 'changes the current_user' do
@@ -216,8 +216,8 @@ RSpec.describe UsersController do
   end
 
   describe 'POST stop_impersonating' do
-    let(:user) { FactoryBot.create(:user) }
-    let(:impersonated_user) { FactoryBot.create(:user) }
+    let(:user) { create(:user) }
+    let(:impersonated_user) { create(:user) }
     before do
       sign_in user
       controller.impersonate_user(impersonated_user)

--- a/spec/factories/conference_preferences.rb
+++ b/spec/factories/conference_preferences.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :conference_preference do
-    team { FactoryBot.create(:team, :in_current_season) }
-    first_conference { FactoryBot.create(:conference, :in_current_season) }
-    second_conference { FactoryBot.create(:conference, :in_current_season) }
+    team { create(:team, :in_current_season) }
+    first_conference { create(:conference, :in_current_season) }
+    second_conference { create(:conference, :in_current_season) }
 
     trait :student_preference do
       after(:create) do |preference|

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
 
     trait :with_conference_preferences do
       after(:create) do |team|
-        FactoryBot.create(:conference_preference, :with_terms_checked, team: team)
+        create(:conference_preference, :with_terms_checked, team: team)
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,18 +10,18 @@ FactoryBot.define do
     confirmed_at { Date.yesterday }
 
     factory :coach do
-      transient { team { FactoryBot.create(:team) } }
+      transient { team { create(:team) } }
 
       after(:create) do |user, evaluator|
-        FactoryBot.create(:coach_role, user: user, team: evaluator.team)
+        create(:coach_role, user: user, team: evaluator.team)
       end
     end
 
     factory :student do
-      transient { team { FactoryBot.create(:team, :in_current_season) } }
+      transient { team { create(:team, :in_current_season) } }
 
       after(:create) do |user, evaluator|
-        FactoryBot.create(:student_role, user: user, team: evaluator.team)
+        create(:student_role, user: user, team: evaluator.team)
       end
 
       trait :applicant do
@@ -48,40 +48,40 @@ FactoryBot.define do
     end
 
     factory :mentor do
-      transient { team { FactoryBot.create(:team) } }
+      transient { team { create(:team) } }
 
       after(:create) do |user, evaluator|
-        FactoryBot.create(:mentor_role, user: user, team: evaluator.team)
+        create(:mentor_role, user: user, team: evaluator.team)
       end
     end
 
     factory :organizer do
       after(:create) do |user|
-        FactoryBot.create(:organizer_role, user: user)
+        create(:organizer_role, user: user)
       end
     end
 
     factory :helpdesk do
       after(:create) do |user|
-        FactoryBot.create(:helpdesk_role, user: user)
+        create(:helpdesk_role, user: user)
       end
     end
 
     factory :developer do
       after(:create) do |user|
-        FactoryBot.create(:developer_role, user: user)
+        create(:developer_role, user: user)
       end
     end
 
     factory :supervisor do
       after(:create) do |user|
-        FactoryBot.create(:supervisor_role, user: user)
+        create(:supervisor_role, user: user)
       end
     end
 
     factory :reviewer do
       after(:create) do |user|
-        FactoryBot.create(:reviewer_role, user: user)
+        create(:reviewer_role, user: user)
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe ApplicationHelper do
   end
 
   describe '.time_for_user' do
-    let(:user) { FactoryBot.create(:user, timezone: "Europe/Rome") }
+    let(:user) { create(:user, timezone: "Europe/Rome") }
 
     before do
       Timecop.travel(Time.utc(2013, 5, 2, "12:00"))

--- a/spec/helpers/teams_helper_spec.rb
+++ b/spec/helpers/teams_helper_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 RSpec.describe TeamsHelper do
 
   describe "#conference_exists?" do
-    let(:conference_preference) { FactoryBot.create :conference_preference, :with_terms_checked }
-    let(:team_without) { FactoryBot.create :team }
+    let(:conference_preference) { create :conference_preference, :with_terms_checked }
+    let(:team_without) { create :team }
     let(:team_with) { conference_preference.team }
 
     it 'returns false if no conference_preference was persisted for the team' do

--- a/spec/lib/selection/service/application_distribution_spec.rb
+++ b/spec/lib/selection/service/application_distribution_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 require 'selection/service/application_distribution'
 
 describe Selection::Service::ApplicationDistribution do
-  let!(:reviewers) { FactoryBot.create_list(:reviewer, 4) }
-  let(:user) { FactoryBot.create(:user) }
-  let(:project) { FactoryBot.create(:project, :in_current_season, :accepted, submitter: user) }
-  let(:applications) { FactoryBot.create_list(:application, 10, :in_current_season, :for_project, project1: project) }
+  let!(:reviewers) { create_list(:reviewer, 4) }
+  let(:user) { create(:user) }
+  let(:project) { create(:project, :in_current_season, :accepted, submitter: user) }
+  let(:applications) { create_list(:application, 10, :in_current_season, :for_project, project1: project) }
 
   before do
     Todo.destroy_all

--- a/spec/mailers/application_form_mailer_spec.rb
+++ b/spec/mailers/application_form_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ApplicationFormMailer do
-  let(:application) { FactoryBot.build_stubbed(:application) }
+  let(:application) { build_stubbed(:application) }
   subject { ApplicationFormMailer.new_application(application) }
 
   it 'has ENV["EMAIL_FROM"] as from' do

--- a/spec/mailers/role_mailer_spec.rb
+++ b/spec/mailers/role_mailer_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 
 describe RoleMailer, type: :mailer do
   describe 'user_added_to_team' do
-    let(:user) { FactoryBot.create(:user) }
-    let(:team) { FactoryBot.create(:team) }
-    let(:role) { FactoryBot.create(:mentor_role, user: user, team: team) }
+    let(:user) { create(:user) }
+    let(:team) { create(:team) }
+    let(:role) { create(:mentor_role, user: user, team: team) }
 
     before do
       subject

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -7,8 +7,8 @@ describe Ability do
 
   context 'ability' do
     context 'when a user is connected' do
-      let!(:user) { FactoryBot.create(:user) }
-      let!(:team) { FactoryBot.create(:team) }
+      let!(:user) { create(:user) }
+      let!(:team) { create(:team) }
 
       describe 'she/he is allowed to do everything on her/his account' do
         it { expect(ability).to be_able_to(:show, user) }
@@ -18,14 +18,14 @@ describe Ability do
       end
 
       context 'when a user is admin' do
-        let(:organizer_role) { FactoryBot.create(:organizer_role, user: user) }
+        let(:organizer_role) { create(:organizer_role, user: user) }
         it "should be able to CRUD on anyone's account" do
           expect(subject).to be_able_to(:crud, organizer_role)
         end
       end
 
       describe 'she/he is not allowed to CRUD on someone else account' do
-        let(:other_user) { FactoryBot.create(:user) }
+        let(:other_user) { create(:user) }
         it { expect(ability).not_to be_able_to(:show, other_user) }
       end
 
@@ -35,7 +35,7 @@ describe Ability do
         # email address is hidden: admin, user's supervisor in current season (confirmed)
         # email address is not hidden: admin, confirmed user, user him/herself
 
-        let(:other_user) { FactoryBot.create(:user) }
+        let(:other_user) { create(:user) }
 
         context 'when email address is hidden' do
           context 'when an admin' do
@@ -100,7 +100,7 @@ describe Ability do
         # email address is hidden: not admin, not user's supervisor in current season
         # email address is not hidden: not admin, not confirmed user, not user him/herself
 
-        let(:other_user) { FactoryBot.create(:user) }
+        let(:other_user) { create(:user) }
 
         context 'when email address is hidden' do
           context "when not an admin or user's supervisor in current season" do
@@ -132,7 +132,7 @@ describe Ability do
 
 
       context 'resend_confirmation_instruction' do
-        let(:other_user) { FactoryBot.create(:user) }
+        let(:other_user) { create(:user) }
 
         describe 'a user can only resend her/his own confirmation' do
           it { expect(ability).to be_able_to(:resend_confirmation_instruction, user) }
@@ -140,7 +140,7 @@ describe Ability do
         end
 
         describe 'a admin can resend all confirmation tokens' do
-          let!(:organizer_role) { FactoryBot.create(:organizer_role, user: user) }
+          let!(:organizer_role) { create(:organizer_role, user: user) }
           it { expect(ability).to be_able_to(:resend_confirmation_instruction, other_user) }
         end
       end
@@ -148,7 +148,7 @@ describe Ability do
       describe "team's students or admin should be able to mark preferences to a conference" do
         context 'when user is a student from a team and try to update conference preferences' do
 
-          let!(:conference_preference) { FactoryBot.create(:conference_preference, :student_preference, :with_terms_checked) }
+          let!(:conference_preference) { create(:conference_preference, :student_preference, :with_terms_checked) }
           let!(:user) { conference_preference.team.students.first }
 
           it 'allows marking of conference preference' do
@@ -156,7 +156,7 @@ describe Ability do
           end
 
           context 'when user is admin' do
-            let!(:organiser_role) { FactoryBot.create(:organizer_role, user: user)}
+            let!(:organiser_role) { create(:organizer_role, user: user)}
             it "should be able to crud conference preference" do
               expect(subject).to be_able_to(:crud, conference_preference)
             end
@@ -164,15 +164,15 @@ describe Ability do
         end
 
         context 'when different users' do
-          let!(:other_user) { FactoryBot.create(:user)}
-          let!(:conference_preference) { FactoryBot.create(:conference_preference, :with_terms_checked, team: team)}
+          let!(:other_user) { create(:user)}
+          let!(:conference_preference) { create(:conference_preference, :with_terms_checked, team: team)}
           it { expect(ability).not_to be_able_to(:crud, other_user) }
 
         end
       end
 
       describe "just orga members, team's supervisor and team's students should be able to see offered conference for a team" do
-        let(:user) { FactoryBot.build(:student)}
+        let(:user) { build(:student)}
 
         context 'when the user is an student of another team' do
           it { expect(ability).not_to be_able_to(:see_offered_conferences, Team.new) }
@@ -233,7 +233,7 @@ describe Ability do
 
       describe 'access to mailings' do
         let!(:mailing) { Mailing.new }
-        let!(:user) { FactoryBot.create(:student) }
+        let!(:user) { create(:student) }
 
         context 'when user is a recipient' do
           it 'allows to read' do
@@ -262,7 +262,7 @@ describe Ability do
 
         context 'when not confirmed' do
           let!(:user) { create :student, confirmed_at: nil }
-          let(:team) { FactoryBot.create(:team) }
+          let(:team) { create(:team) }
 
           it 'does not allow to create teams' do
             expect(subject).not_to be_able_to :create, Team.new
@@ -347,12 +347,12 @@ describe Ability do
     end
 
     context 'working with projects' do
-      let!(:user) { FactoryBot.create(:user) }
+      let!(:user) { create(:user) }
 
       context 'crud' do
 
         it 'can be edited when I am an admin' do
-          FactoryBot.create(:organizer_role, user: user)
+          create(:organizer_role, user: user)
           expect(subject).to be_able_to :crud, Project.new
         end
 
@@ -387,8 +387,8 @@ describe Ability do
   end
 
   context 'to join helpdesk team' do
-    let(:user) { FactoryBot.create(:helpdesk) }
-    let(:team) { FactoryBot.create(:team) }
+    let(:user) { create(:helpdesk) }
+    let(:team) { create(:team) }
 
     it 'should be logged in' do
       expect(ability.signed_in?(user)).to eql true
@@ -399,13 +399,13 @@ describe Ability do
     end
 
     it 'should be able to join helpdesk team' do
-      helpdesk_team = FactoryBot.create(:team, :helpdesk)
+      helpdesk_team = create(:team, :helpdesk)
       expect(ability).to be_able_to(:join, helpdesk_team)
     end
   end
 
   context 'Crud Conferences' do
-    let!(:user) { FactoryBot.create(:user) }
+    let!(:user) { create(:user) }
 
     it 'permit crud conference when user is a current student' do
       create :student_role, user: user

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe Application do
-  subject { FactoryBot.build(:application) }
+  subject { build(:application) }
 
   it { is_expected.to validate_presence_of(:application_data) }
   it { is_expected.to validate_presence_of(:team) }
 
   it_behaves_like 'HasSeason'
   it_behaves_like 'Rateable' do
-    let(:rateable) { FactoryBot.create(:application) }
+    let(:rateable) { create(:application) }
   end
 
   context 'with associations' do
@@ -80,8 +80,8 @@ describe Application do
   end
 
   describe 'student_name' do
-    let(:team)    { FactoryBot.build(:team, students: [student]) }
-    let(:student) { FactoryBot.build(:student) }
+    let(:team)    { build(:team, students: [student]) }
+    let(:student) { build(:student) }
 
     before { allow(subject).to receive(:team).and_return(team) }
 
@@ -100,11 +100,11 @@ describe Application do
   end
 
   describe '#project1, project2' do
-    let(:application) { FactoryBot.create(:application) }
+    let(:application) { create(:application) }
 
     shared_examples :projectnr do |nr|
       context 'when project set' do
-        let(:project) { FactoryBot.create(:project) }
+        let(:project) { create(:project) }
 
         before do
           application.application_data["project#{nr}_id"] = project.id

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -5,8 +5,8 @@ describe Comment do
   it { is_expected.to belong_to(:commentable) }
 
   before do
-    @first_comment = FactoryBot.create(:team_comment)
-    @second_comment = FactoryBot.create(:application_comment)
+    @first_comment = create(:team_comment)
+    @second_comment = create(:application_comment)
   end
 
   describe '.ordered' do

--- a/spec/models/conference/importer_spec.rb
+++ b/spec/models/conference/importer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Conference::Importer do
       end
 
       it 'updates an existing conference' do
-        FactoryBot.create(:conference, gid: 2017001, city: "Bangalore", country: "Belgium")
+        create(:conference, gid: 2017001, city: "Bangalore", country: "Belgium")
 
         expect{subject}.to change{Conference.find_by(gid: 2017001).city}.from("Bangalore").to("Gent")
         expect{subject}.not_to change{Conference.find_by(gid: 2017001).country}
@@ -38,15 +38,15 @@ RSpec.describe Conference::Importer do
 
       it "will not destroy conferences" do
         # gid 2017010 is not in the .csv file
-        FactoryBot.create(:conference, gid: 2017010)
+        create(:conference, gid: 2017010)
         expect {subject}.not_to change{Conference.find_by(gid: 2017010)}
       end
 
       it 'assign the season_id' do
-        FactoryBot.create(:conference, gid: 2017001, season_id: nil)
-        FactoryBot.create(:conference, gid: 2018005, season_id: nil)
-        s_2017 = FactoryBot.create(:season, name: "2017")
-        s_2018 = FactoryBot.create(:season, name: "2018")
+        create(:conference, gid: 2017001, season_id: nil)
+        create(:conference, gid: 2018005, season_id: nil)
+        s_2017 = create(:season, name: "2017")
+        s_2018 = create(:season, name: "2018")
 
         expect{subject}.to change{Conference.find_by(gid: 2017001).season_id}.to(s_2017.id)
         expect(Conference.find_by(gid: 2018005).season_id).to eq s_2018.id

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -14,7 +14,7 @@ describe Conference do
   it { is_expected.to validate_presence_of(:region) }
 
   describe 'validates chronological dates' do
-    subject { FactoryBot.build(:conference) }
+    subject { build(:conference) }
     let(:start_date) { subject.starts_on }
 
     it 'with an incorrect order of dates it raises an error' do
@@ -46,7 +46,7 @@ describe Conference do
   end
 
   describe '#date_range' do
-    subject { FactoryBot.build_stubbed(:conference) }
+    subject { build_stubbed(:conference) }
 
     it 'has a date range' do
       expect(subject.date_range).to be_a(DateRange)
@@ -56,8 +56,8 @@ describe Conference do
   describe '#tickets_left' do
 
     context 'ticket value defined' do
-      let(:conference_preference) { FactoryBot.build(:conference_preference, confirmed: true) }
-      subject { FactoryBot.build_stubbed(:conference, tickets: 2) }
+      let(:conference_preference) { build(:conference_preference, confirmed: true) }
+      subject { build_stubbed(:conference, tickets: 2) }
 
       it 'subtracts conference preferences' do
         allow(subject).to receive(:conference_preference).and_return([conference_preference])
@@ -67,7 +67,7 @@ describe Conference do
     end
 
     context 'tickets value not defined' do
-      subject { FactoryBot.build_stubbed(:conference, tickets: nil) }
+      subject { build_stubbed(:conference, tickets: nil) }
 
       it 'returns 0' do
         allow(subject).to receive(:conference_preference).and_return([])

--- a/spec/models/mailing_spec.rb
+++ b/spec/models/mailing_spec.rb
@@ -42,7 +42,7 @@ describe Mailing do
   end
 
   describe '#recipient?' do
-    let(:student) { FactoryBot.create(:student) }
+    let(:student) { create(:student) }
 
     it 'returns false for a an empty recipients list' do
       subject.to = nil

--- a/spec/models/rating/table_spec.rb
+++ b/spec/models/rating/table_spec.rb
@@ -12,10 +12,10 @@ describe Rating::Table do
   end
 
   describe 'filtering and sorting' do
-    let(:blank)        { FactoryBot.build(:application, id: 4) }
-    let(:less_coaches) { FactoryBot.build(:application, id: 1, flags: ['less_than_two_coaches']) }
-    let(:remote)       { FactoryBot.build(:application, id: 2, flags: ['remote_team']) }
-    let(:male)         { FactoryBot.build(:application, id: 3, flags: ['male_gender']) }
+    let(:blank)        { build(:application, id: 4) }
+    let(:less_coaches) { build(:application, id: 1, flags: ['less_than_two_coaches']) }
+    let(:remote)       { build(:application, id: 2, flags: ['remote_team']) }
+    let(:male)         { build(:application, id: 3, flags: ['male_gender']) }
     let(:applications) { [blank, less_coaches, remote, male] }
 
     subject { described_class.new(applications: applications, options: options) }

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 describe Rating do
-  let(:application) { FactoryBot.build(:application) }
+  let(:application) { build(:application) }
 
   describe 'associations' do
     it { is_expected.to belong_to(:user) }
@@ -15,7 +15,7 @@ describe Rating do
     # https://github.com/thoughtbot/shoulda-matchers/issues/535
     # that's why we do it "by hand"
     it 'should only allow for one rating per user and rateable' do
-      user = FactoryBot.create :user
+      user = create :user
       Rating.create(rateable: application, user: user)
       expect{ Rating.create!(rateable: application, user: user) }.to raise_error(ActiveRecord::RecordInvalid)
     end
@@ -23,14 +23,14 @@ describe Rating do
   describe 'scopes' do
     describe 'by' do
       it 'should return the rating for the given user' do
-        user = FactoryBot.create(:user)
-        rating = FactoryBot.create(:rating, user: user, rateable: application)
+        user = create(:user)
+        rating = create(:rating, user: user, rateable: application)
         expect(Rating.by(user).first).to eq(rating)
       end
     end
   end
   describe '.user_names' do
-    let!(:users) { FactoryBot.create_list :reviewer, 3 }
+    let!(:users) { create_list :reviewer, 3 }
     let(:user_names) { users.map(&:name) }
 
     it 'returns names of all reviewers' do
@@ -44,7 +44,7 @@ describe Rating do
   end
   describe '#points' do
     it 'should add up some points given through valid fields' do
-      rating = FactoryBot.create(:rating, rateable: application)
+      rating = create(:rating, rateable: application)
       rating.diversity = 1
       rating.save
 

--- a/spec/models/recipients_spec.rb
+++ b/spec/models/recipients_spec.rb
@@ -61,11 +61,11 @@ describe Recipients do
   describe '#users' do
     context 'when grouped' do
       let(:to) { %w(students) }
-      let!(:selected_team) { FactoryBot.create(:team, kind: Team::KINDS.sample) }
-      let!(:selected_students) { FactoryBot.create_list(:student, 2, team: selected_team) }
+      let!(:selected_team) { create(:team, kind: Team::KINDS.sample) }
+      let!(:selected_students) { create_list(:student, 2, team: selected_team) }
 
-      let!(:unselected_team) { FactoryBot.create(:team, kind: nil) }
-      let!(:unselected_students) { FactoryBot.create_list(:student, 2, team: unselected_team) }
+      let!(:unselected_team) { create(:team, kind: nil) }
+      let!(:unselected_students) { create_list(:student, 2, team: unselected_team) }
 
       context 'when group is selected_teams' do
         let(:group) { 'selected_teams' }
@@ -93,8 +93,8 @@ describe Recipients do
 
       context 'when to is just organizers' do
         let(:to) { %w(organizers) }
-        let!(:helpdesks) { FactoryBot.create_list(:helpdesk, 2) }
-        let!(:organizers) { FactoryBot.create_list(:organizer, 2 ) }
+        let!(:helpdesks) { create_list(:helpdesk, 2) }
+        let!(:organizers) { create_list(:organizer, 2 ) }
 
         it 'returns all organizers' do
           expect(subject.users).to match_array(organizers)
@@ -105,12 +105,12 @@ describe Recipients do
     context 'when seasons are selected' do
       let(:to) { %w(students) }
       let(:seasons) { %w(2015) }
-      let(:season_2015) { FactoryBot.create(:season, name: '2015') }
-      let(:team) { FactoryBot.create(:team, season: season_2015) }
-      let!(:students) { FactoryBot.create_list(:student, 2, team: team) }
-      let!(:coaches) { FactoryBot.create_list(:coach, 2, team: team) }
-      let!(:other_students) { FactoryBot.create_list(:student, 2) }
-      let!(:organizers) { FactoryBot.create_list(:organizer, 2 ) }
+      let(:season_2015) { create(:season, name: '2015') }
+      let(:team) { create(:team, season: season_2015) }
+      let!(:students) { create_list(:student, 2, team: team) }
+      let!(:coaches) { create_list(:coach, 2, team: team) }
+      let!(:other_students) { create_list(:student, 2) }
+      let!(:organizers) { create_list(:organizer, 2 ) }
 
       it 'only returns students that belong to the 2015 season' do
         expect(subject.users).to match_array(students)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Submission do
-  let(:submission) { FactoryBot.build(:submission) }
-  let(:unsent) { FactoryBot.create(:submission, sent_at: nil)}
+  let(:submission) { build(:submission) }
+  let(:unsent) { create(:submission, sent_at: nil)}
 
   describe '#sent?' do
     it 'lists unsent submissions' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -22,7 +22,7 @@ describe Team do
 
   context 'multiple team memberships' do
     let!(:existing_team) { role.team }
-    let(:role)   { FactoryBot.create "#{role_name}_role" }
+    let(:role)   { create "#{role_name}_role" }
     let(:member) { role.user }
     let(:user) { create(:user) }
     let(:team) { create :team, :in_current_season }
@@ -148,11 +148,11 @@ describe Team do
   end
 
   describe '#coaches_confirmed?' do
-    let(:role) { FactoryBot.create "#{role_name}_role" }
+    let(:role) { create "#{role_name}_role" }
     let(:role_name) { 'coach' }
     let(:member) { role.user }
     let(:user) { create(:user) }
-    let(:team) { FactoryBot.create(:team) }
+    let(:team) { create(:team) }
     let(:roles_attributes) { [{ name: role_name, team_id: team.id, user_id: member.id }] }
 
     it 'says its coaches are confirmed when all coaches are confirmed' do
@@ -172,7 +172,7 @@ describe Team do
   describe '#confirmed?' do
     let(:first_student) { create(:user) }
     let(:second_student) { create(:user) }
-    let(:team) { FactoryBot.create(:team) }
+    let(:team) { create(:team) }
     let(:role_name) { 'student' }
     it 'will not be confirmed if only one student present' do
       team.attributes = { roles_attributes: [{ name: role_name, user_id: first_student.id }] }
@@ -360,7 +360,7 @@ describe Team do
   end
 
   describe 'checking' do
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { create(:user) }
 
     subject { create :team }
 

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Todo, type: :model do
 
   describe '.for_current_season' do
     let!(:todos) do
-      FactoryBot.create_list(:todo, 3,
+      create_list(:todo, 3,
         application: build(:application, :in_current_season)
       )
     end
@@ -18,10 +18,10 @@ RSpec.describe Todo, type: :model do
     subject { described_class.for_current_season }
 
     before do
-      FactoryBot.create(:todo,
+      create(:todo,
         application: build(:application, season: build(:season))
       )
-      FactoryBot.create(:todo,
+      create(:todo,
         application: build(:application, :in_current_season, :skip_validations, team: nil)
       )
     end
@@ -32,12 +32,12 @@ RSpec.describe Todo, type: :model do
   end
 
   describe '#rating' do
-    let!(:todo) { FactoryBot.create(:todo) }
+    let!(:todo) { create(:todo) }
 
     subject { todo.rating }
 
     it 'returns rating if user rated application' do
-      rating = FactoryBot.build(:rating,
+      rating = build(:rating,
         user:        todo.user,
         rateable_id: todo.application.id,
         rateable_type: "Application"
@@ -52,7 +52,7 @@ RSpec.describe Todo, type: :model do
   end
 
   describe '#eligible?' do
-    let(:todo) { FactoryBot.build(:todo) }
+    let(:todo) { build(:todo) }
 
     it 'returns true if application does not have any flags set' do
       todo.application.flags = []
@@ -71,10 +71,10 @@ RSpec.describe Todo, type: :model do
   end
 
   describe '#done?' do
-    let!(:todo) { FactoryBot.create(:todo) }
+    let!(:todo) { create(:todo) }
 
     it 'returns true if application has been rated' do
-      rating = FactoryBot.build(:rating,
+      rating = build(:rating,
         user:        todo.user,
         rateable_id: todo.application.id,
         rateable_type: "Application"
@@ -89,7 +89,7 @@ RSpec.describe Todo, type: :model do
   end
 
   describe '#sign_offs?' do
-    let(:todo) { FactoryBot.build(:todo) }
+    let(:todo) { build(:todo) }
 
     it 'returns an array of booleans for the application sign_offs' do
       todo.application.application_data = { "signed_off_at_project1": Time.now.utc.to_s }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -236,26 +236,26 @@ describe User do
 
   describe '#admin?' do
     it 'returns false for users w/o admin role' do
-      student = FactoryBot.create(:student)
+      student = create(:student)
       expect(student).not_to be_admin
     end
 
     it 'returns true if user has a admin role' do
-      supervisor = FactoryBot.create(:supervisor)
-      FactoryBot.create(:organizer_role, user: supervisor)
+      supervisor = create(:supervisor)
+      create(:organizer_role, user: supervisor)
       expect(supervisor).to be_admin
     end
   end
 
   describe '#mentor?' do
     it 'returns false for users w/o mentor role' do
-      student = FactoryBot.create(:student)
+      student = create(:student)
       expect(student).not_to be_mentor
     end
 
     it 'returns true if user has a mentor role' do
-      mentor = FactoryBot.create(:mentor)
-      FactoryBot.create(:organizer_role, user: mentor)
+      mentor = create(:mentor)
+      create(:organizer_role, user: mentor)
       expect(mentor).to be_mentor
     end
   end
@@ -264,7 +264,7 @@ describe User do
     let!(:maintainer) { create(:user) }
 
     it 'returns false for users who did not submit a project' do
-      student = FactoryBot.create(:student)
+      student = create(:student)
       expect(student).not_to be_project_maintainer
     end
 
@@ -290,7 +290,7 @@ describe User do
     end
 
     it 'returns true if user has a reviewer role' do
-      reviewer = FactoryBot.create(:reviewer)
+      reviewer = create(:reviewer)
       expect(reviewer).to be_reviewer
     end
   end
@@ -301,7 +301,7 @@ describe User do
     end
 
     it 'returns true if user has a student role' do
-      student = FactoryBot.create(:student)
+      student = create(:student)
       expect(student).to be_student
     end
   end
@@ -312,7 +312,7 @@ describe User do
     end
 
     it 'returns true if user has a supervisor role' do
-      supervisor = FactoryBot.create(:supervisor)
+      supervisor = create(:supervisor)
       expect(supervisor).to be_supervisor
     end
   end
@@ -324,27 +324,27 @@ describe User do
     end
 
     it 'returns false if user has a random student role' do
-      student = FactoryBot.build(:student)
+      student = build(:student)
       expect(student).not_to be_current_student
     end
 
     it 'returns false if user\'s team has not been accepted' do
-      team    = FactoryBot.create(:team, :in_current_season, kind: nil)
-      student = FactoryBot.create(:student, team: team)
+      team    = create(:team, :in_current_season, kind: nil)
+      student = create(:student, team: team)
       expect(student).not_to be_current_student
     end
 
     it 'returns true if user is among this season\'s accepted students' do
-      team    = FactoryBot.create(:team, :in_current_season, kind: 'sponsored')
-      student = FactoryBot.create(:student, team: team)
+      team    = create(:team, :in_current_season, kind: 'sponsored')
+      student = create(:student, team: team)
       expect(student).to be_current_student
     end
   end
 
   describe '#student_team' do
     before do
-      @user_not_student = FactoryBot.create(:user)
-      @student = FactoryBot.create(:student)
+      @user_not_student = create(:user)
+      @student = create(:student)
       @student_team = @student.teams.first
     end
 
@@ -364,10 +364,10 @@ describe User do
 
   describe 'Search for user names and team names' do
     before do
-      @cruyff = FactoryBot.create(:user, name: "Johan Cruyff")
-      @eesy = FactoryBot.create(:user, name: "Eesy Peesy")
-      @team = FactoryBot.create(:team, name: "Cheesy")
-      @cheesy = FactoryBot.create(:student, team: @team)
+      @cruyff = create(:user, name: "Johan Cruyff")
+      @eesy = create(:user, name: "Eesy Peesy")
+      @team = create(:team, name: "Cheesy")
+      @cheesy = create(:student, team: @team)
 
     end
 
@@ -392,10 +392,10 @@ describe User do
   end
 
   context 'with roles' do
-    let!(:user) { FactoryBot.create(:user) }
-    let!(:team) { FactoryBot.create(:team) }
-    let!(:coach) { FactoryBot.create(:coach_role, team: team, user: user) }
-    let!(:mentor) { FactoryBot.create(:mentor_role, team: team, user: user) }
+    let!(:user) { create(:user) }
+    let!(:team) { create(:team) }
+    let!(:coach) { create(:coach_role, team: team, user: user) }
+    let!(:mentor) { create(:mentor_role, team: team, user: user) }
 
     it 'lists unique teams even with different roles' do
       expect(user.teams.count).to eql 1

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -2,7 +2,7 @@ module ControllerMacros
   def login_user(user=nil)
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
-      user ||= FactoryBot.create(:user)
+      user ||= create(:user)
       sign_in user
     end
   end

--- a/spec/support/shared_examples/rateable.rb
+++ b/spec/support/shared_examples/rateable.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples 'Rateable' do
 
     context 'when ratings' do
       before do
-        FactoryBot.create_list(:rating, 2,
+        create_list(:rating, 2,
           rateable: rateable,
           data:     { 'diversity' => 1 }
         )
@@ -35,12 +35,12 @@ RSpec.shared_examples 'Rateable' do
 
     context 'when even ratings' do
       before do
-        FactoryBot.create_list(:rating, 2,
+        create_list(:rating, 2,
           rateable: rateable,
           data:     { 'diversity' => 1 }
         )
 
-        FactoryBot.create_list(:rating, 2,
+        create_list(:rating, 2,
           rateable: rateable,
           data:     { 'diversity' => 5 }
         )
@@ -53,12 +53,12 @@ RSpec.shared_examples 'Rateable' do
 
     context 'when odd ratings' do
       before do
-        FactoryBot.create_list(:rating, 2,
+        create_list(:rating, 2,
           rateable: rateable,
           data:     { 'diversity' => 1 }
         )
 
-        FactoryBot.create_list(:rating, 1,
+        create_list(:rating, 1,
           rateable: rateable,
           data:     { 'diversity' => 4 }
         )
@@ -80,12 +80,12 @@ RSpec.shared_examples 'Rateable' do
     end
 
     context 'when ratings' do
-      let(:user1) { FactoryBot.create(:user) }
-      let(:user2) { FactoryBot.create(:user) }
+      let(:user1) { create(:user) }
+      let(:user2) { create(:user) }
 
       before do
-        FactoryBot.create(:rating, rateable: rateable, user: user1)
-        FactoryBot.create(:rating, rateable: rateable, user: user2)
+        create(:rating, rateable: rateable, user: user1)
+        create(:rating, rateable: rateable, user: user2)
       end
 
       it 'retuns the users names and points' do
@@ -108,8 +108,8 @@ RSpec.shared_examples 'Rateable' do
 
     context 'when ratings' do
       before do
-        FactoryBot.create_list(:rating, 2, rateable: rateable, pick: true)
-        FactoryBot.create_list(:rating, 2, rateable: rateable)
+        create_list(:rating, 2, rateable: rateable, pick: true)
+        create_list(:rating, 2, rateable: rateable)
       end
 
       it 'returns the sum of picks given' do
@@ -129,8 +129,8 @@ RSpec.shared_examples 'Rateable' do
 
     context 'when ratings' do
       before do
-        FactoryBot.create_list(:rating, 2, rateable: rateable, like: true)
-        FactoryBot.create_list(:rating, 2, rateable: rateable)
+        create_list(:rating, 2, rateable: rateable, like: true)
+        create_list(:rating, 2, rateable: rateable)
       end
 
       it 'returns the sum of likes given' do


### PR DESCRIPTION
After briefly discussing this with @carpodaster, seeing it in the code bases I interact with daily and in regard of our 👮 👮 for line and method length, I chose to move things back from the "long" FactoryBot syntax to the short one.
E.g.
```
FactoryBot.create(:thing)
=> 
create(:thing)
```

Feel free to discard the PR if you totally disagree with this 😉 