### PR TITLE
Feature/browse past projects

### DIFF
--- a/app/assets/stylesheets/controllers/projects.sass
+++ b/app/assets/stylesheets/controllers/projects.sass
@@ -30,3 +30,6 @@
 
 .space_btns
   margin-left: 10px
+
+nav.past-projects
+  margin-bottom: 10px

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -25,11 +25,12 @@ class ProjectsController < ApplicationController
   end
 
   def index
-    if Season.current.active?
-      @projects = Project.selected
-    else
-      @projects = Project.in_current_season.where(aasm_state: %w(accepted proposed))
-    end
+    season = Season.find_by(name: params['filter']) || Season.current
+    @projects = if season.current? and !season.active?
+                  Project.in_current_season.not_rejected
+                else
+                  Project.selected(season: season)
+                end
   end
 
   def destroy

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -19,4 +19,9 @@ module ProjectsHelper
     project.tags.map{ |t| "<span class='label label-default'>#{t}</span>" }.join(' ').html_safe
   end
 
+  # @return [Array<String>] a list of years we have projects for, most recent first.
+  def project_years
+    (Season.joins(:projects).distinct.pluck(:name) + [Date.today.year.to_s]).uniq.reverse
+  end
+
 end

--- a/app/models/concerns/has_season.rb
+++ b/app/models/concerns/has_season.rb
@@ -4,5 +4,12 @@ module HasSeason
 
   included do
     belongs_to :season
+
+    # @param season [#name, String, Integer]
+    # @return [ActiveRecord::Relation]
+    def self.in_season(season)
+      season = season.try(:name) || season
+      joins(:season).where('seasons.name' => season)
+    end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,6 +11,7 @@ class Project < ApplicationRecord
 
   validates :name, :submitter, :mentor_email, presence: true
 
+  scope :not_rejected, -> { where.not(aasm_state: 'rejected') }
   scope :in_current_season, -> do
     where(season: Season.transition? ? Season.succ : Season.current)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,9 +38,12 @@ class Project < ApplicationRecord
     end
   end
 
-  def self.selected
-    project_names = Team.in_current_season.accepted.pluck(:project_name)
-    Project.in_current_season.accepted.where(name: project_names)
+  # Returns the accepted projects that ended up being assigned a team.
+  #
+  # @param season [Season] the season to query, defaults to the current one.
+  def self.selected(season: Season.current)
+    project_names = Team.in_season(season).accepted.pluck(:project_name)
+    in_season(season).accepted.where(name: project_names)
   end
 
   def taglist

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Season < ApplicationRecord
 
+  has_many :projects
+
   validates :name, presence: true, uniqueness: true, inclusion: { in: ('1999'..'2050') }
 
   before_validation :set_application_dates

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -56,6 +56,11 @@ class Season < ApplicationRecord
     Time.now.utc.between?(acceptance_notification_at, ends_at)
   end
 
+  # @return [Boolean] whether or not the Season represents the current year
+  def current?
+    name == Date.today.year.to_s
+  end
+
   def started?
     Time.now.utc >= (starts_at || 1.week.from_now)
   end

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -7,6 +7,10 @@ h1.header
   = icon('users')
   span Projects
 
+nav.past-projects
+  - project_years.each do |filter|
+    = link_to filter.titleize, projects_path(filter: filter), class: "label label-default"
+
 table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
   tr
     th Name

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -39,6 +39,24 @@ RSpec.describe ProjectsController, type: :controller do
         expect(response.body).not_to include 'proposed project'
       end
     end
+
+    context 'with a season filter' do
+      let!(:season2017) { Season.find_or_create_by(name: '2017') }
+      let!(:proposed) { create(:project, :in_current_season, name: 'proposed project') }
+      let!(:selected2017) { create(:project, :accepted, season: season2017, name: "selected by a team 2017") }
+      let!(:selected) { create(:project, :accepted, :in_current_season, name: "selected by a team (current)") }
+      let!(:no_team) { create(:project, :accepted, season: season2017, name: "project without team 2017") }
+      let!(:team) { create(:team, season: season2017, project_name: selected2017.name) }
+
+      it 'shows selected projects in past season only' do
+        get :index, params: { filter: '2017' }
+        expect(response).to be_success
+        expect(response.body).to include "selected by a team 2017"
+        expect(response.body).not_to include "selected by a team (current)"
+        expect(response.body).not_to include 'project without team 2017'
+        expect(response.body).not_to include 'proposed project 2017'
+      end
+    end
   end
 
   describe 'GET new' do

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Season, type: :model do
     it { is_expected.not_to allow_value('201o').for(:name) }
   end
 
+  describe 'associations' do
+    it { is_expected.to have_many(:projects) }
+  end
+
   describe 'callbacks' do
     subject { described_class.new name: Date.today.year }
 

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -132,6 +132,25 @@ RSpec.describe Season, type: :model do
     end
   end
 
+  describe '#current?' do
+    subject { described_class.new(name: year) }
+
+    context 'in a past year' do
+      let(:year) { Date.today.year - 1 }
+      it { is_expected.not_to be_current }
+    end
+
+    context 'in the same year' do
+      let(:year) { Date.today.year }
+      it { is_expected.to be_current }
+    end
+
+    context 'in a future year' do
+      let(:year) { Date.today.year + 1 }
+      it { is_expected.not_to be_current }
+    end
+  end
+
   describe '.current' do
     it 'creates a season record' do
       create :season, name: '2000'

--- a/spec/support/shared_examples/has_season.rb
+++ b/spec/support/shared_examples/has_season.rb
@@ -1,3 +1,16 @@
 RSpec.shared_examples 'HasSeason' do
   it { expect(subject).to belong_to :season }
+
+  describe '.in_season' do
+    it 'returns a relation' do
+      expect(described_class.in_season('1984')).to be_kind_of ActiveRecord::Relation
+    end
+
+    it 'accepts an String as well as any object responding to #name' do
+      sql_string = described_class.in_season('test').to_sql
+      sql_double = described_class.in_season(double(name: 'test')).to_sql
+
+      expect(sql_double).to eql sql_string
+    end
+  end
 end


### PR DESCRIPTION
**What?**
Adds the ability to browse past projects. For past seasons, only **accepted and assigned** projects will be shown, just as we do for the current season once it started.

The orga-version of the projects view hasn't been touched. No need to mingle in the past ^^

![desktop-animation](https://user-images.githubusercontent.com/164400/35017128-d559d320-fb1b-11e7-8c6c-f06ab6538e9f.gif)