### PR TITLE
Don't show a "my team" button to guest users / users without a team

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,6 +57,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_student
+    return unless current_user
     @current_student ||= Student.new(current_user)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,10 +179,6 @@ class User < ApplicationRecord
     (q_user_names + q_team_names).uniq
   end
 
-  def student_team
-    teams.in_current_season.last if student?
-  end
-
   def interested_in_list
     interested_in.reject(&:blank?).join(', ')
   end

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -1,6 +1,6 @@
 nav.actions
   ul.list-inline
-    li = link_to 'My Team', current_student.current_team, class: 'btn btn-default btn-sm' if current_student.current_team
+    li = link_to 'My Team', current_student.current_team, class: 'btn btn-default btn-sm' if current_student&.current_team
     li = link_to icon('plus', 'New Team'), new_team_path, class: 'btn btn-primary btn-sm' if can? :create, Team.new(season: Season.current)
   div.pull-right.dropdown
     button.btn.btn-default.dropdown-toggle data-toggle="dropdown"
@@ -12,6 +12,3 @@ nav.actions
          a data-behaviour="switch-teams-year" data-value=year =year
 
 = render 'table', namespace: nil
-
-
-

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  describe '#current_student' do
+    subject(:current_student) { controller.current_student }
+
+    context 'with a signed in user' do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it 'returns a student for the user' do
+        expect(current_student).to be_a(Student)
+        expect(current_student).to have_attributes(id: user.id, name: user.name)
+      end
+    end
+
+    context 'without a signed in user' do
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -32,39 +32,27 @@ RSpec.describe Student, type: :model do
   end
 
   describe '#current_team' do
-    it 'returns nil if no team can be determined' do
-      expect(subject.current_team).to be_nil
-    end
+    subject(:current_team) { described_class.new(user).current_team }
 
-    context 'with a team' do
-      let(:old_season) { Season.find_or_create_by(name: '2015') }
-      let(:old_team) { create :team, season: old_season }
+    let(:user) { create(:user) }
 
-      let(:user) { create :user }
-      let(:current_team) { create :team, :in_current_season }
+    it { is_expected.to be_nil }
 
-      subject { described_class.new(user).current_team }
+    context 'when the user is in teams for multiple seasons' do
+      let(:old_season) { create :season, name: '2015' }
+      let(:old_team)   { create :team, season: old_season }
+      let(:team)       { create :team, :in_current_season }
 
-      context 'when the user has been a student before' do
-        before do
-          create :student_role, user: user, team: current_team
-          create :student_role, user: user, team: old_team
-        end
+      before { create :student_role, user: user, team: old_team }
 
-        it 'returns the current season\'s team' do
-          expect(subject).to eql current_team
-        end
+      it 'returns the team where she is a student for the current_season' do
+        create :student_role, user: user, team: team
+        expect(current_team).to eql team
       end
 
-      context 'when the user has been a student before but is now contributing to the project' do
-        before do
-          create :student_role, user: user, team: old_team
-          create :supervisor_role, user: user, team: current_team
-        end
-
-        it 'does not return any team' do
-          expect(subject).to be_nil
-        end
+      it 'returns nothing if the user has a different role in the current_season' do
+        create :coach_role, user: user, team: team
+        expect(current_team).to be_nil
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -341,27 +341,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#student_team' do
-    before do
-      @user_not_student = create(:user)
-      @student = create(:student)
-      @student_team = @student.teams.first
-    end
-
-    it 'the method student_team return the student current team' do
-      expect(@student.student_team).to eql @student_team
-    end
-
-    it 'does not return student_team if when a user is not a student' do
-      expect(@user_not_student.student_team).to eql nil
-    end
-
-    it 'does not return student_team if student does not have a team' do
-      @student.teams.first.destroy
-      expect(@student.student_team).to eql nil
-    end
-  end
-
   describe 'Search for user names and team names' do
     before do
       @cruyff = create(:user, name: "Johan Cruyff")


### PR DESCRIPTION
This fixes a bug on the team index page (likely only visible in production): both guest users and users who aren't students or part of a team see a `my team` button which will bring them to the show view for some random team where at least one student deleted their account **(we should try to avoid getting these invalid team records in the first place...)**

Looked like this _(see I'm not signed in)_:
<img width="1792" alt="screen shot 2017-12-28 at 12 22 03" src="https://user-images.githubusercontent.com/3491815/34449833-58abba90-ecfd-11e7-837e-9a9c2aaaeb65.png">

Tiny bit of background: the `current_student` helper defined in the `ApplicationController` would always return a `Student`, even if there's no `current_user` (the student would then be called `nil`) and would therefore always find a `current_team` - one with a `user_id` being nil.