### PR TITLE
Remove some RSpec legacy stuff

### DIFF
--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ActivitiesController do
+RSpec.describe ActivitiesController, type: :controller do
   render_views
 
   describe 'GET index' do

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ApplicationDraftsController do
+RSpec.describe ApplicationDraftsController, type: :controller do
   render_views
 
   let(:team) { create :team, :in_current_season }

--- a/spec/controllers/calendar_controller_spec.rb
+++ b/spec/controllers/calendar_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CalendarController do
+RSpec.describe CalendarController, type: :controller do
   describe 'GET index' do
     before { get :index }
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CommentsController do
+RSpec.describe CommentsController, type: :controller do
   render_views
   let(:valid_attributes) { { "text" => FFaker::CheesyLingo.sentence } }
   let(:user) { create(:user) }

--- a/spec/controllers/community_controller_spec.rb
+++ b/spec/controllers/community_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe CommunityController do
+RSpec.describe CommunityController, type: :controller do
   render_views
 
   let(:valid_attributes) { build(:user).attributes.except('github_id', 'avatar_url', *User.immutable_attributes.map(&:to_s)) }

--- a/spec/controllers/concerns/ordered_conferences_spec.rb
+++ b/spec/controllers/concerns/ordered_conferences_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe OrderedConferences do
+RSpec.describe OrderedConferences, type: :controller do
   render_views
 
   describe '#index' do

--- a/spec/controllers/conference_attendances_controller_spec.rb
+++ b/spec/controllers/conference_attendances_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ConferenceAttendancesController do
+RSpec.describe ConferenceAttendancesController, type: :controller do
   let(:team) { create(:team, :in_current_season) }
   let(:student) { create(:student, team: team)}
   let(:attendance) { create(:conference_attendance, team: team )}

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ConferencesController do
+RSpec.describe ConferencesController, type: :controller do
   render_views
 
   describe 'GET index' do

--- a/spec/controllers/contributors_controller_spec.rb
+++ b/spec/controllers/contributors_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ContributorsController do
+RSpec.describe ContributorsController, type: :controller do
   render_views
 
   describe 'GET index' do

--- a/spec/controllers/mailings_controller_spec.rb
+++ b/spec/controllers/mailings_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MailingsController do
+RSpec.describe MailingsController, type: :controller do
   render_views
 
   let!(:mailing) { create(:mailing) }

--- a/spec/controllers/mentor/applications_controller_spec.rb
+++ b/spec/controllers/mentor/applications_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Mentor::ApplicationsController do
+RSpec.describe Mentor::ApplicationsController, type: :controller do
   render_views
 
   let(:user) { create(:user) }

--- a/spec/controllers/mentor/comments_controller_spec.rb
+++ b/spec/controllers/mentor/comments_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mentor::CommentsController do
+RSpec.describe Mentor::CommentsController, type: :controller do
   render_views
 
   let(:user) { create(:user) }

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe OmniauthCallbacksController do
+RSpec.describe OmniauthCallbacksController, type: :controller do
   before do
     @request.env["devise.mapping"] = Devise.mappings[:user]
   end

--- a/spec/controllers/orga/conferences_controller_spec.rb
+++ b/spec/controllers/orga/conferences_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Orga::ConferencesController do
+RSpec.describe Orga::ConferencesController, type: :controller do
   render_views
 
   it_behaves_like 'redirects for non-admins'

--- a/spec/controllers/orga/dashboard_controller_spec.rb
+++ b/spec/controllers/orga/dashboard_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Orga::DashboardController do
+RSpec.describe Orga::DashboardController, type: :controller do
   render_views
 
   describe '#GET index' do

--- a/spec/controllers/orga/exports_controller_spec.rb
+++ b/spec/controllers/orga/exports_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Orga::ExportsController do
+RSpec.describe Orga::ExportsController, type: :controller do
   render_views
 
   it_behaves_like 'redirects for non-admins'

--- a/spec/controllers/orga/mailings_controller_spec.rb
+++ b/spec/controllers/orga/mailings_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Orga::MailingsController do
+RSpec.describe Orga::MailingsController, type: :controller do
   render_views
 
   it_behaves_like 'redirects for non-admins'

--- a/spec/controllers/orga/projects_controller_spec.rb
+++ b/spec/controllers/orga/projects_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Orga::ProjectsController do
+RSpec.describe Orga::ProjectsController, type: :controller do
   render_views
 
   it_behaves_like 'redirects for non-admins'

--- a/spec/controllers/orga/seasons_controller_spec.rb
+++ b/spec/controllers/orga/seasons_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Orga::SeasonsController do
+RSpec.describe Orga::SeasonsController, type: :controller do
   render_views
 
   it_behaves_like 'redirects for non-admins'

--- a/spec/controllers/orga/teams_controller_spec.rb
+++ b/spec/controllers/orga/teams_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Orga::TeamsController do
+RSpec.describe Orga::TeamsController, type: :controller do
   render_views
 
   let(:user) { create(:user) }

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe PagesController do
+RSpec.describe PagesController, type: :controller do
   render_views
 
   describe 'GET show' do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ProjectsController do
+RSpec.describe ProjectsController, type: :controller do
   render_views
 
   let(:project) { create(:project) }

--- a/spec/controllers/rating/applications_controller_spec.rb
+++ b/spec/controllers/rating/applications_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating::ApplicationsController, type: :controller do
+RSpec.describe Rating::ApplicationsController, type: :controller do
   render_views
 
   describe 'GET index' do

--- a/spec/controllers/rating/comments_controller_spec.rb
+++ b/spec/controllers/rating/comments_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'rating/comments_controller'
 
-describe Rating::CommentsController, type: :controller do
+RSpec.describe Rating::CommentsController, type: :controller do
   render_views
 
   let(:valid_attributes) { { text: FFaker::CheesyLingo.sentence } }

--- a/spec/controllers/rating/ratings_controller_spec.rb
+++ b/spec/controllers/rating/ratings_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating::RatingsController, type: :controller do
+RSpec.describe Rating::RatingsController, type: :controller do
   render_views
 
   describe 'POST create' do

--- a/spec/controllers/rating/todos_controller_spec.rb
+++ b/spec/controllers/rating/todos_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating::TodosController, type: :controller do
+RSpec.describe Rating::TodosController, type: :controller do
   render_views
 
   describe 'GET index' do

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RolesController do
+RSpec.describe RolesController, type: :controller do
   let(:user) { create(:user) }
   let(:valid_attributes) { build(:role, team: team).attributes }
 

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SourcesController do
+RSpec.describe SourcesController, type: :controller do
 
   let(:user)             { create(:user) }
   let(:team)             { create(:team) }

--- a/spec/controllers/students/status_updates_controller_spec.rb
+++ b/spec/controllers/students/status_updates_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Students::StatusUpdatesController do
+RSpec.describe Students::StatusUpdatesController, type: :controller do
   render_views
 
   it_behaves_like 'redirects for non-users'

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe StudentsController do
+RSpec.describe StudentsController, type: :controller do
   render_views
 
   describe 'GET index' do

--- a/spec/controllers/supervisor/comments_controller_spec.rb
+++ b/spec/controllers/supervisor/comments_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Supervisor::CommentsController do
+RSpec.describe Supervisor::CommentsController, type: :controller do
   render_views
   let(:valid_attributes) { { "text" => FFaker::Lorem.paragraph } }
   let(:user) { create(:user) }

--- a/spec/controllers/supervisor/dashboard_controller_spec.rb
+++ b/spec/controllers/supervisor/dashboard_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Supervisor::DashboardController do
+RSpec.describe Supervisor::DashboardController, type: :controller do
   render_views
   describe 'routes for dashboard', type: :routing do
     it 'routes /dashboard to the dashboard controller' do

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'cancan/matchers'
 
-RSpec.describe TeamsController do
+RSpec.describe TeamsController, type: :controller do
   render_views
 
   include_context 'with user logged in'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe UsersController do
+RSpec.describe UsersController, type: :controller do
   render_views
 
   let(:valid_attributes) { build(:user).attributes.except('github_id', 'avatar_url', *User.immutable_attributes.map(&:to_s)) }

--- a/spec/exporters/users_spec.rb
+++ b/spec/exporters/users_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe Exporters::Users do
-
   describe '#current_students' do
     let(:old_team) { create :team, season: nil }
     let(:new_team) { create :team, :in_current_season }

--- a/spec/helpers/application_drafts_helper_spec.rb
+++ b/spec/helpers/application_drafts_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ApplicationDraftsHelper do
+RSpec.describe ApplicationDraftsHelper, type: :helper do
 
   describe '#may_edit?' do
     let(:student_role) { create :student_role }

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ApplicationFormHelper do
+RSpec.describe ApplicationFormHelper, type: :helper do
   describe '.time_span_array' do
     it 'returns an array of timespans' do
       expect(time_span_array.size).to eq(6)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ApplicationHelper do
+RSpec.describe ApplicationHelper, type: :helper do
   describe '#application_disambiguation_link' do
     let(:draft) { create :application_draft }
     let(:user)  { create :user }

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ApplicationsHelper do
+RSpec.describe ApplicationsHelper, type: :helper do
   describe '.link_to_application_project' do
     let(:application) { mock_model Application }
 

--- a/spec/helpers/teams_helper_spec.rb
+++ b/spec/helpers/teams_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe TeamsHelper do
+RSpec.describe TeamsHelper, type: :helper do
 
   describe "#conference_exists?" do
     let(:conference_preference) { create :conference_preference }

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe UrlHelper do
+RSpec.describe UrlHelper, type: :helper do
   describe 'normalize_url' do
     it 'keeps a nil value' do
       expect(Source.new(url: nil).url).to be_nil

--- a/spec/inputs/city_input_spec.rb
+++ b/spec/inputs/city_input_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CityInput do
+RSpec.describe CityInput do
   include RSpec::Rails::HelperExampleGroup
 
   describe '#input' do

--- a/spec/lib/feed_spec.rb
+++ b/spec/lib/feed_spec.rb
@@ -3,7 +3,7 @@ require 'feed'
 require 'stringio'
 require 'webrick'
 
-describe Feed do
+RSpec.describe Feed do
   let(:out)    { StringIO.new }
   let(:logger) { Logger.new(out) }
 

--- a/spec/lib/github/user_spec.rb
+++ b/spec/lib/github/user_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'github/user'
 
-describe Github::User do
+RSpec.describe Github::User do
   before :each do
     stub_request(:get, /./).to_return(body: File.read('spec/stubs/github/user.json'))
   end

--- a/spec/lib/selection/distance_spec.rb
+++ b/spec/lib/selection/distance_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'selection/distance'
 
-describe Selection::Distance do
+RSpec.describe Selection::Distance do
   let(:from) { ['30.1279442', '31.3300184'] }
   let(:to)   { ['30.0444196', '31.2357116000001'] }
 

--- a/spec/lib/selection/service/application_distribution_spec.rb
+++ b/spec/lib/selection/service/application_distribution_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'selection/service/application_distribution'
 
-describe Selection::Service::ApplicationDistribution do
+RSpec.describe Selection::Service::ApplicationDistribution do
   let!(:reviewers) { create_list(:reviewer, 4) }
   let(:user) { create(:user) }
   let(:project) { create(:project, :in_current_season, :accepted, submitter: user) }

--- a/spec/lib/selection/service/flag_applications_spec.rb
+++ b/spec/lib/selection/service/flag_applications_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'selection/service/flag_applications'
 
-describe Selection::Service::FlagApplications do
+RSpec.describe Selection::Service::FlagApplications do
   let(:valid_data) do
     {
       'student0_application_location_lat':          '30.1279442',

--- a/spec/mailers/application_form_mailer_spec.rb
+++ b/spec/mailers/application_form_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe ApplicationFormMailer do
+RSpec.describe ApplicationFormMailer, type: :mailer do
   let(:application) { build_stubbed(:application) }
   subject { ApplicationFormMailer.new_application(application) }
 

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe CommentMailer do
+RSpec.describe CommentMailer, type: :mailer do
   let(:team)    { build_stubbed :team }
   let(:comment) { build_stubbed :comment, commentable: team }
 

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Mailer do
+RSpec.describe Mailer, type: :mailer do
   def message_part(mail, content_type)
     mail.body.parts.find { |p| p.content_type =~ /#{content_type}/ }.body.raw_source
   end

--- a/spec/mailers/project_mailer_spec.rb
+++ b/spec/mailers/project_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ProjectMailer do
+RSpec.describe ProjectMailer, type: :mailer do
   let(:project) { build :project }
 
   describe '#proposal' do

--- a/spec/mailers/role_mailer_spec.rb
+++ b/spec/mailers/role_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe RoleMailer, type: :mailer do
+RSpec.describe RoleMailer, type: :mailer do
   describe 'user_added_to_team' do
     let(:user) { create(:user) }
     let(:team) { create(:team) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'cancan/matchers'
 
-describe Ability do
+RSpec.describe Ability, type: :model do
   subject { ability }
   let(:ability) { Ability.new(user) }
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Activity do
+RSpec.describe Activity, type: :model do
   it { is_expected.to belong_to(:team) }
 
   context 'with validations' do

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-RSpec.describe ApplicationDraft do
+RSpec.describe ApplicationDraft, type: :model do
   it_behaves_like 'HasSeason'
 
   context 'with associations' do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ApplicationForm do
+RSpec.describe ApplicationForm, type: :model do
   let(:team) { build_stubbed :team }
   let(:user) { build_stubbed :user }
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Application, type: :model do
+RSpec.describe Application, type: :model do
   subject { build(:application) }
 
   it_behaves_like 'HasSeason'

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Comment do
+RSpec.describe Comment, type: :model do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to belong_to(:commentable) }
 

--- a/spec/models/conference/importer_spec.rb
+++ b/spec/models/conference/importer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'csv'
 
-RSpec.describe Conference::Importer do
+RSpec.describe Conference::Importer, type: :model do
 
   describe "#call" do
     # 6 sample conferences in test.csv, 4 valid

--- a/spec/models/conference_attendance_spec.rb
+++ b/spec/models/conference_attendance_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ConferenceAttendance do
+RSpec.describe ConferenceAttendance, type: :model do
   it { is_expected.to belong_to(:team) }
   it { is_expected.to belong_to(:conference) }
 end

--- a/spec/models/conference_preference_spec.rb
+++ b/spec/models/conference_preference_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ConferencePreference do
+RSpec.describe ConferencePreference, type: :model do
   it { is_expected.to belong_to(:team) }
   it { is_expected.to belong_to(:first_conference) }
   it { is_expected.to belong_to(:second_conference) }

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Conference do
+RSpec.describe Conference, type: :model do
   it_behaves_like 'HasSeason'
 
   it { is_expected.to have_many(:conference_attendances).dependent(:destroy) }

--- a/spec/models/creates_application_from_draft_spec.rb
+++ b/spec/models/creates_application_from_draft_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe CreatesApplicationFromDraft do
+RSpec.describe CreatesApplicationFromDraft, type: :model do
   let(:application_draft) { build :application_draft }
 
   subject { described_class.new application_draft }

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe DateRange do
-
+RSpec.describe DateRange, type: :model do
   describe '#to_s' do
     let(:start_date) { Date.parse('2015-12-31') }
     let(:end_date)   { Date.parse('2015-12-31') }

--- a/spec/models/mailing_spec.rb
+++ b/spec/models/mailing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mailing do
+RSpec.describe Mailing, type: :model do
   let(:mailing) { Mailing.new(
     from: Mailing::FROM,
     to: 'coaches',

--- a/spec/models/mentor/application_spec.rb
+++ b/spec/models/mentor/application_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mentor::Application do
+RSpec.describe Mentor::Application, type: :model do
   describe 'attributes' do
     subject { described_class.new }
 

--- a/spec/models/mentor/comment_spec.rb
+++ b/spec/models/mentor/comment_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mentor::Comment do
+RSpec.describe Mentor::Comment, type: :model do
   describe 'database' do
     it 'uses the Comment table under the hood' do
       comment         = described_class.create

--- a/spec/models/mentor/student_spec.rb
+++ b/spec/models/mentor/student_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mentor::Student do
+RSpec.describe Mentor::Student, type: :model do
   describe 'attributes' do
     subject { described_class.new }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Project do
-
+RSpec.describe Project, type: :model do
   it_behaves_like 'HasSeason'
 
   context 'with associations' do

--- a/spec/models/rating/strictness_spec.rb
+++ b/spec/models/rating/strictness_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Rating::Strictness do
+RSpec.describe Rating::Strictness, type: :model do
 
   describe '#adjusted_points_for_applications' do
     subject { described_class.new.adjusted_points_for_applications }

--- a/spec/models/rating/table_spec.rb
+++ b/spec/models/rating/table_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating::Table do
+RSpec.describe Rating::Table, type: :model do
   describe 'attributes' do
     let(:applications) { build_list(:application, 3) }
 

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating, type: :model do
+RSpec.describe Rating, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:application) }

--- a/spec/models/recipients_spec.rb
+++ b/spec/models/recipients_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Recipients do
+RSpec.describe Recipients, type: :model do
   let(:mailing) do
     build :mailing,
           cc: 'cc@email.com',

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Role do
+RSpec.describe Role, type: :model do
   let(:user) { create(:user) }
   let(:team) { create(:team) }
 

--- a/spec/models/season/phase_switcher_spec.rb
+++ b/spec/models/season/phase_switcher_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Season::PhaseSwitcher do
+RSpec.describe Season::PhaseSwitcher, type: :model do
   context '.destined' do
     let(:season) { Season.current }
 

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Season do
+RSpec.describe Season, type: :model do
   context 'with validations' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Source do
+RSpec.describe Source, type: :model do
   it { is_expected.to belong_to(:team) }
   it { is_expected.to validate_presence_of(:url) }
 

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Student do
-
+RSpec.describe Student, type: :model do
   let(:user) { build_stubbed(:user) }
 
   subject { described_class.new user }

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Submission do
+RSpec.describe Submission, type: :model do
   let(:submission) { build(:submission) }
   let(:unsent) { create(:submission, sent_at: nil)}
 

--- a/spec/models/team_performance_spec.rb
+++ b/spec/models/team_performance_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe TeamPerformance do
+RSpec.describe TeamPerformance, type: :model do
   def create_all_teams
     [team_nothing, team_activitiy, team_commented, team_both_outdated, team_both]
   end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Team do
+RSpec.describe Team, type: :model do
   subject { Team.new(kind: 'sponsored') }
 
   it { is_expected.to have_many(:activities) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe User do
+RSpec.describe User, type: :model do
   before do
     stub_request(:get, /./).to_return(body: File.read('spec/stubs/github/user.json'))
   end

--- a/spec/requests/application_process_spec.rb
+++ b/spec/requests/application_process_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe 'The Application Process' do
-
+RSpec.describe 'The Application Process', type: :request do
   describe 'GET /apply' do
-
     context 'with student logged in' do
       let!(:user) { create :student }
       before { sign_in user }

--- a/spec/routing/application_drafts_routing_spec.rb
+++ b/spec/routing/application_drafts_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ApplicationDraftsController do
+RSpec.describe ApplicationDraftsController, type: :routing do
   describe 'routing' do
     it 'does not route to #show' do
       expect(get 'application_drafts/:id').not_to be_routable

--- a/spec/routing/calendar_routing_spec.rb
+++ b/spec/routing/calendar_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CalendarController do
+RSpec.describe CalendarController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get('/calendar/index')).to route_to('calendar#index')

--- a/spec/routing/comments_routing_spec.rb
+++ b/spec/routing/comments_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Supervisor::CommentsController do
+RSpec.describe Supervisor::CommentsController, type: :routing do
   describe 'routing' do
     it 'routes to #create' do
       expect(post('supervisor/comments')).to route_to('supervisor/comments#create')
@@ -8,7 +8,7 @@ describe Supervisor::CommentsController do
   end
 end
 
-describe CommentsController do
+RSpec.describe CommentsController, type: :routing do
   describe 'routing' do
     it 'routes to #create' do
       expect(post('/comments')).to route_to('comments#create')

--- a/spec/routing/conferences_routing_spec.rb
+++ b/spec/routing/conferences_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ConferencesController do
+RSpec.describe ConferencesController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get('/conferences')).to route_to('conferences#index')

--- a/spec/routing/join_routing_spec.rb
+++ b/spec/routing/join_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe JoinController do
+RSpec.describe JoinController, type: :routing do
   describe 'routing' do
     it 'routes to #new' do
       expect(get('/teams/1/join/new')).to route_to('join#new', team_id: '1')

--- a/spec/routing/mentor/applications_routing_spec.rb
+++ b/spec/routing/mentor/applications_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mentor::ApplicationsController do
+RSpec.describe Mentor::ApplicationsController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get '/mentor/applications').to route_to 'mentor/applications#index'

--- a/spec/routing/mentor/comments_routing_spec.rb
+++ b/spec/routing/mentor/comments_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mentor::CommentsController do
+RSpec.describe Mentor::CommentsController, type: :routing do
   describe 'routing' do
     it 'routes to #create' do
       expect(post '/mentor/comments').to route_to 'mentor/comments#create'

--- a/spec/routing/orga/dashboard_routing_spec.rb
+++ b/spec/routing/orga/dashboard_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Orga::DashboardController do
+RSpec.describe Orga::DashboardController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get 'orga/').to route_to 'orga/dashboard#index'

--- a/spec/routing/orga/submissions_routing_spec.rb
+++ b/spec/routing/orga/submissions_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Orga::SubmissionsController do
+RSpec.describe Orga::SubmissionsController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get('/orga/mailings/1/submissions')).to route_to('orga/submissions#index', mailing_id: '1')

--- a/spec/routing/orga/users_info_routing_spec.rb
+++ b/spec/routing/orga/users_info_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Orga::UsersInfoController do
+RSpec.describe Orga::UsersInfoController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get('/orga/users/info')).to route_to('orga/users_info#index')

--- a/spec/routing/rating/applications_routing_spec.rb
+++ b/spec/routing/rating/applications_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating::ApplicationsController do
+RSpec.describe Rating::ApplicationsController, type: :routing do
   describe 'routing' do
     it 'routes to #show' do
       expect(get '/rating/applications/:id').to route_to 'rating/applications#show', id: ':id'

--- a/spec/routing/rating/ratings_routing_spec.rb
+++ b/spec/routing/rating/ratings_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating::RatingsController do
+RSpec.describe Rating::RatingsController, type: :routing do
   describe 'routing' do
     it 'does not route to #index' do
       expect(get 'rating/ratings').not_to be_routable

--- a/spec/routing/rating/todos_routing_spec.rb
+++ b/spec/routing/rating/todos_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rating::TodosController do
+RSpec.describe Rating::TodosController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get 'rating/todos').to route_to 'rating/todos#index'

--- a/spec/routing/roles_routing_spec.rb
+++ b/spec/routing/roles_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RolesController do
+RSpec.describe RolesController, type: :routing do
   describe 'routing' do
     it 'routes to #new' do
       expect(get('/teams/1/roles/new')).to route_to('roles#new', team_id: '1')

--- a/spec/routing/sources_routing_spec.rb
+++ b/spec/routing/sources_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SourcesController do
+RSpec.describe SourcesController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get('/sources')).to route_to('sources#index')

--- a/spec/routing/teams_info_routing_spec.rb
+++ b/spec/routing/teams_info_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe TeamsInfoController do
+RSpec.describe TeamsInfoController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get('/teams/info')).to route_to('teams_info#index')

--- a/spec/routing/teams_routing_spec.rb
+++ b/spec/routing/teams_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe TeamsController do
+RSpec.describe TeamsController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get('/teams')).to route_to('teams#index')

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe UsersController do
+RSpec.describe UsersController, type: :routing do
   describe 'routing' do
     it 'routes to #show' do
       expect(get('/users/1')).to route_to('users#show', id: '1')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.expose_dsl_globally = false # disable RSpec < 3 global monkey patching
   config.use_transactional_fixtures = false
   config.infer_base_class_for_anonymous_controllers = false
 
@@ -41,8 +42,6 @@ RSpec.configure do |config|
 
   config.include ActiveJob::TestHelper
   config.include RSpecHtmlMatchers
-
-  config.infer_spec_type_from_file_location!
 
   config.before(:suite) do
     WebMock.disable_net_connect!(

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -12,16 +12,4 @@ RSpec.configure do |config|
   config.after do
     DatabaseCleaner.clean
   end
-
-
-  # rspec-rails 3 will no longer automatically infer an example group's spec type
-  # from the file location. You can explicitly opt-in to the feature using this
-  # config option.
-  # To explicitly tag specs without using automatic inference, set the `:type`
-  # metadata manually:
-  #
-  #     describe ThingsController, :type => :controller do
-  #       # Equivalent to being in spec/controllers
-  #     end
-  config.infer_spec_type_from_file_location!
 end


### PR DESCRIPTION
This is a follow up to #880 and #871 to remove leftover of the pre v3 era of RSpec:
1. Inferring the spec type from the file location
  see [the RSpec docs](https://relishapp.com/rspec/rspec-rails/docs/directory-structure) for details on this
1. Have 'describe' available from the main object
  see [global namespace](https://relishapp.com/rspec/rspec-core/v/3-7/docs/configuration/global-namespace-dsl) for details

Motivation for this: I just thing it's a) generally healthy to keep the application up to data with current standards and b) easier to understand for people new to the project then.

PS: I know this touches loads of files... The important parts are the configuration and that the suite is still ✅ 

PS 2: No need to look at this until #880 is agreed upon and I've rebased this branch on it.