### PR TITLE
Restore FactoryBot calls in seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,38 +1,38 @@
 # Teams
-create_list(:team, 5, :in_current_season, kind: "sponsored")
-create(:team, :in_current_season, kind: "voluntary")
-create(:team, :in_current_season) # not accepted
+FactoryBot.create_list(:team, 5, :in_current_season, kind: "sponsored")
+FactoryBot.create(:team, :in_current_season, kind: "voluntary")
+FactoryBot.create(:team, :in_current_season) # not accepted
 
-create(:team, :last_season, kind: "sponsored")
-create(:team, :last_season, kind: "voluntary")
+FactoryBot.create(:team, :last_season, kind: "sponsored")
+FactoryBot.create(:team, :last_season, kind: "voluntary")
 
 # Users with different roles
-create_list(:student, 12)
-create_list(:coach, 3)
-create_list(:organizer, 2)
-create(:mentor)
-create(:supervisor)
+FactoryBot.create_list(:student, 12)
+FactoryBot.create_list(:coach, 3)
+FactoryBot.create_list(:organizer, 2)
+FactoryBot.create(:mentor)
+FactoryBot.create(:supervisor)
 
 # To explore use cases where user has no role yet
-create_list(:user, 3)
+FactoryBot.create_list(:user, 3)
 
 # Status updates for different teams
 5.times do
-  create(:status_update, published_at: Time.now, team: Team.all.sample)
+  FactoryBot.create(:status_update, published_at: Time.now, team: Team.all.sample)
 end
 
 # Applications and their projects
-create(:application_draft)
-create(:application_draft, :appliable)
+FactoryBot.create(:application_draft)
+FactoryBot.create(:application_draft, :appliable)
 
-create(:project, :in_current_season) # proposed
-create_list(:project, 3, :accepted, :in_current_season)
-create(:project, :rejected, :in_current_season)
+FactoryBot.create(:project, :in_current_season) # proposed
+FactoryBot.create_list(:project, 3, :accepted, :in_current_season)
+FactoryBot.create(:project, :rejected, :in_current_season)
 
 # Conferences
 6.times do
   random_date = rand(1.year).seconds.from_now
-  create(:conference, :in_current_season,
+  FactoryBot.create(:conference, :in_current_season,
     location: FFaker::Venue.name,
     region: ["Africa", "South America", "North America", "Europe", "Asia Pacific"].sample,
     starts_on: random_date,


### PR DESCRIPTION
Related to #871 
Looks like seeds.rb doesn't share in the Bot's syntax methods sugar.
Restoring the `FactoryBot`'s on create methods.

<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->
