### PR TITLE
Fix/redirect after deleting user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,6 +52,7 @@ class UsersController < ApplicationController
 
   def destroy
     @user.destroy
+    reset_session if @user == current_user
     respond_to do |format|
       format.html { redirect_to community_url }
       format.json { head :no_content }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,7 +53,7 @@ class UsersController < ApplicationController
   def destroy
     @user.destroy
     respond_to do |format|
-      format.html { redirect_to users_url }
+      format.html { redirect_to community_url }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,7 +52,7 @@ class UsersController < ApplicationController
 
   def destroy
     @user.destroy
-    reset_session if @user == current_user
+    sign_out @user
     respond_to do |format|
       format.html { redirect_to community_url }
       format.json { head :no_content }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -60,12 +60,12 @@ class UsersController < ApplicationController
 
   def impersonate
     impersonate_user(@user)
-    redirect_to community_index_path, notice: "Now impersonating #{@user.name}."
+    redirect_to community_path, notice: "Now impersonating #{@user.name}."
   end
 
   def stop_impersonating
     stop_impersonating_user
-    redirect_to community_index_path, notice: "Impersonation stopped. You're back to being #{current_user.name}!"
+    redirect_to community_path, notice: "Impersonation stopped. You're back to being #{current_user.name}!"
   end
 
   def resend_confirmation_instruction

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -156,7 +156,7 @@ module ApplicationHelper
 
   def link_to_user_roles(user)
     user.roles.map do |role|
-      links = [link_to(role.name.capitalize, community_index_path(role: role.name))]
+      links = [link_to(role.name.capitalize, community_path(role: role.name))]
       links << link_to(role.team.display_name, role.team) if role.team
       links.join(' at ')
     end.compact.join(', ').html_safe

--- a/app/views/application/_nav_right.html.slim
+++ b/app/views/application/_nav_right.html.slim
@@ -19,7 +19,7 @@ ul.nav.navbar-nav.navbar-right
         li class=active_if(projects_path) = link_to 'Projects', projects_path
       li.divider.hidden-xs
       li class=active_if(teams_path) = link_to 'Teams', teams_path
-      li class=active_if(community_index_path) = link_to 'Community', community_index_path
+      li class=active_if(community_path) = link_to 'Community', community_path
   li class=active_if(page_path('help')) = link_to 'Help', page_path('help')
 
   - if signed_in?

--- a/app/views/users/_search.html.slim
+++ b/app/views/users/_search.html.slim
@@ -1,8 +1,8 @@
-= form_tag community_index_path, method: :get, id: "search-form", class: "form-inline" do |f|
+= form_tag community_path, method: :get, id: "search-form", class: "form-inline" do |f|
   .form-group
     = text_field_tag :search, params[:search], placeholder: "Search user or team", class: "form-control"
   .form-group
     = submit_tag "Go", class: "form-control btn btn-default"
   - if params[:search].present?
     .form-group
-      = link_to "Clear search results", community_index_path, class: "btn btn-default"
+      = link_to "Clear search results", community_path, class: "btn btn-default"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -2,7 +2,7 @@ nav.page
   .back-nav
     ul
       li = icon('chevron-left')
-      li = link_to 'All participants', community_index_path, class: 'back'
+      li = link_to 'All participants', community_path, class: 'back'
 
 nav.actions
   ul.list-inline

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,6 @@ Rails.application.routes.draw do
   resources :conferences
   resources :conference_attendances, only: :update
   resources :contributors, only: :index
-  resources :community, only: :index
   resources :students, only: :index
   resources :status_updates, only: :show
   resources :status_update_comments, only: :create
@@ -118,6 +117,7 @@ Rails.application.routes.draw do
     resources :comments, only: [:create, :update]
   end
 
+  get '/community', to: 'community#index', as: :community
   # get 'activities(.:format)', to: 'activities#index', as: :activities
   get 'activities(/page/:page)(.:format)', to: 'activities#index', as: :activities
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe UsersController, type: :controller do
 
     it 'redirects to user#show' do
       post :impersonate, params: { id: impersonated_user.id }
-      expect(response).to redirect_to community_index_path
+      expect(response).to redirect_to community_path
       expect(flash[:notice]).to include "Now impersonating #{impersonated_user.name}"
     end
   end
@@ -230,7 +230,7 @@ RSpec.describe UsersController, type: :controller do
 
     it 'redirects to community#index' do
       post :stop_impersonating
-      expect(response).to redirect_to community_index_path
+      expect(response).to redirect_to community_path
       expect(flash[:notice]).to include "Impersonation stopped"
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -165,20 +165,14 @@ RSpec.describe UsersController, type: :controller do
 
   describe "DELETE destroy" do
     let(:user) { create(:user) }
-    before :each do
-      sign_in user
-    end
+    before { sign_in user }
 
     context "its own profile" do
-      it "destroys the requested user" do
+      it "destroys the requested user and redirects to /community" do
         expect {
           delete :destroy, params: { id: user.to_param }
         }.to change(User, :count).by(-1)
-      end
-
-      it "redirects to the users list" do
-        delete :destroy, params: { id: user.to_param }
-        expect(response).to redirect_to(users_url)
+        expect(response).to redirect_to(community_path)
       end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -169,9 +169,10 @@ RSpec.describe UsersController, type: :controller do
 
     context "its own profile" do
       it "destroys the requested user and redirects to /community" do
-        expect {
-          delete :destroy, params: { id: user.to_param }
-        }.to change(User, :count).by(-1)
+        expect { delete :destroy, params: { id: user.to_param } }
+          .to change { User.count }.by(-1)
+          .and change { session['warden.user.user.key'] }.to nil
+
         expect(response).to redirect_to(community_path)
       end
     end


### PR DESCRIPTION
Fixes #915 

* Fixes the redirect target
* Improves the naming of the named route for `/community` (i.e. `community_path` now)
* Logs out the current user if they just deleted themselves.