### PR TITLE
Create an error reporting facade

### DIFF
--- a/lib/error_reporting.rb
+++ b/lib/error_reporting.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'sentry-raven'
+
+# Facade to log custom errors to our exception tracking service
+# (currently Sentry).
+class ErrorReporting
+  class << self
+
+    # @param msg_or_exception [Exception, String] data to send to Sentry.io
+    def call(msg_or_exception)
+      capture_method = case msg_or_exception
+                       when Exception then :capture_exception
+                       else :capture_message
+                       end
+
+      Raven.public_send(capture_method, msg_or_exception)
+    end
+  end
+end

--- a/spec/lib/error_reporting_spec.rb
+++ b/spec/lib/error_reporting_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'error_reporting'
+
+RSpec.describe ErrorReporting do
+  describe '.call' do
+    let(:raven_double) { double(capture_message: :ok, capture_exception: :ok) }
+
+    before do
+      stub_const('Raven', raven_double)
+    end
+
+    let(:error) { Class.new(Exception).new("Nope.") }
+    let(:strng) { "Err, what about … no?" }
+
+    it 'will send descendants of Exception' do
+      described_class.call error
+      expect(raven_double).to have_received(:capture_exception)
+    end
+
+    it 'will send a simple String message' do
+      described_class.call strng
+      expect(raven_double).to have_received(:capture_message)
+    end
+  end
+end

--- a/spec/lib/error_reporting_spec.rb
+++ b/spec/lib/error_reporting_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ErrorReporting do
     end
 
     let(:error) { Class.new(Exception).new("Nope.") }
-    let(:strng) { "Err, what about … no?" }
+    let(:string) { "Err, what about … no?" }
 
     it 'will send descendants of Exception' do
       described_class.call error
@@ -18,7 +18,7 @@ RSpec.describe ErrorReporting do
     end
 
     it 'will send a simple String message' do
-      described_class.call strng
+      described_class.call string
       expect(raven_double).to have_received(:capture_message)
     end
   end


### PR DESCRIPTION
While exception tracker libraries tie into Ruby's/Rails' system automatically for uncaught exceptions, using the exception tracker's log/system/dashboard for rescued errors requires special API calls.

We still haven't figured out which exception tracker we want to use (we've used Sentry, Honeybadger, and Rollbar so far). This simple class makes it easy to swap error logging providers for manual error reports.

Note: the explicit `require` statements are for a seemless tie-in with PR #905. 

**Edit**: The `Raven.capture_exception` does work:

![bildschirmfoto vom 2018-01-07 16-34-08](https://user-images.githubusercontent.com/164400/34650896-b3a766ac-f3c8-11e7-9abe-6646c82287d3.png)

  