### PR TITLE
Fix which navigation items to show when and how to mark them "active"

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,11 +5,6 @@ module ApplicationHelper
 
   TIMEZONES = ActiveSupport::TimeZone.all.map{|t| t.tzinfo.name}.uniq.sort
 
-  def show_application_link?
-    current_season.application_period? ||
-      (Time.now.utc.between? current_season.applications_close_at, current_season.acceptance_notification_at)
-  end
-
   def application_disambiguation_link
     if current_user && current_user.application_drafts.in_current_season.any?
       link_to 'My Application', application_drafts_path

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 module NavHelper
-  SOC_CONTROLLER = %w(conferences projects applications application_drafts teams users)
+  SOC_CONTROLLER = %w(conferences projects applications application_drafts teams community).freeze
 
-  def dropdown_active?
+  def active_if_soc_dropdown_active
     'active' if SOC_CONTROLLER.include?(params[:controller])
   end
 
-  def active?(controller_name)
-    'active' if params[:controller] == controller_name.to_s
+  def active_if(path)
+    'active' if current_page?(path)
+  end
+
+  def active_if_controller(controller)
+    'active' if params[:controller] == controller
   end
 
   def during_application_phase?

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -9,4 +9,13 @@ module NavHelper
   def active?(controller_name)
     'active' if params[:controller] == controller_name.to_s
   end
+
+  def during_application_phase?
+    current_season.application_period? ||
+      (Time.now.utc.between? current_season.applications_close_at, current_season.acceptance_notification_at)
+  end
+
+  def during_season?
+    current_season.started? && !current_season.transition?
+  end
 end

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 module NavHelper
-  SOC_CONTROLLER = %w(conferences projects applications application_drafts teams community).freeze
+  SOC_CONTROLLERS = %w(conferences projects applications application_drafts teams community).freeze
 
   def active_if_soc_dropdown_active
-    'active' if SOC_CONTROLLER.include?(params[:controller])
+    'active' if SOC_CONTROLLERS.include?(params[:controller])
   end
 
   def active_if(path)

--- a/app/views/application/_nav_right.html.slim
+++ b/app/views/application/_nav_right.html.slim
@@ -8,12 +8,12 @@ ul.nav.navbar-nav.navbar-right
       - if Season.projects_proposable?
         li.divider.hidden-xs
         li class=active?(:projects) = link_to 'Submit your Project', new_project_path
-        li class=active?(:projects) = link_to 'Projects', projects_path      
-      - if show_application_link?
+        li class=active?(:projects) = link_to 'Projects', projects_path
+      - elsif during_application_phase?
         li.divider.hidden-xs
         li class=active?(:application_drafts) = application_disambiguation_link
         li class=active?(:projects) = link_to 'Projects', projects_path
-      - if current_season.started?
+      - elsif during_season?
         li.divider.hidden-xs
         li class=active?(:conferences) = link_to 'Conferences',  conferences_path
         li class=active?(:projects) = link_to 'Projects', projects_path
@@ -21,7 +21,7 @@ ul.nav.navbar-nav.navbar-right
       li class=active?(:teams) = link_to 'Teams', teams_path
       li class=active?(:users) = link_to 'Community', community_index_path
   li class=('active' if params[:page] == 'help') = link_to 'Help', page_path('help')
-    
+
   - if signed_in?
     = render 'nav_signed_in'
   - else

--- a/app/views/application/_nav_right.html.slim
+++ b/app/views/application/_nav_right.html.slim
@@ -1,26 +1,26 @@
 ul.nav.navbar-nav.navbar-right
-  li class=active?(:activities) = link_to 'Activities', root_path
-  li.dropdown class=dropdown_active?
+  li class=active_if(root_path) = link_to 'Activities', root_path
+  li.dropdown class=active_if_soc_dropdown_active
     a.dropdown-toggle data-toggle="dropdown" href="#"
       | Summer of Code
       span.caret
     ul.dropdown-menu role="menu"
       - if Season.projects_proposable?
         li.divider.hidden-xs
-        li class=active?(:projects) = link_to 'Submit your Project', new_project_path
-        li class=active?(:projects) = link_to 'Projects', projects_path
+        li class=active_if(new_project_path) = link_to 'Submit your Project', new_project_path
+        li class=active_if(projects_path) = link_to 'Projects', projects_path
       - elsif during_application_phase?
         li.divider.hidden-xs
-        li class=active?(:application_drafts) = application_disambiguation_link
-        li class=active?(:projects) = link_to 'Projects', projects_path
+        li class=active_if_controller('application_drafts') = application_disambiguation_link
+        li class=active_if(projects_path) = link_to 'Projects', projects_path
       - elsif during_season?
         li.divider.hidden-xs
-        li class=active?(:conferences) = link_to 'Conferences',  conferences_path
-        li class=active?(:projects) = link_to 'Projects', projects_path
+        li class=active_if(conferences_path) = link_to 'Conferences', conferences_path
+        li class=active_if(projects_path) = link_to 'Projects', projects_path
       li.divider.hidden-xs
-      li class=active?(:teams) = link_to 'Teams', teams_path
-      li class=active?(:users) = link_to 'Community', community_index_path
-  li class=('active' if params[:page] == 'help') = link_to 'Help', page_path('help')
+      li class=active_if(teams_path) = link_to 'Teams', teams_path
+      li class=active_if(community_index_path) = link_to 'Community', community_index_path
+  li class=active_if(page_path('help')) = link_to 'Help', page_path('help')
 
   - if signed_in?
     = render 'nav_signed_in'

--- a/spec/helpers/nav_helper_spec.rb
+++ b/spec/helpers/nav_helper_spec.rb
@@ -1,6 +1,58 @@
 require 'spec_helper'
 
-RSpec.describe NavHelper, type: :helper do
+RSpec.describe NavHelper, type: :helper, wip: true do
+  describe '#active_if' do
+    subject(:css_class) { helper.active_if(path) }
+
+    let(:path) { 'some/random/path' }
+
+    it 'returns the active css class if the given path is the current one' do
+      expect(helper).to receive(:current_page?).with(path).and_return(true)
+      expect(css_class).to eq 'active'
+    end
+
+    it 'returns nothing if the given path is not the current one' do
+      expect(helper).to receive(:current_page?).with(path).and_return(false)
+      expect(css_class).to be_nil
+    end
+  end
+
+  describe '#active_if_soc_dropdown_active' do
+    subject(:css_class) { helper.active_if_soc_dropdown_active }
+
+    it 'returns active for all controller specified in the helper' do
+      described_class::SOC_CONTROLLER.each do |controller|
+        params = ActionController::Parameters.new(controller: controller)
+        allow(helper).to receive(:params).and_return(params)
+        expect(helper.active_if_soc_dropdown_active).to eq 'active'
+      end
+    end
+
+    it 'returns nil for any other controller' do
+      params = ActionController::Parameters.new(controller: 'something_random')
+      allow(helper).to receive(:params).and_return(params)
+      expect(css_class).to be_nil
+    end
+  end
+
+  describe '#active_if_controller' do
+    subject(:css_class) { helper.active_if_controller(controller_name) }
+
+    let(:controller_name) { 'some_random_string' }
+
+    it 'returns active if the given controller matches the current page' do
+      params = ActionController::Parameters.new(controller: controller_name)
+      allow(helper).to receive(:params).and_return(params)
+      expect(css_class).to eq 'active'
+    end
+
+    it 'returns nil if the controller does not match' do
+      params = ActionController::Parameters.new(controller: 'something_else')
+      allow(helper).to receive(:params).and_return(params)
+      expect(css_class).to be_nil
+    end
+  end
+
   describe '#during_season?' do
     subject { helper.during_season? }
 

--- a/spec/helpers/nav_helper_spec.rb
+++ b/spec/helpers/nav_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe NavHelper, type: :helper, wip: true do
+RSpec.describe NavHelper, type: :helper do
   describe '#active_if' do
     subject(:css_class) { helper.active_if(path) }
 
@@ -21,7 +21,7 @@ RSpec.describe NavHelper, type: :helper, wip: true do
     subject(:css_class) { helper.active_if_soc_dropdown_active }
 
     it 'returns active for all controller specified in the helper' do
-      described_class::SOC_CONTROLLER.each do |controller|
+      described_class::SOC_CONTROLLERS.each do |controller|
         params = ActionController::Parameters.new(controller: controller)
         allow(helper).to receive(:params).and_return(params)
         expect(helper.active_if_soc_dropdown_active).to eq 'active'

--- a/spec/helpers/nav_helper_spec.rb
+++ b/spec/helpers/nav_helper_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe NavHelper, type: :helper do
+  describe '#during_season?' do
+    subject { helper.during_season? }
+
+    before { allow(helper).to receive(:current_season).and_return(season) }
+
+    context 'when the season started and is not transitioning' do
+      let(:season) { instance_double(Season, started?: true, transition?: false) }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when the season started and is transitioning' do
+      let(:season) { instance_double(Season, started?: true, transition?: true) }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when the season did not start yet' do
+      let(:season) { instance_double(Season, started?: false, transition?: false) }
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '#during_application_phase?' do
+    subject { helper.during_application_phase? }
+
+    before { allow(helper).to receive(:current_season).and_return(season) }
+
+    context 'during application_period' do
+      let(:season) { instance_double(Season, application_period?: true) }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'after application_period but before acceptance_notifications' do
+      let(:season) do
+        instance_double(Season,
+          application_period?:        false,
+          applications_close_at:      1.day.ago.utc,
+          acceptance_notification_at: 2.days.from_now.utc
+        )
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'after summer started' do
+      let(:season) do
+        instance_double(Season,
+          application_period?:        false,
+          applications_close_at:      2.days.ago.utc,
+          acceptance_notification_at: 1.days.ago.utc
+        )
+      end
+
+      it { is_expected.to eq false }
+    end
+  end
+end


### PR DESCRIPTION
This fixes the problem of a) having the same items multiple times in the dropdown navigation when being between seasons and b) having multiple items marked as `active` in the dropdown.

**Before**
<img width="1792" alt="screen shot 2017-12-27 at 19 29 07" src="https://user-images.githubusercontent.com/3491815/34411559-a3249154-ebd7-11e7-9e05-6391ca927282.png">

**After**
<img width="1792" alt="screen shot 2017-12-28 at 14 02 18" src="https://user-images.githubusercontent.com/3491815/34411573-bd330ad0-ebd7-11e7-864d-aa0a79a6b59f.png">

This is specifically about hiding the `projects` and `conferences` item again after the season has ended and we're transitioning to the next season.

I will add a follow-up PR with better feature-testing the navigation.
