### PR TITLE
Enforce frozen string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -146,13 +146,12 @@ Style/Encoding:
   StyleGuide: "#utf-8"
   Enabled: true
 
-# TODO
 Style/FrozenStringLiteralComment:
   Description: "Add frozen_string_literal comment to the top of files"
   Include:
   - "app/**/*.rb"
   - "lib/**/*.rb"
-  Enabled: false
+  Enabled: true
 
 Style/HashSyntax:
   Description: "Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax { :a => 1, :b => 2}"

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ActivitiesController < ApplicationController
   before_action :normalize_params, only: :index
   before_action :cors_preflight, only: :index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   after_action :store_location

--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationDraftsController < ApplicationController
 
   before_action :checktime, only: [:new, :create, :update]

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CalendarController < ApplicationController
   def index
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CommentsController < ApplicationController
 
   # This controller manages the comments on applications and projects.

--- a/app/controllers/community_controller.rb
+++ b/app/controllers/community_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CommunityController < ApplicationController
   before_action :normalize_params, only: :index
 

--- a/app/controllers/concerns/ordered_conferences.rb
+++ b/app/controllers/concerns/ordered_conferences.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module OrderedConferences
   def index
     @conferences = Conference.ordered(sort_params).in_current_season

--- a/app/controllers/conference_attendances_controller.rb
+++ b/app/controllers/conference_attendances_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ConferenceAttendancesController < ApplicationController
 
   def update

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ConferencesController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ContributorsController < ApplicationController
   after_action :cors_set_headers, only: :index
 

--- a/app/controllers/join_controller.rb
+++ b/app/controllers/join_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class JoinController < ApplicationController
   before_action :set_team
   before_action :allow_helpdesk

--- a/app/controllers/mailings_controller.rb
+++ b/app/controllers/mailings_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class MailingsController < ApplicationController
 
   load_and_authorize_resource except: :index

--- a/app/controllers/mentor/applications_controller.rb
+++ b/app/controllers/mentor/applications_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mentor::ApplicationsController < Mentor::BaseController
   before_action :application, only: [:show, :signoff, :fav]
 

--- a/app/controllers/mentor/base_controller.rb
+++ b/app/controllers/mentor/base_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mentor::BaseController < ApplicationController
   before_action :authenticate_user!
   before_action -> { require_project_maintainer }

--- a/app/controllers/mentor/comments_controller.rb
+++ b/app/controllers/mentor/comments_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mentor::CommentsController < Mentor::BaseController
   def create
     comment = Mentor::Comment.create(create_params)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def github
     user = User.find_or_create_for_github_oauth(request.env['omniauth.auth'])

--- a/app/controllers/orga/base_controller.rb
+++ b/app/controllers/orga/base_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Orga::BaseController < ApplicationController
   before_action :must_be_admin
   before_action :set_breadcrumbs

--- a/app/controllers/orga/conferences_controller.rb
+++ b/app/controllers/orga/conferences_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Orga::ConferencesController < Orga::BaseController
   before_action :find_conference, only: [:show, :destroy]
   before_action :ensure_file_was_posted, only: :import

--- a/app/controllers/orga/dashboard_controller.rb
+++ b/app/controllers/orga/dashboard_controller.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class Orga::DashboardController < Orga::BaseController
 end

--- a/app/controllers/orga/exports_controller.rb
+++ b/app/controllers/orga/exports_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # eager load export classes in development
 Dir[Rails.root.join('app/exporters/*.rb')].each { |f| require f }
 

--- a/app/controllers/orga/mailings_controller.rb
+++ b/app/controllers/orga/mailings_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Orga::MailingsController < Orga::BaseController
   before_action :normalize_params, only: [:create, :update]
   before_action :find_mailing, only: [:show, :edit, :update, :destroy]

--- a/app/controllers/orga/projects_controller.rb
+++ b/app/controllers/orga/projects_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Orga::ProjectsController < Orga::BaseController
   before_action :find_resource, except: [:index]
 

--- a/app/controllers/orga/seasons_controller.rb
+++ b/app/controllers/orga/seasons_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Orga::SeasonsController < Orga::BaseController
   before_action :find_resource, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/orga/submissions_controller.rb
+++ b/app/controllers/orga/submissions_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Orga::SubmissionsController < Orga::BaseController
   before_action :find_mailing
 

--- a/app/controllers/orga/teams_controller.rb
+++ b/app/controllers/orga/teams_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Orga::TeamsController < Orga::BaseController
   before_action :find_resource, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/orga/users_info_controller.rb
+++ b/app/controllers/orga/users_info_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Orga::UsersInfoController < Orga::BaseController
   before_action :normalize_params, only: :index
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class PagesController < ApplicationController
   LAYOUTS = {
     help: 'help'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ProjectsController < ApplicationController
 
   before_action :soft_login_required, only: [:new]

--- a/app/controllers/rating/applications_controller.rb
+++ b/app/controllers/rating/applications_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'csv'
 
 class Rating::ApplicationsController < Rating::BaseController

--- a/app/controllers/rating/base_controller.rb
+++ b/app/controllers/rating/base_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Rating::BaseController < ApplicationController
   before_action :authenticate_user!
   before_action -> { require_role 'reviewer' }

--- a/app/controllers/rating/comments_controller.rb
+++ b/app/controllers/rating/comments_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Rating::CommentsController < CommentsController
   PATH_PARENTS = [:rating]
 end

--- a/app/controllers/rating/overview_controller.rb
+++ b/app/controllers/rating/overview_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Rating::OverviewController < Rating::BaseController
   def index
   end

--- a/app/controllers/rating/ratings_controller.rb
+++ b/app/controllers/rating/ratings_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Rating::RatingsController < Rating::BaseController
   # In order to get the rating data persisted, FIRST create the rating record,
   # then update it to actually set the values.

--- a/app/controllers/rating/todos_controller.rb
+++ b/app/controllers/rating/todos_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Rating::TodosController < Rating::BaseController
   respond_to :html
 

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RolesController < ApplicationController
   before_action :set_team, except: [:confirm]
   before_action :set_role, except: [:confirm, :index, :show]

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SourcesController < ApplicationController
   before_action :cors_preflight, only: :index
   after_action  :cors_set_headers, only: :index

--- a/app/controllers/status_update_comments_controller.rb
+++ b/app/controllers/status_update_comments_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class StatusUpdateCommentsController < CommentsController
 
   def create

--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class StatusUpdatesController < ApplicationController
   def show
     @status_update = Activity.with_kind('status_update').find params[:id]

--- a/app/controllers/students/base_controller.rb
+++ b/app/controllers/students/base_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Students::BaseController < ApplicationController
   before_action :must_be_student
 

--- a/app/controllers/students/status_updates_controller.rb
+++ b/app/controllers/students/status_updates_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Students::StatusUpdatesController < Students::BaseController
   before_action :find_resource, only: [:show, :edit, :update, :destroy]
   helper_method :status_updates

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class StudentsController < ApplicationController
   after_action :cors_set_headers, only: :index
 

--- a/app/controllers/supervisor/base_controller.rb
+++ b/app/controllers/supervisor/base_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Supervisor::BaseController < ApplicationController
 
   before_action :must_be_supervisor

--- a/app/controllers/supervisor/comments_controller.rb
+++ b/app/controllers/supervisor/comments_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Supervisor::CommentsController < Supervisor::BaseController
 
   def index

--- a/app/controllers/supervisor/dashboard_controller.rb
+++ b/app/controllers/supervisor/dashboard_controller.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class Supervisor::DashboardController < Supervisor::BaseController
 end

--- a/app/controllers/supervisor/notes_controller.rb
+++ b/app/controllers/supervisor/notes_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Supervisor::NotesController < Supervisor::BaseController
 
   def update

--- a/app/controllers/teams_info_controller.rb
+++ b/app/controllers/teams_info_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class TeamsInfoController < ApplicationController
   # before_action :normalize_params, only: :index
   before_action { authorize!(:read, :teams_info) unless current_user.try(:admin?) }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy, :impersonate]
 

--- a/app/exporters/base.rb
+++ b/app/exporters/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'csv'
 
 module Exporters

--- a/app/exporters/conference_preferences.rb
+++ b/app/exporters/conference_preferences.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Exporters
   class ConferencePreferences < Base
 

--- a/app/exporters/projects.rb
+++ b/app/exporters/projects.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Exporters
   class Projects < Base
 

--- a/app/exporters/teams.rb
+++ b/app/exporters/teams.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Exporters
   class Teams < Base
 

--- a/app/exporters/users.rb
+++ b/app/exporters/users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Exporters
   class Users < Base
 

--- a/app/helpers/application_drafts_helper.rb
+++ b/app/helpers/application_drafts_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ApplicationDraftsHelper
   STUDENT_FIELDS = [:name,
                     :application_age,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'cgi'
 require 'uri'
 module ApplicationHelper

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ApplicationsHelper
   def show_or_na(value)
     value.presence || 'n/a'

--- a/app/helpers/authentication/active_record_helpers.rb
+++ b/app/helpers/authentication/active_record_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Authentication
   module ActiveRecordHelpers
     def self.included(base)

--- a/app/helpers/conference_attendances_helper.rb
+++ b/app/helpers/conference_attendances_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ConferenceAttendancesHelper
 
   def show_attendance(attendance)

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'redcarpet_camo_renderer'
 
 module MarkdownHelper

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module NavHelper
   SOC_CONTROLLER = %w(conferences projects applications application_drafts teams users)
 

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ProfilesHelper
   def github_handle=(handle)
     super(normalize_handle(handle))

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ProjectsHelper
 
   def project_status(project)

--- a/app/helpers/ratings_helper.rb
+++ b/app/helpers/ratings_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RatingsHelper
   def field_tooltip(key)
     key = key.to_s

--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module TeamsHelper
 
   def conference_exists_for?(team)

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module UrlHelper
   def normalize_url(url)
     url = url.strip if url

--- a/app/inputs/character_limited_input.rb
+++ b/app/inputs/character_limited_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CharacterLimitedInput < SimpleForm::Inputs::TextInput
   def input_html_options
     super.merge(data: { behaviour: 'character-limited', maxlength: Student::CHARACTER_LIMIT })

--- a/app/inputs/city_input.rb
+++ b/app/inputs/city_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CityInput < SimpleForm::Inputs::StringInput
   def input(wrapper_options)
     super << lat_field << lng_field

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mailer < ActionMailer::Base
   helper :markdown
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # See the wiki for details:
 # https://github.com/ryanb/cancan/wiki/Defining-Abilities
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Activity < ApplicationRecord
   KINDS = %w(feed_entry mailing status_update)
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Application < ApplicationRecord
   include HasSeason, Rateable
 

--- a/app/models/application_data.rb
+++ b/app/models/application_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationData
   def initialize(data)
     @data = data || {}

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationDraft < ApplicationRecord
   include HasSeason
   include AASM

--- a/app/models/application_draft/student_attribute_proxy.rb
+++ b/app/models/application_draft/student_attribute_proxy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationDraft::StudentAttributeProxy
   attr_reader :match, :application_draft
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :project

--- a/app/models/concerns/has_season.rb
+++ b/app/models/concerns/has_season.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module HasSeason
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/rateable.rb
+++ b/app/models/concerns/rateable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Rateable
   extend ActiveSupport::Concern
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'csv'
 class Conference < ApplicationRecord
   REGION_LIST = [

--- a/app/models/conference/importer.rb
+++ b/app/models/conference/importer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'csv'
 class Conference::Importer
 

--- a/app/models/conference_attendance.rb
+++ b/app/models/conference_attendance.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ConferenceAttendance < ApplicationRecord
   belongs_to :team
   belongs_to :conference

--- a/app/models/conference_preference.rb
+++ b/app/models/conference_preference.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ConferencePreference < ApplicationRecord
   validates :terms_of_ticket, inclusion: { in: [true] }, if: :conference_exists?
   validates :terms_of_travel, inclusion: { in: [true] }, if: :conference_exists?

--- a/app/models/creates_application_from_draft.rb
+++ b/app/models/creates_application_from_draft.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CreatesApplicationFromDraft
   PROJECT_FIELDS = ApplicationDraft::PROJECT_FIELDS.map(&:to_s)
   STUDENT_FIELDS = [0, 1].map { |index| User.columns.map(&:name).select{ |n| /\Aapplication_/ =~ n }.map{|n| "student#{index}_#{n}" } }.flatten

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class DateRange
   # Step 1: only in use with Conference date range.
   # Validation is supposed to be in input (e.g. Conference.rb), but

--- a/app/models/mailing.rb
+++ b/app/models/mailing.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mailing < ApplicationRecord
 
   TO = %w(teams students coaches helpdesk organizers supervisors developers mentors)

--- a/app/models/mentor/application.rb
+++ b/app/models/mentor/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mentor
   class Application
     include ActiveModel::Model

--- a/app/models/mentor/comment.rb
+++ b/app/models/mentor/comment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mentor
   class Comment < ApplicationRecord
     self.table_name = 'comments'

--- a/app/models/mentor/student.rb
+++ b/app/models/mentor/student.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mentor
   class Student
     include ActiveModel::Model

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Note < ApplicationRecord
 
   def self.notepad(user)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Project < ApplicationRecord
   include HasSeason
 

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Rating < ApplicationRecord
   belongs_to :application, required: true
   belongs_to :user, required: true

--- a/app/models/rating/table.rb
+++ b/app/models/rating/table.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Rating::Table
   DEFAULT_OPTS = { hide_flags: [] }
   FLAGS        = %i(remote_team

--- a/app/models/rating_criterium.rb
+++ b/app/models/rating_criterium.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RatingCriterium
   attr_reader :weight
 

--- a/app/models/recipients.rb
+++ b/app/models/recipients.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Recipients
   delegate :seasons, :group, :to, :cc, :bcc, to: :mailing
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Role < ApplicationRecord
   include AASM
 

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Season < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/skill_level.rb
+++ b/app/models/skill_level.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SkillLevel
 
   MATRIX = {

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Source < ApplicationRecord
   include UrlHelper
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Student < SimpleDelegator
   include ActiveModel::Validations
   include ActiveModel::Conversion

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Submission < ApplicationRecord
   class << self
     def unsent

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Team < ApplicationRecord
   include ProfilesHelper, HasSeason
 

--- a/app/models/team_performance.rb
+++ b/app/models/team_performance.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class TeamPerformance
 # Internal: calculates a Team's performance score for supervisor's dashboard
 

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Todo < ApplicationRecord
   BLACK_FLAGS = %w(remote_team male_gender age_below_18 less_than_two_coaches zero_community)
   SIGN_OFFS   = %w(signed_off_at_project1 signed_off_at_project2)

--- a/lib/confs.rb
+++ b/lib/confs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # To run this script pass a filename as ARGV[0], as in
 #
 #   $ ruby -Ilib lib/confs.rb path/to/data.rb

--- a/lib/confs/application.rb
+++ b/lib/confs/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Application
   attr_reader :team, :name, :conf
   attr_accessor :flight

--- a/lib/confs/applications.rb
+++ b/lib/confs/applications.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Applications
   attr_reader :apps
 

--- a/lib/confs/conf.rb
+++ b/lib/confs/conf.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Conf
   attr_reader :name, :tickets, :flights
   attr_accessor :popularity

--- a/lib/confs/confs.rb
+++ b/lib/confs/confs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Confs
   include Enumerable
 

--- a/lib/confs/raffle.rb
+++ b/lib/confs/raffle.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Raffle
   attr_reader :confs, :apps, :winners, :runs
 

--- a/lib/confs/result.rb
+++ b/lib/confs/result.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Result
   attr_reader :confs, :winners
 

--- a/lib/confs/table.rb
+++ b/lib/confs/table.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Table
   class Row
     attr_reader :table, :cells

--- a/lib/feed.rb
+++ b/lib/feed.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'feedjira'
 
 class Feed

--- a/lib/feed/discovery.rb
+++ b/lib/feed/discovery.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'open-uri'
 
 class Feed

--- a/lib/feed/image.rb
+++ b/lib/feed/image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'open-uri'
 
 class Feed

--- a/lib/feed/item.rb
+++ b/lib/feed/item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Feed
   class Item
     attr_reader :base_url, :team_id, :item

--- a/lib/feed/s3.rb
+++ b/lib/feed/s3.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Feed
   class S3
     attr_reader :s3, :url, :logger

--- a/lib/github/user.rb
+++ b/lib/github/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'gh'
 
 module Github

--- a/lib/mail_interceptor.rb
+++ b/lib/mail_interceptor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class MailInterceptor
   def self.delivering_email(message)
     message.to = `git config user.email`

--- a/lib/mailer_previews/role_mailer_preview.rb
+++ b/lib/mailer_previews/role_mailer_preview.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Preview all emails at http://localhost:3000/rails/mailers/role_mailer
 class RoleMailerPreview < ActionMailer::Preview
   def user_added_to_team

--- a/lib/redcarpet_camo_renderer.rb
+++ b/lib/redcarpet_camo_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Redcarpet
   module Render
     class Camo < Redcarpet::Render::HTML

--- a/lib/selection/distance.rb
+++ b/lib/selection/distance.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'selection/refinements'
 
 module Selection

--- a/lib/selection/refinements.rb
+++ b/lib/selection/refinements.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Selection
   module Refinements
     module StringMathExtensions

--- a/lib/selection/service/application_distribution.rb
+++ b/lib/selection/service/application_distribution.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Selection
   module Service
     class ApplicationDistribution

--- a/lib/selection/service/flag_applications.rb
+++ b/lib/selection/service/flag_applications.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'selection/distance'
 
 module Selection


### PR DESCRIPTION
**What**
- Employs Ruby 2.3+'s `frozen_string_literal` magic comment to, well, freeze all string literals
- Enforces the use of this magic comment with Rubocop

**Why**
- Forward compatibility w/ MRI 3 where Strings are said to become immutable.
- Re-use a couple of string instances. More of a nice side-effect than an immediate concern.
- Good to train one's "muscle memory" / programming habits and word with immutable strings already


