### PR TITLE
Issue #659 fixed - media query for navbar container - width lessened by 40px

### DIFF
--- a/app/assets/stylesheets/partials/_navbar.sass
+++ b/app/assets/stylesheets/partials/_navbar.sass
@@ -1,6 +1,10 @@
 nav#navigation
   @extend .navbar, .navbar-inverse, .navbar-static-top
 
+  @media (min-width: 1200px)
+    .container
+      width: 1130px
+
   a.dropdown-toggle-img
     @extend .dropdown-toggle
     padding: 2px


### PR DESCRIPTION
Fixes bug in issue #659 where the fork me badge overlaps with the sign in button on some screens.
