### PR TITLE
Use existing project as a template to create a new one

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,7 @@ class ProjectsController < ApplicationController
   before_action :soft_login_required, only: [:new]
   before_action :check_date!, only: [:new, :create]
 
-  load_and_authorize_resource only: [:edit, :update, :destroy]
+  load_and_authorize_resource only: [:edit, :update, :destroy, :use_as_template]
 
   def new
     submitter = current_user || User.new
@@ -70,6 +70,11 @@ class ProjectsController < ApplicationController
         format.html { render action: :new }
       end
     end
+  end
+
+  def use_as_template
+    @project = @project.dup
+    render :new
   end
 
   private

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -21,7 +21,7 @@ module ProjectsHelper
 
   # @return [Array<String>] a list of years we have projects for, most recent first.
   def project_years
-    (Season.joins(:projects).distinct.pluck(:name) + [Date.today.year.to_s]).uniq.reverse
+    (Season.joins(:projects).distinct.pluck(:name) + [Date.today.year.to_s]).uniq.sort.reverse
   end
 
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -72,6 +72,7 @@ class Ability
     can :crud, :comments if user.admin?
     can :read, :users_info if user.admin? || user.supervisor?
 
+    # projects
     can :crud, Project do |project|
       user.admin? ||
         (user.confirmed? && user == project.submitter)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -76,6 +76,9 @@ class Ability
       user.admin? ||
         (user.confirmed? && user == project.submitter)
     end
+    can :use_as_template, Project do |project|
+      user == project.submitter
+    end
 
     can :create, Project if user.confirmed?
     cannot :create, Project if !user.confirmed?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -77,7 +77,7 @@ class Ability
         (user.confirmed? && user == project.submitter)
     end
     can :use_as_template, Project do |project|
-      user == project.submitter
+      user == project.submitter && !project.season&.current?
     end
 
     can :create, Project if user.confirmed?

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -19,7 +19,7 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
     th Comments
     th title="Application referencing this project as 1st choice" Applications (1st Choice)
     th title="Application referencing this project as 2nd choice" Applications (2nd Choice)
-    th Status
+    th colspan=2 Status
 
   - @projects.each do |project|
     tr
@@ -47,6 +47,9 @@ table.table.table-striped.table-bordered.table-condensed.hidden-sm.hidden-xs
         | /
         span.label.label-primary title="Applications sent in" = project.second_choice_application_drafts.applied.count
       td = project_status project
+      td
+        - if can? :use_as_template, project
+          = link_to "Use as template", [:use_as_template, project], class: 'btn btn-xs btn-primary'
 
 - @projects.each do |project|
   table.table.table-striped.table-bordered.table-condensed.hidden-md.hidden-lg

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,10 @@ Rails.application.routes.draw do
   resources :status_updates, only: :show
   resources :status_update_comments, only: :create
   resources :projects do
-    get 'receipt', as: :receipt, on: :member
+    member do
+      get :receipt, as: :receipt
+      get :use_as_template
+    end
     post 'preview', on: :collection
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -401,7 +401,6 @@ RSpec.describe Ability, type: :model do
         end
       end
     end
-
   end
 
   context 'to join helpdesk team' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -382,6 +382,24 @@ RSpec.describe Ability, type: :model do
 
       end
 
+      context 'when using a project as a template' do
+        let(:user) { build :user }
+
+        context 'for the original project submitter' do
+          let(:project) { build :project, submitter: user }
+
+          it 'can be used as a template' do
+            expect(subject).to be_able_to :use_as_template, project
+          end
+        end
+
+        context 'for a project submitted by someone else' do
+          let(:project) { build :project }
+          it 'cannot be used as a template' do
+            expect(subject).not_to be_able_to :use_as_template, project
+          end
+        end
+      end
     end
 
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -387,17 +387,17 @@ RSpec.describe Ability, type: :model do
 
         context 'for the original project submitter' do
           let(:project) { build :project, submitter: user }
+          it { is_expected.to be_able_to :use_as_template, project }
 
-          it 'can be used as a template' do
-            expect(subject).to be_able_to :use_as_template, project
+          context 'for a project from the same season' do
+            let(:project) { build :project, :in_current_season, submitter: user }
+            it { is_expected.not_to be_able_to :use_as_template, project }
           end
         end
 
         context 'for a project submitted by someone else' do
           let(:project) { build :project }
-          it 'cannot be used as a template' do
-            expect(subject).not_to be_able_to :use_as_template, project
-          end
+          it { is_expected.not_to be_able_to :use_as_template, project }
         end
       end
     end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe ProjectsController, type: :request do
 
   describe 'GET /projects/:id/use_as_template' do
-    let!(:submitter) { create :user }
-    let!(:season)    { nil }
-    let!(:project)   { create :project, season: season, submitter: submitter }
+    let(:submitter) { create :user }
+    let(:season)    { nil }
+    let!(:project)  { create :project, season: season, submitter: submitter }
 
     shared_examples_for 'returns to the root page' do
       it 'returns to the root page' do
@@ -22,7 +22,7 @@ RSpec.describe ProjectsController, type: :request do
     end
 
     context 'when the user is logged in' do
-      let!(:user) { create :user }
+      let(:user) { create :user }
       before { sign_in user }
 
       context 'when the user does not own the project' do
@@ -30,15 +30,15 @@ RSpec.describe ProjectsController, type: :request do
       end
 
       context 'when the user has submitted the project before' do
-        let!(:submitter) { user }
+        let(:submitter) { user }
 
         context 'when the project is from the current season' do
-          let!(:season) { Season.current }
+          let(:season) { Season.current }
           it_behaves_like 'returns to the root page'
         end
 
         context 'when the project is from a past season' do
-          let!(:season) { Season.find_or_create_by!(name: '2013') }
+          let(:season) { Season.find_or_create_by!(name: '2013') }
 
           it 'returns to the root page' do
             get use_as_template_project_path(project)
@@ -49,5 +49,4 @@ RSpec.describe ProjectsController, type: :request do
       end
     end
   end
-
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProjectsController, type: :request do
+
+  describe 'GET /projects/:id/use_as_template' do
+    let!(:submitter) { create :user }
+    let!(:season)    { nil }
+    let!(:project)   { create :project, season: season, submitter: submitter }
+
+    shared_examples_for 'returns to the root page' do
+      it 'returns to the root page' do
+        get use_as_template_project_path(project), headers: { 'HTTP_REFERER' => '/previouspage' }
+        expect(response).to redirect_to '/' # load_and_authorize_resource ignores the referrer
+        expect(flash[:alert]).to match %r{not authorized}
+      end
+    end
+
+    context 'when the user is not logged in' do
+      it_behaves_like 'returns to the root page'
+    end
+
+    context 'when the user is logged in' do
+      let!(:user) { create :user }
+      before { sign_in user }
+
+      context 'when the user does not own the project' do
+        it_behaves_like 'returns to the root page'
+      end
+
+      context 'when the user has submitted the project before' do
+        let!(:submitter) { user }
+
+        context 'when the project is from the current season' do
+          let!(:season) { Season.current }
+          it_behaves_like 'returns to the root page'
+        end
+
+        context 'when the project is from a past season' do
+          let!(:season) { Season.find_or_create_by!(name: '2013') }
+
+          it 'returns to the root page' do
+            get use_as_template_project_path(project)
+            expect(response).to be_success
+            expect(response.body).to match project.name
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
**What?**
Allows people who have submitted a project in a past season to use that project as a base for a new submission in the current year.

<img width="1163" alt="screen shot 2018-01-19 at 22 34 55" src="https://user-images.githubusercontent.com/164400/35172892-c172f63e-fd69-11e7-8dda-2edda0976f94.png">

The action will trigger the normal "new" form with the fields being already populated:

<img width="1165" alt="screen shot 2018-01-19 at 22 41 25" src="https://user-images.githubusercontent.com/164400/35172932-ec454ff6-fd69-11e7-80b3-ae248a55c68c.png">

It only works for past years. You cannot clone an already submitted project for the current season.

This said, I'm more than happy for suggestions on where to put the action button. Especially because my `colspan` hack link looks really bad when you don't have anything to use as a template:

<img width="1170" alt="screen shot 2018-01-19 at 22 35 09" src="https://user-images.githubusercontent.com/164400/35173029-35995a62-fd6a-11e7-81f8-4d1afd8863cd.png">
