### PR TITLE
Update application emails

### DIFF
--- a/app/views/application_form_mailer/_student_info.slim
+++ b/app/views/application_form_mailer/_student_info.slim
@@ -12,7 +12,11 @@ b = t('simple_form.labels.student.application_age')
 p = show_or_na(data.public_send("student#{student_index}_application_age"))
 
 b = t('simple_form.labels.student.application_gender_identification')
-p = show_or_na(data.public_send("student#{student_index}_application_gender_identification"))
+- if pair
+  p
+    i This section is private.
+- else
+  p = show_or_na(data.public_send("student#{student_index}_application_gender_identification"))
 
 b = t('simple_form.labels.student.application_diversity')
 = simple_format(auto_link(show_or_na(data.public_send("student#{student_index}_application_diversity"))))

--- a/app/views/application_form_mailer/_student_info_text.text.erb
+++ b/app/views/application_form_mailer/_student_info_text.text.erb
@@ -12,7 +12,11 @@ Basics
   <%= show_or_na(data.public_send("student#{student_index}_application_age")) %>
 
 <%= t('simple_form.labels.student.application_gender_identification') %>
+<% if pair %>
+  This section is private.
+<% else %>
   <%= show_or_na(data.public_send("student#{student_index}_application_gender_identification")) %>
+<% end %>
 
 <%= t('simple_form.labels.student.application_diversity') %>
   <%= show_or_na(data.public_send("student#{student_index}_application_diversity")) %>


### PR DESCRIPTION
Quick and dirty follow up for #918 : hide the `gender_identification` field from team pair also in emails...

Looks like this in the wild now:
![screen shot 2018-01-31 at 13 53 10](https://user-images.githubusercontent.com/3491815/35624140-6a87cdee-068e-11e8-8a52-7ca27d4243df.png)


*and for txt email*
![screen shot 2018-01-31 at 13 52 55](https://user-images.githubusercontent.com/3491815/35624160-751008c6-068e-11e8-8e32-eb638cd7b61b.png)


PS: This is only a quick lunch-break-fix™ - I know how to clean this up and will do once I have more time when finishing #765 

