### PR TITLE
Fix crash when `current_team` is nil

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -19,7 +19,7 @@ class ApplicationDraftsController < ApplicationController
     if !current_user.confirmed?
       redirect_to root_path, alert: 'You need to click on the link in the email to confirm your account before you can create an application.'
     elsif current_user.student?
-      redirect_to root_path, alert: 'You need to have a partner in your team to create an application.' unless current_team.confirmed?
+      redirect_to root_path, alert: 'You need to have a partner in your team to create an application.' unless current_team.try(:confirmed?)
     else
       redirect_to new_team_path, alert: 'You need to be in a team as a student to create an application.'
     end

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -82,6 +82,13 @@ RSpec.describe ApplicationDraftsController, type: :controller do
         expect(flash[:alert]).to be_present
       end
 
+      it 'redirects for a team from last season' do
+        create :student_role, user: user, team: create(:team, :last_season)
+        get :new
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to be_present
+      end
+
       it 'renders the "new" template for a tean with two students' do
         other_role = create :student_role
         create :student_role, user: user, team: other_role.team


### PR DESCRIPTION
Related issue #926 

- Students with teams in previous seasons will get a crash when applying with no current team
