### PR TITLE
[#726] Cleanup Rating - Application reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ end
 
 group :test do
   gem 'rails-controller-testing'
-  gem 'shoulda'
   gem 'shoulda-matchers'
   gem 'webmock'
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,10 +307,6 @@ GEM
     sax-machine (1.3.2)
     sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
-    shoulda (3.5.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (>= 1.4.1, < 3.0)
-    shoulda-context (1.2.2)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     simple_form (3.5.0)
@@ -414,7 +410,6 @@ DEPENDENCIES
   rubocop
   sass-rails
   sentry-raven
-  shoulda
   shoulda-matchers
   simple_form
   slim-rails

--- a/app/controllers/rating/ratings_controller.rb
+++ b/app/controllers/rating/ratings_controller.rb
@@ -16,7 +16,7 @@ class Rating::RatingsController < Rating::BaseController
   private
 
   def new_rating_params
-    params.require(:rating).permit(:rateable_id, :rateable_type, :like, :pick, Rating::FIELDS.keys)
+    params.require(:rating).permit(:application_id, :like, :pick, Rating::FIELDS.keys)
   end
 
   def rating_attr_params
@@ -24,7 +24,7 @@ class Rating::RatingsController < Rating::BaseController
   end
 
   def find_or_create_rating
-    rateable_args = new_rating_params.values_at(:rateable_type, :rateable_id)
-    Rating.by(current_user).for(*rateable_args).first_or_create
+    application = Application.find_by(id: new_rating_params[:application_id])
+    application.ratings.by(current_user).first_or_create
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,4 +1,4 @@
-class Activity < ActiveRecord::Base
+class Activity < ApplicationRecord
   KINDS = %w(feed_entry mailing status_update)
 
   belongs_to :team

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,14 +1,6 @@
 class Application < ActiveRecord::Base
   include HasSeason, Rateable
 
-  belongs_to :application_draft
-  belongs_to :team, inverse_of: :applications, counter_cache: true
-  belongs_to :project
-
-  has_many :todos, dependent: :destroy
-
-  validates :team, :application_data, presence: true
-
   PROJECT_VISIBILITY_WEIGHT = ENV['PROJECT_VISIBILITY_WEIGHT'] || 2
   COACHING_COMPANY_WEIGHT = ENV['COACHING_COMPANY_WEIGHT'] || 2
   MENTOR_PICK_WEIGHT = ENV['MENTOR_PICK_WEIGHT'] || 2
@@ -21,7 +13,13 @@ class Application < ActiveRecord::Base
           :less_than_two_coaches,
           :less_than_40_hours_a_week]
 
+  belongs_to :application_draft
+  belongs_to :team, inverse_of: :applications, counter_cache: true
+  belongs_to :project
+
   has_many :comments, -> { order(:created_at) }, as: :commentable, dependent: :destroy
+
+  validates :team, :application_data, presence: true
 
   scope :hidden, -> { where('applications.hidden IS NOT NULL and applications.hidden = ?', true) }
   scope :visible, -> { where('applications.hidden IS NULL or applications.hidden = ?', false) }
@@ -30,16 +28,16 @@ class Application < ActiveRecord::Base
     ApplicationDraft.human_attribute_name(key)
   end
 
-  def data
-    ApplicationData.new(application_data)
-  end
-
   def self.rateable
     joins("LEFT JOIN projects p1 ON p1.id::text = applications.application_data -> 'project1_id'")
       .joins("LEFT JOIN projects p2 ON p2.id::text = applications.application_data -> 'project2_id'")
       .includes(:ratings, :team)
       .where(season: Season.current)
       .where.not(team: nil)
+  end
+
+  def data
+    ApplicationData.new(application_data)
   end
 
   def name

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,4 +1,4 @@
-class Application < ActiveRecord::Base
+class Application < ApplicationRecord
   include HasSeason, Rateable
 
   PROJECT_VISIBILITY_WEIGHT = ENV['PROJECT_VISIBILITY_WEIGHT'] || 2

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -1,4 +1,4 @@
-class ApplicationDraft < ActiveRecord::Base
+class ApplicationDraft < ApplicationRecord
   include HasSeason
 
   include AASM

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,4 @@
-class Comment < ActiveRecord::Base
+class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :project
   belongs_to :commentable, polymorphic: true

--- a/app/models/concerns/rateable.rb
+++ b/app/models/concerns/rateable.rb
@@ -1,7 +1,8 @@
 module Rateable
   extend ActiveSupport::Concern
+
   included do
-    has_many :ratings, as: :rateable
+    has_many :ratings, dependent: :destroy
   end
 
   def average_points

--- a/app/models/concerns/rateable.rb
+++ b/app/models/concerns/rateable.rb
@@ -3,6 +3,7 @@ module Rateable
 
   included do
     has_many :ratings, dependent: :destroy
+    has_many :todos, dependent: :destroy
   end
 
   def average_points

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,5 +1,5 @@
 require 'csv'
-class Conference < ActiveRecord::Base
+class Conference < ApplicationRecord
   REGION_LIST = [
     "Africa",
     "South America",

--- a/app/models/conference_preference.rb
+++ b/app/models/conference_preference.rb
@@ -1,4 +1,4 @@
-class ConferencePreference < ActiveRecord::Base
+class ConferencePreference < ApplicationRecord
   validates :terms_of_ticket, inclusion: { in: [true] }, if: :conference_exists?
   validates :terms_of_travel, inclusion: { in: [true] }, if: :conference_exists?
   before_save :change_status_terms, unless: :conference_exists?

--- a/app/models/mailing.rb
+++ b/app/models/mailing.rb
@@ -1,4 +1,4 @@
-class Mailing < ActiveRecord::Base
+class Mailing < ApplicationRecord
 
   TO = %w(teams students coaches helpdesk organizers supervisors developers mentors)
   FROM = ENV['EMAIL_FROM'] || 'contact@rgsoc.org'

--- a/app/models/mentor/comment.rb
+++ b/app/models/mentor/comment.rb
@@ -1,5 +1,5 @@
 module Mentor
-  class Comment < ActiveRecord::Base
+  class Comment < ApplicationRecord
     self.table_name = 'comments'
 
     default_scope { where(commentable_type: COMMENTABLE_TYPE) }

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,4 +1,4 @@
-class Note < ActiveRecord::Base
+class Note < ApplicationRecord
 
   def self.notepad(user)
     Note.find_or_create_by(user_id: user.id)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,4 @@
-class Project < ActiveRecord::Base
+class Project < ApplicationRecord
   include HasSeason
 
   belongs_to :submitter, class_name: 'User'

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,5 +1,5 @@
 class Rating < ApplicationRecord
-  belongs_to :application, inverse_of: :ratings, required: true
+  belongs_to :application, required: true
   belongs_to :user, required: true
 
   serialize :data

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,6 +1,6 @@
 class Rating < ActiveRecord::Base
-  belongs_to :application, inverse_of: :ratings
-  belongs_to :user
+  belongs_to :application, inverse_of: :ratings, required: true
+  belongs_to :user, required: true
 
   serialize :data
 
@@ -108,25 +108,9 @@ class Rating < ActiveRecord::Base
 
   before_validation :set_data
 
-  validates :application, presence: true
-  validates :user,        presence: true
-  validates :user_id,     uniqueness: { scope: :application_id }
+  validates :user_id, uniqueness: { scope: :application_id }
 
   scope :by, -> (user) { where(user_id: user.id) }
-
-  class << self
-    def user_names
-      User.includes(:roles).where('roles.name = ?', 'reviewer').pluck(:name)
-    end
-
-    def excluding(names)
-      joins(:user).where('users.name NOT IN (?)', names)
-    end
-  end
-
-  def woman?
-    data[:is_woman] == 1
-  end
 
   # public: The weighted sum of the points that the reviewer gave.
   def points

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,4 +1,4 @@
-class Rating < ActiveRecord::Base
+class Rating < ApplicationRecord
   belongs_to :application, inverse_of: :ratings, required: true
   belongs_to :user, required: true
 

--- a/app/models/rating/strictness.rb
+++ b/app/models/rating/strictness.rb
@@ -44,9 +44,7 @@ class Rating::Strictness
   private
 
   def ratings
-    @ratings ||= Rating
-                  .includes(:application)
-                  .where('applications.season_id' => season.id)
+    @ratings ||= Rating.joins(:application).where('applications.season_id' => season.id)
   end
 
   # @return [Array<Integer>] list of IDs for all rated applications

--- a/app/models/rating/strictness.rb
+++ b/app/models/rating/strictness.rb
@@ -45,14 +45,13 @@ class Rating::Strictness
 
   def ratings
     @ratings ||= Rating
-                  .joins('JOIN applications ON ratings.rateable_id = applications.id')
-                  .where(rateable_type: 'Application')
+                  .includes(:application)
                   .where('applications.season_id' => season.id)
   end
 
   # @return [Array<Integer>] list of IDs for all rated applications
   def application_ids
-    @application_ids ||= ratings.pluck(:rateable_id)
+    @application_ids ||= ratings.pluck(:application_id)
   end
 
   # @return [Array<Application>] all rated applications

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,4 @@
-class Role < ActiveRecord::Base
+class Role < ApplicationRecord
   include AASM
 
   TEAM_ROLES  = %w(student coach)

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,4 +1,4 @@
-class Season < ActiveRecord::Base
+class Season < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,4 +1,4 @@
-class Source < ActiveRecord::Base
+class Source < ApplicationRecord
   include UrlHelper
 
   KINDS = %w(blog repository)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,4 +1,4 @@
-class Submission < ActiveRecord::Base
+class Submission < ApplicationRecord
   class << self
     def unsent
       where(sent_at: nil)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,4 +1,4 @@
-class Team < ActiveRecord::Base
+class Team < ApplicationRecord
   include ProfilesHelper, HasSeason
 
   delegate :sponsored?, :voluntary?, to: :kind

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -32,6 +32,6 @@ class Todo < ApplicationRecord
   end
 
   def validate_number_of_reviewers
-    errors.add(:user, 'too many reviewers') if application.todos.count > 3
+    errors.add(:user, :too_many_reviewers) if application.todos.count > 3
   end
 end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -5,8 +5,7 @@ class Todo < ApplicationRecord
   belongs_to :user, inverse_of: :todos, required: true
   belongs_to :application, inverse_of: :todos, required: true
 
-  delegate :season, to: :application
-  delegate :application_data, to: :application
+  delegate :application_data, :season, to: :application
 
   validate :validate_number_of_reviewers, if: :application
 

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -2,8 +2,8 @@ class Todo < ApplicationRecord
   BLACK_FLAGS = %w(remote_team male_gender age_below_18 less_than_two_coaches zero_community)
   SIGN_OFFS   = %w(signed_off_at_project1 signed_off_at_project2)
 
-  belongs_to :user, inverse_of: :todos, required: true
-  belongs_to :application, inverse_of: :todos, required: true
+  belongs_to :user, required: true
+  belongs_to :application, required: true
 
   delegate :application_data, :season, to: :application
 

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -2,13 +2,13 @@ class Todo < ApplicationRecord
   BLACK_FLAGS = %w(remote_team male_gender age_below_18 less_than_two_coaches zero_community)
   SIGN_OFFS   = %w(signed_off_at_project1 signed_off_at_project2)
 
-  belongs_to :user
-  belongs_to :application
+  belongs_to :user, inverse_of: :todos, required: true
+  belongs_to :application, inverse_of: :todos, required: true
 
-  delegate   :season, to: :application
-  delegate   :application_data, to: :application
+  delegate :season, to: :application
+  delegate :application_data, to: :application
 
-  validate :validate_number_of_reviewers
+  validate :validate_number_of_reviewers, if: :application
 
   def self.for_current_season
     includes(:user, application: [:team, :ratings, :season])
@@ -33,6 +33,6 @@ class Todo < ApplicationRecord
   end
 
   def validate_number_of_reviewers
-    errors.add(:user, 'too many reviewers') if application.todos.size > 3
+    errors.add(:user, 'too many reviewers') if application.todos.count > 3
   end
 end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -17,7 +17,7 @@ class Todo < ApplicationRecord
   end
 
   def rating
-    Rating.find_by(user: user, rateable_type: "Application", rateable_id: application)
+    Rating.find_by(user: user, application: application)
   end
 
   def eligible?
@@ -33,6 +33,6 @@ class Todo < ApplicationRecord
   end
 
   def validate_number_of_reviewers
-    errors.add(:user, "too many reviewers") if application.todos.size > 3
+    errors.add(:user, 'too many reviewers') if application.todos.size > 3
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'github/user'
 
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   TSHIRT_SIZES = %w(XXS XS S M L XL 2XL 3XL)
   TSHIRT_CUTS = %w(Straight Fitted)
   URL_PREFIX_PATTERN = /\A(http|https).*\z/i

--- a/app/views/rating/shared/_rating_sidebar.html.slim
+++ b/app/views/rating/shared/_rating_sidebar.html.slim
@@ -1,11 +1,10 @@
 #rating data-behavior='rating-sidebar'
   = simple_form_for path_parents << @rating do |f|
-    = f.input :rateable_id, as: :hidden, value: application.id
-    = f.input :rateable_type, as: :hidden, value: application.class
+    = f.input :application_id, as: :hidden, value: application.id
 
     - Rating::FIELDS.keys.each do |key|
       = f.input key, collection: Rating.send("#{key}_options"), include_blank: false, selected: rating.send(key), input_html: field_tooltip(key)
 
-    = f.input :like, label: "Like", label_html: field_tooltip(:like)
-    = f.input :pick, label: "My Pick", label_html: field_tooltip(:pick)
-    = f.submit 'Save', class: "btn btn-primary"
+    = f.input :like, label: 'Like', label_html: field_tooltip(:like)
+    = f.input :pick, label: 'My Pick', label_html: field_tooltip(:pick)
+    = f.submit 'Save', class: 'btn btn-primary'

--- a/config/initializers/new_framework_defaults_5_1.rb
+++ b/config/initializers/new_framework_defaults_5_1.rb
@@ -9,6 +9,9 @@
 # Make `form_with` generate non-remote forms.
 Rails.application.config.action_view.form_with_generates_remote_forms = false
 
+# Make belongs_to required by default (goal to turn this on at some point...)
+Rails.application.config.active_record.belongs_to_required_by_default = false
+
 # Unknown asset fallback will return the path passed in when the given
 # asset is not present in the asset pipeline.
 # Rails.application.config.assets.unknown_asset_fallback = false

--- a/config/initializers/new_framework_defaults_5_1.rb
+++ b/config/initializers/new_framework_defaults_5_1.rb
@@ -9,7 +9,8 @@
 # Make `form_with` generate non-remote forms.
 Rails.application.config.action_view.form_with_generates_remote_forms = false
 
-# Make belongs_to required by default (goal to turn this on at some point...)
+# The belongs_to associations are required by default in Rails 5
+# we cannot opt into this right now, but it would be a goal for the future
 Rails.application.config.active_record.belongs_to_required_by_default = false
 
 # Unknown asset fallback will return the path passed in when the given

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,8 +69,6 @@ en:
         voluntary_hours_per_week: How many hours per week would you be able to work on the project?
         heard_about_it: How have you heard about the program?
         misc_info: Anything else to add?
-
-
         project_url: Project URL
         coaches_hours_per_week: "Coaches' Hours-per-Week"
         coaches_why_team_successful: "Coaches' Success-Statement"
@@ -84,3 +82,10 @@ en:
 
       project:
         issues_and_features: Tasks and features
+
+    errors:
+        models:
+          todo:
+            attributes:
+              user:
+                too_many_reviewers: too many reviewers

--- a/db/migrate/20171112174323_remove_polymorphism_from_ratings.rb
+++ b/db/migrate/20171112174323_remove_polymorphism_from_ratings.rb
@@ -1,5 +1,7 @@
 class RemovePolymorphismFromRatings < ActiveRecord::Migration[5.1]
-  class Rating < ActiveRecord::Base; end
+  class Rating < ActiveRecord::Base
+    self.table_name = :ratings
+  end
 
   def up
     add_index :ratings, :application_id

--- a/db/migrate/20171112174323_remove_polymorphism_from_ratings.rb
+++ b/db/migrate/20171112174323_remove_polymorphism_from_ratings.rb
@@ -1,0 +1,32 @@
+class RemovePolymorphismFromRatings < ActiveRecord::Migration[5.1]
+  class Rating < ActiveRecord::Base; end
+
+  def up
+    add_index :ratings, :application_id
+    remove_index :ratings, column: [:rateable_id, :rateable_type]
+    migrate_and_remove_existing_records
+    remove_column :ratings, :rateable_type, :string
+    remove_column :ratings, :rateable_id, :integer
+  end
+
+  def down
+    add_column :ratings, :rateable_type, :string
+    add_column :ratings, :rateable_id, :integer
+    add_index :ratings, [:rateable_id, :rateable_type]
+    remove_index :ratings, column: [:application_id]
+    migrate_records_back
+  end
+
+  def migrate_and_remove_existing_records
+    Rating.where(rateable_type: 'Application').find_each do |rating|
+      rating.update(application_id: rating.rateable_id)
+    end
+    Rating.where(application_id: nil).destroy_all
+  end
+
+  def migrate_records_back
+    Rating.find_each do |rating|
+      rating.update(rateable_id: rating.application_id, rateable_type: 'Application')
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170918135346) do
+ActiveRecord::Schema.define(version: 20171112174323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -195,10 +195,8 @@ ActiveRecord::Schema.define(version: 20170918135346) do
     t.datetime "updated_at"
     t.integer "user_id"
     t.boolean "pick"
-    t.integer "rateable_id"
-    t.string "rateable_type", limit: 255
     t.boolean "like"
-    t.index ["rateable_id", "rateable_type"], name: "index_ratings_on_rateable_id_and_rateable_type"
+    t.index ["application_id"], name: "index_ratings_on_application_id"
   end
 
   create_table "roles", id: :serial, force: :cascade do |t|

--- a/spec/controllers/rating/applications_controller_spec.rb
+++ b/spec/controllers/rating/applications_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating::ApplicationsController do
+describe Rating::ApplicationsController, type: :controller do
   render_views
 
   describe 'GET index' do
@@ -98,7 +98,7 @@ describe Rating::ApplicationsController do
 
         it 'assigns new @rating from user' do
           expect(assigns :rating).to be_a_new Rating
-          expect(assigns :rating).to have_attributes(user: user, rateable: application)
+          expect(assigns :rating).to have_attributes(user: user, application: application)
         end
 
         it 'renders rating/applications/show' do
@@ -107,7 +107,7 @@ describe Rating::ApplicationsController do
       end
 
       context 'when application already rated by user' do
-        let!(:rating) { create :rating, :for_application, user: user, rateable: application }
+        let!(:rating) { create :rating, user: user, application: application }
 
         it 'assigns existing @rating' do
           get :show, params: { id: application }

--- a/spec/controllers/rating/ratings_controller_spec.rb
+++ b/spec/controllers/rating/ratings_controller_spec.rb
@@ -20,14 +20,21 @@ describe Rating::RatingsController, type: :controller do
     context 'when reviewer' do
       let(:user) { create :reviewer }
       let!(:application) { create :application }
-      let(:params) { {rating: {rateable_id: application.id, rateable_type: 'Application', diversity: 5}} }
+      let(:params) do
+        {
+          rating: {
+            application_id: application.id,
+            diversity: 5
+          }
+        }
+      end
 
       before { sign_in user }
 
       it 'creates new rating record for application' do
         expect{
           post :create, params: params
-        }.to change{Rating.count}.by 1
+        }.to change{ Rating.count }.by 1
       end
 
       it 'sets rating attribute' do
@@ -52,8 +59,8 @@ describe Rating::RatingsController, type: :controller do
       before { sign_in user }
 
       context 'when user not author of rating' do
-        let!(:rating) { create :rating, :for_application, user: create(:user), rateable: application }
-        let(:params) { {id: rating, rating: { diversity: 5 }} }
+        let!(:rating) { create :rating, user: create(:user), application: application }
+        let(:params) { { id: rating, rating: { diversity: 5 } } }
 
         it 'raises RecordNotFound exception' do
           expect{
@@ -62,7 +69,7 @@ describe Rating::RatingsController, type: :controller do
         end
       end
       context 'when user author of rating' do
-        let!(:rating) { create :rating, :for_application, user: user, rateable: application }
+        let!(:rating) { create :rating, user: user, application: application }
         let(:params) { {id: rating, rating: { diversity: 5 }} }
 
         it 'updates rating data hash' do

--- a/spec/factories/ratings.rb
+++ b/spec/factories/ratings.rb
@@ -2,9 +2,5 @@ FactoryBot.define do
   factory :rating do
     user
     application
-
-    trait :for_application do
-      association :rateable, factory: :application
-    end
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Application do
+describe Application, type: :model do
   subject { build(:application) }
 
   it { is_expected.to validate_presence_of(:application_data) }
@@ -8,7 +8,7 @@ describe Application do
 
   it_behaves_like 'HasSeason'
   it_behaves_like 'Rateable' do
-    let(:rateable) { create(:application) }
+    let(:application) { create(:application) }
   end
 
   context 'with associations' do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -46,7 +46,7 @@ describe Application, type: :model do
       let!(:from_other_season) { create(:application, season: build(:season)) }
       let!(:without_team)      { create(:application, :in_current_season, :skip_validations, team: nil) }
 
-      it 'returns only applications from the current season which a team' do
+      it 'returns only applications from the current season with a team' do
         expect(applications).to contain_exactly application
       end
     end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -3,43 +3,29 @@ require 'spec_helper'
 describe Application, type: :model do
   subject { build(:application) }
 
-  it { is_expected.to validate_presence_of(:application_data) }
-  it { is_expected.to validate_presence_of(:team) }
-
   it_behaves_like 'HasSeason'
+
   it_behaves_like 'Rateable' do
     let(:application) { create(:application) }
   end
 
-  context 'with associations' do
+  describe 'associations' do
     it { is_expected.to belong_to(:team).inverse_of(:applications).counter_cache(true) }
     it { is_expected.to belong_to(:project) }
     it { is_expected.to belong_to(:application_draft) }
     it { is_expected.to belong_to(:application_draft) }
     it { is_expected.to have_many(:comments).dependent(:destroy).order(:created_at) }
-    it { is_expected.to have_many(:todos).dependent(:destroy) }
-    it { is_expected.to have_many(:ratings) }
   end
 
-  describe '#name' do
-    it 'returns an empty string' do
-      subject.team = nil
-      subject.project = nil
-      expect(subject.name).to eql ''
-    end
-
-    it 'derives its name from its team and project' do
-      subject.team = build_stubbed(:team, name: 'Foobar')
-      subject.project = build_stubbed(:project, name: 'Hello World')
-
-      expect(subject.name).to eql 'Foobar - Hello World'
-    end
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:application_data) }
+    it { is_expected.to validate_presence_of(:team) }
   end
 
   describe 'scopes' do
     describe '.hidden' do
       it 'returns only hidden applications' do
-        expect(Application.hidden.where_clause.send(:predicates)).to eq(
+        expect(described_class.hidden.where_clause.send(:predicates)).to eq(
           ["applications.hidden IS NOT NULL and applications.hidden = 't'"]
         )
       end
@@ -47,15 +33,27 @@ describe Application, type: :model do
 
     describe '.visible' do
       it 'returns only visible applications' do
-        expect(Application.visible.where_clause.send(:predicates)).to eq(
+        expect(described_class.visible.where_clause.send(:predicates)).to eq(
           ["applications.hidden IS NULL or applications.hidden = 'f'"]
         )
+      end
+    end
+
+    describe '.rateable' do
+      subject(:applications) { described_class.rateable }
+
+      let!(:application)       { create(:application, :in_current_season) }
+      let!(:from_other_season) { create(:application, season: build(:season)) }
+      let!(:without_team)      { create(:application, :in_current_season, :skip_validations, team: nil) }
+
+      it 'returns only applications from the current season which a team' do
+        expect(applications).to contain_exactly application
       end
     end
   end
 
   describe 'flags' do
-    flags = Application::FLAGS
+    flags = described_class::FLAGS
 
     flags.each do |flag|
       it { is_expected.to respond_to("#{flag}?") }
@@ -79,15 +77,6 @@ describe Application, type: :model do
     end
   end
 
-  describe 'student_name' do
-    let(:team)    { build(:team, students: [student]) }
-    let(:student) { build(:student) }
-
-    before { allow(subject).to receive(:team).and_return(team) }
-
-    it { expect(subject.student_name).to eq student.name }
-  end
-
   describe 'proxy methods' do
     proxy_methods = %w(location minimum_money)
 
@@ -97,6 +86,15 @@ describe Application, type: :model do
         it { expect(subject.send(key)).to eq subject.data.send(key) }
       end
     end
+  end
+
+  describe '#student_name' do
+    let(:team)    { build(:team, students: [student]) }
+    let(:student) { build(:student) }
+
+    before { allow(subject).to receive(:team).and_return(team) }
+
+    it { expect(subject.student_name).to eq student.name }
   end
 
   describe '#project1, project2' do
@@ -119,5 +117,20 @@ describe Application, type: :model do
 
     it_behaves_like :projectnr, 1
     it_behaves_like :projectnr, 2
+  end
+
+  describe '#name' do
+    it 'returns an empty string if neither project nor team are set' do
+      subject.team = nil
+      subject.project = nil
+      expect(subject.name).to eql ''
+    end
+
+    it 'derives its name from its team and project' do
+      subject.team = build_stubbed(:team, name: 'Foobar')
+      subject.project = build_stubbed(:project, name: 'Hello World')
+
+      expect(subject.name).to eql 'Foobar - Hello World'
+    end
   end
 end

--- a/spec/models/rating/strictness_spec.rb
+++ b/spec/models/rating/strictness_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Rating::Strictness do
     context "when there's only one application" do
       let!(:application) { create :application, :in_current_season }
 
-      let!(:rating1) { create :rating, rateable: application }
-      let!(:rating2) { create :rating, rateable: application }
+      let!(:rating1) { create :rating, application: application }
+      let!(:rating2) { create :rating, application: application }
 
       context 'when reviewers rate equally' do
         before { allow_any_instance_of(Rating).to receive(:points) { 5.0 } }
@@ -40,10 +40,10 @@ RSpec.describe Rating::Strictness do
 
       let!(:reviewers) { create_list :user, 2 }
 
-      let!(:rating1) { create :rating, rateable: application1, user: reviewers.first  }
-      let!(:rating2) { create :rating, rateable: application2, user: reviewers.first  }
-      let!(:rating3) { create :rating, rateable: application1, user: reviewers.second }
-      let!(:rating4) { create :rating, rateable: application2, user: reviewers.second }
+      let!(:rating1) { create :rating, application: application1, user: reviewers.first  }
+      let!(:rating2) { create :rating, application: application2, user: reviewers.first  }
+      let!(:rating3) { create :rating, application: application1, user: reviewers.second }
+      let!(:rating4) { create :rating, application: application2, user: reviewers.second }
 
       # We still want to stub Rating#points, but we need different
       # valus. Return `a` for the first rating, `b` else.

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Rating, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:application).inverse_of(:ratings) }
+    it { is_expected.to belong_to(:application) }
   end
 
   describe 'validations' do

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,41 +1,27 @@
 require 'spec_helper'
 
 describe Rating, type: :model do
-  let(:application) { build(:application) }
-
   describe 'associations' do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:application).inverse_of(:ratings) }
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:application) }
-    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to validate_presence_of(:application).with_message(:required) }
+    it { is_expected.to validate_presence_of(:user).with_message(:required)}
     it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:application_id) }
   end
 
-  describe 'scopes' do
-    describe '.by' do
-      it 'should return the rating for the given user' do
-        user         = create(:user)
-        rating       = create(:rating, user: user, application: application)
-        other_rating = create(:rating, application: application)
-        expect(Rating.by(user)).to contain_exactly rating
-      end
-    end
-  end
+  describe '.by' do
+    subject(:ratings) { Rating.by(user) }
 
-  describe '.user_names' do
-    let!(:users) { create_list :reviewer, 3 }
-    let(:user_names) { users.map(&:name) }
+    let(:application) { build(:application) }
+    let(:user)        { create(:user) }
 
-    it 'returns names of all reviewers' do
-      expect(Rating.user_names).to match_array user_names
-    end
-
-    it 'excludes other users' do
-      user = create :user
-      expect(Rating.user_names).not_to include user.name
+    it 'returns only ratings by the given user' do
+      rating       = create(:rating, user: user, application: application)
+      other_rating = create(:rating, application: application)
+      expect(ratings).to contain_exactly rating
     end
   end
 

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,34 +1,30 @@
 require 'spec_helper'
-describe Rating do
+
+describe Rating, type: :model, wip: true do
   let(:application) { build(:application) }
 
   describe 'associations' do
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:application) }
-    it { is_expected.to belong_to(:rateable) }
+    it { is_expected.to belong_to(:application).inverse_of(:ratings) }
   end
-  describe 'validations' do
-    it { is_expected.to validate_presence_of :rateable }
-    it { is_expected.to validate_presence_of :user_id }
 
-    # shoulda matcher for uniqueness does not work in this scenario
-    # https://github.com/thoughtbot/shoulda-matchers/issues/535
-    # that's why we do it "by hand"
-    it 'should only allow for one rating per user and rateable' do
-      user = create :user
-      Rating.create(rateable: application, user: user)
-      expect{ Rating.create!(rateable: application, user: user) }.to raise_error(ActiveRecord::RecordInvalid)
-    end
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:application) }
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:application_id) }
   end
+
   describe 'scopes' do
-    describe 'by' do
+    describe '.by' do
       it 'should return the rating for the given user' do
-        user = create(:user)
-        rating = create(:rating, user: user, rateable: application)
-        expect(Rating.by(user).first).to eq(rating)
+        user         = create(:user)
+        rating       = create(:rating, user: user, application: application)
+        other_rating = create(:rating, application: application)
+        expect(Rating.by(user)).to contain_exactly rating
       end
     end
   end
+
   describe '.user_names' do
     let!(:users) { create_list :reviewer, 3 }
     let(:user_names) { users.map(&:name) }
@@ -42,9 +38,10 @@ describe Rating do
       expect(Rating.user_names).not_to include user.name
     end
   end
+
   describe '#points' do
     it 'should add up some points given through valid fields' do
-      rating = create(:rating, rateable: application)
+      rating = create(:rating)
       rating.diversity = 1
       rating.save
 

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating, type: :model, wip: true do
+describe Rating, type: :model do
   let(:application) { build(:application) }
 
   describe 'associations' do

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Todo, type: :model do
       expect(todo).to be_done
     end
 
-    it 'returns false if the application not rated yet' do
+    it 'returns false if the application is not rated yet' do
       expect(todo).not_to be_done
     end
   end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Todo, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:user).inverse_of(:todos) }
-    it { is_expected.to belong_to(:application).inverse_of(:todos) }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:application) }
   end
 
   describe 'delegations' do

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 RSpec.describe Todo, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:user)                                    }
-    it { is_expected.to belong_to(:application)                             }
-    it { is_expected.to delegate_method(:season).to(:application)           }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:application) }
+    it { is_expected.to delegate_method(:season).to(:application) }
     it { is_expected.to delegate_method(:application_data).to(:application) }
   end
 
@@ -37,11 +37,7 @@ RSpec.describe Todo, type: :model do
     subject { todo.rating }
 
     it 'returns rating if user rated application' do
-      rating = build(:rating,
-        user:        todo.user,
-        rateable_id: todo.application.id,
-        rateable_type: "Application"
-      )
+      rating = build(:rating, user: todo.user, application: todo.application)
       rating.save(validate: false) # TODO: remove this once rating is updated
       expect(subject).to eq rating
     end
@@ -74,11 +70,7 @@ RSpec.describe Todo, type: :model do
     let!(:todo) { create(:todo) }
 
     it 'returns true if application has been rated' do
-      rating = build(:rating,
-        user:        todo.user,
-        rateable_id: todo.application.id,
-        rateable_type: "Application"
-      )
+      rating = build(:rating, user: todo.user, application: todo.application)
       rating.save(validate: false) # TODO: tmp solution
       expect(todo).to be_done
     end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -2,53 +2,64 @@ require 'spec_helper'
 
 RSpec.describe Todo, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:application) }
+    it { is_expected.to belong_to(:user).inverse_of(:todos) }
+    it { is_expected.to belong_to(:application).inverse_of(:todos) }
+  end
+
+  describe 'delegations' do
     it { is_expected.to delegate_method(:season).to(:application) }
     it { is_expected.to delegate_method(:application_data).to(:application) }
   end
 
-  describe '.for_current_season' do
-    let!(:todos) do
-      create_list(:todo, 3,
-        application: build(:application, :in_current_season)
-      )
-    end
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:user).with_message(:required) }
+    it { is_expected.to validate_presence_of(:application).with_message(:required) }
 
-    subject { described_class.for_current_season }
+    it 'is invalid if there are already 4 todos assigned for the application' do
+      application = create(:application)
+      create_list(:todo, 4, application: application)
+      todo = build(:todo, application: application)
+
+      expect(todo).not_to be_valid
+      expect(todo.errors.messages).to eq({ user: ['too many reviewers'] })
+    end
+  end
+
+  describe '.for_current_season' do
+    let(:application_from_other_season) { build(:application, season: build(:season)) }
+    let(:application_without_team) { build(:application, :in_current_season, :skip_validations, team: nil) }
+    let(:application_from_current_season) { build(:application, :in_current_season) }
+    let!(:todos) { create_list(:todo, 3, application: application_from_current_season) }
+
+    subject(:ratings) { described_class.for_current_season }
 
     before do
-      create(:todo,
-        application: build(:application, season: build(:season))
-      )
-      create(:todo,
-        application: build(:application, :in_current_season, :skip_validations, team: nil)
-      )
+      create(:todo, application: application_from_other_season)
+      create(:todo, application: application_without_team)
     end
 
-    it 'returns only todos for applications with teams from the current season' do
-      expect(subject).to match_array(todos)
+    it 'returns todos for applications with teams from the current season' do
+      expect(ratings).to match_array todos
     end
   end
 
   describe '#rating' do
-    let!(:todo) { create(:todo) }
+    let(:todo) { create(:todo) }
 
     subject { todo.rating }
 
-    it 'returns rating if user rated application' do
-      rating = build(:rating, user: todo.user, application: todo.application)
-      rating.save(validate: false) # TODO: remove this once rating is updated
+    it 'returns the rating if the user already rated the application' do
+      rating = create(:rating, user: todo.user, application: todo.application)
       expect(subject).to eq rating
     end
 
-    it 'returns nil if user did not rate application' do
+    it 'returns nil if user did not yet rate the application' do
       expect(subject).to be_nil
     end
   end
 
   describe '#eligible?' do
-    let(:todo) { build(:todo) }
+    subject(:todo) { build(:todo) }
 
     it 'returns true if application does not have any flags set' do
       todo.application.flags = []
@@ -67,15 +78,14 @@ RSpec.describe Todo, type: :model do
   end
 
   describe '#done?' do
-    let!(:todo) { create(:todo) }
+    subject(:todo) { create(:todo) }
 
-    it 'returns true if application has been rated' do
-      rating = build(:rating, user: todo.user, application: todo.application)
-      rating.save(validate: false) # TODO: tmp solution
+    it 'returns true if the application has been rated' do
+      rating = create(:rating, user: todo.user, application: todo.application)
       expect(todo).to be_done
     end
 
-    it 'returns false if application not rated yet' do
+    it 'returns false if the application not rated yet' do
       expect(todo).not_to be_done
     end
   end

--- a/spec/support/shared_examples/rateable.rb
+++ b/spec/support/shared_examples/rateable.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples 'Rateable' do
-  it { is_expected.to have_many(:ratings) }
+  it { is_expected.to have_many(:ratings).dependent(:destroy) }
+  it { is_expected.to have_many(:todos).dependent(:destroy) }
 
   describe '#average_points' do
     subject { application.average_points }

--- a/spec/support/shared_examples/rateable.rb
+++ b/spec/support/shared_examples/rateable.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples 'Rateable' do
   it { is_expected.to have_many(:ratings) }
 
   describe '#average_points' do
-    subject { rateable.average_points }
+    subject { application.average_points }
 
     context 'when no rating' do
       it 'returns zero' do
@@ -12,10 +12,7 @@ RSpec.shared_examples 'Rateable' do
 
     context 'when ratings' do
       before do
-        create_list(:rating, 2,
-          rateable: rateable,
-          data:     { 'diversity' => 1 }
-        )
+        create_list(:rating, 2, application: application, data: { 'diversity' => 1 })
       end
 
       it 'retuns the average of points' do
@@ -25,7 +22,7 @@ RSpec.shared_examples 'Rateable' do
   end
 
   describe '#median_points' do
-    subject { rateable.median_points }
+    subject { application.median_points }
 
     context 'when no rating' do
       it 'returns zero' do
@@ -36,12 +33,12 @@ RSpec.shared_examples 'Rateable' do
     context 'when even ratings' do
       before do
         create_list(:rating, 2,
-          rateable: rateable,
+          application: application,
           data:     { 'diversity' => 1 }
         )
 
         create_list(:rating, 2,
-          rateable: rateable,
+          application: application,
           data:     { 'diversity' => 5 }
         )
       end
@@ -54,12 +51,12 @@ RSpec.shared_examples 'Rateable' do
     context 'when odd ratings' do
       before do
         create_list(:rating, 2,
-          rateable: rateable,
+          application: application,
           data:     { 'diversity' => 1 }
         )
 
         create_list(:rating, 1,
-          rateable: rateable,
+          application: application,
           data:     { 'diversity' => 4 }
         )
       end
@@ -71,7 +68,7 @@ RSpec.shared_examples 'Rateable' do
   end
 
   describe '#ratings_short' do
-    subject { rateable.ratings_short }
+    subject { application.ratings_short }
 
     context 'when no ratings' do
       it 'returns an emtpy Array' do
@@ -84,8 +81,8 @@ RSpec.shared_examples 'Rateable' do
       let(:user2) { create(:user) }
 
       before do
-        create(:rating, rateable: rateable, user: user1)
-        create(:rating, rateable: rateable, user: user2)
+        create(:rating, application: application, user: user1)
+        create(:rating, application: application, user: user2)
       end
 
       it 'retuns the users names and points' do
@@ -98,7 +95,7 @@ RSpec.shared_examples 'Rateable' do
   end
 
   describe '#total_picks' do
-    subject { rateable.total_picks }
+    subject { application.total_picks }
 
     context 'when no ratings yet' do
       it 'returns zero' do
@@ -108,8 +105,8 @@ RSpec.shared_examples 'Rateable' do
 
     context 'when ratings' do
       before do
-        create_list(:rating, 2, rateable: rateable, pick: true)
-        create_list(:rating, 2, rateable: rateable)
+        create_list(:rating, 2, application: application, pick: true)
+        create_list(:rating, 2, application: application)
       end
 
       it 'returns the sum of picks given' do
@@ -119,7 +116,7 @@ RSpec.shared_examples 'Rateable' do
   end
 
   describe '#total_likes' do
-    subject { rateable.total_likes }
+    subject { application.total_likes }
 
     context 'when no ratings yet' do
       it 'returns zero' do
@@ -129,8 +126,8 @@ RSpec.shared_examples 'Rateable' do
 
     context 'when ratings' do
       before do
-        create_list(:rating, 2, rateable: rateable, like: true)
-        create_list(:rating, 2, rateable: rateable)
+        create_list(:rating, 2, application: application, like: true)
+        create_list(:rating, 2, application: application)
       end
 
       it 'returns the sum of likes given' do


### PR DESCRIPTION
This removes the redundant polymorphic association for `Ratings` as specified in #726 and uses the already existing `application_id` column for referencing the rated `Application`.

I included a migration to move all the existing "usable" data over to this new data-model. Please note that this migration also **deletes a bunch of `rating` records from 2015** - namely those rating `Users` or `Teams`.
Rating these other entities was possible in the 2015 edition of RGSoC. However, with the new datamodel these records don't make sense any more and I thought it's better to not have them at all instead of running the risk of having these invalid records maybe impacting the current `ratings`...

I also cleaned up the models playing into `rating` (`Todo`, `Application`, `Rating`) to reflect these changes to the data-model and removed a few unused methods from back in the days.

While being already on it, I set all our models to inherit from `ApplicationRecord` the Rails 5 style and add a personal goal to the `new_framework_defaults_5_1.rb` file 😹 