### PR TITLE
Cleanup sending email after submitting an application

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -63,7 +63,6 @@ class ApplicationDraftsController < ApplicationController
     if current_team.coaches_confirmed?
       if application_draft.ready? && application_draft.submit_application!
         flash[:notice] = 'Your application has been submitted!'
-        application_draft.application.notify_orga_and_submitters
       else
         flash[:alert] = 'An error has occurred. Please contact us.'
       end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -82,21 +82,4 @@ class Application < ApplicationRecord
   def project2
     Project.find_by(id: application_data['project2_id'])
   end
-
-  def notify_orga_and_submitters
-    notify_orga
-    notify_submitters
-  end
-
-  private
-
-  def notify_orga
-    ApplicationFormMailer.new_application(self).deliver_later
-  end
-
-  def notify_submitters
-    team.students.each do |student|
-      ApplicationFormMailer.submitted(application: self, student: student).deliver_later
-    end
-  end
 end

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -169,7 +169,7 @@ class ApplicationDraft < ApplicationRecord
     event :submit_application do
       after do |applied_at_time = nil|
         self.applied_at = applied_at_time || Time.now
-        CreatesApplicationFromDraft.new(self).save
+        CreateApplicationFromDraft.new(self).call
       end
 
       transitions from: :draft, to: :applied, guard: :ready?

--- a/app/services/create_application_from_draft.rb
+++ b/app/services/create_application_from_draft.rb
@@ -1,18 +1,22 @@
 # frozen_string_literal: true
-class CreatesApplicationFromDraft
+class CreateApplicationFromDraft
   PROJECT_FIELDS = ApplicationDraft::PROJECT_FIELDS.map(&:to_s)
   STUDENT_FIELDS = [0, 1].map { |index| User.columns.map(&:name).select{ |n| /\Aapplication_/ =~ n }.map{|n| "student#{index}_#{n}" } }.flatten
-
-  delegate :team, to: :application_draft
-
-  attr_reader :application_draft
 
   def initialize(application_draft)
     @application_draft = application_draft
   end
 
-  def save
+  def call
     application.save
+  end
+
+  private
+
+  attr_reader :application_draft
+
+  def team
+    @team ||= application_draft.team
   end
 
   def application

--- a/app/services/create_application_from_draft.rb
+++ b/app/services/create_application_from_draft.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
+
+# CreateApplicationFromDraft is a service to generate an Application record from
+# a given applicable ApplicationDraft. Relevant fields from the draft are
+# "snapshotted" into the application's "data" field.
+# Calling the service returns the newly created Application record if creating
+# the application was successful - or nil otherwise.
 class CreateApplicationFromDraft
   PROJECT_FIELDS = ApplicationDraft::PROJECT_FIELDS.map(&:to_s)
   STUDENT_FIELDS = [0, 1].map { |index| User.columns.map(&:name).select{ |n| /\Aapplication_/ =~ n }.map{|n| "student#{index}_#{n}" } }.flatten
@@ -8,7 +14,7 @@ class CreateApplicationFromDraft
   end
 
   def call
-    application.save
+    application.persisted? ? application : nil
   end
 
   private
@@ -20,7 +26,7 @@ class CreateApplicationFromDraft
   end
 
   def application
-    @application ||= Application.new(application_attributes)
+    @application ||= Application.create(application_attributes)
   end
 
   def application_attributes

--- a/spec/helpers/application_drafts_helper_spec.rb
+++ b/spec/helpers/application_drafts_helper_spec.rb
@@ -62,12 +62,9 @@ RSpec.describe ApplicationDraftsHelper, type: :helper do
         end
 
         context 'when the draft has been submitted' do
-          let(:application_draft) do
-            ApplicationDraft.new.tap do |ad|
-              allow(ad).to receive(:ready?).and_return(true)
-              ad.submit_application(1.hour.ago)
-            end
-          end
+          let(:application_draft) { create(:application_draft, :appliable) }
+
+          before { application_draft.submit_application(1.hour.ago) }
 
           it 'returns false' do
             expect(may_edit? student).to be_falsey

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -133,36 +133,4 @@ RSpec.describe Application, type: :model do
       expect(subject.name).to eql 'Foobar - Hello World'
     end
   end
-
-  describe '#notify_orga_and_submitters' do
-    subject(:notify) { application.notify_orga_and_submitters }
-
-    let!(:application) { create(:application, team: team) }
-    let(:team)         { create(:team) }
-    let!(:students)    { create_list(:student, 2, team: team) }
-    let(:mail)         { instance_double(ActionMailer::MessageDelivery, deliver_later: nil) }
-
-    it 'enqueues 3 emails to be delivered' do
-      expect { notify }.to have_enqueued_job(ActionMailer::DeliveryJob).exactly(3)
-    end
-
-    it 'calls the mailer to send an email to orga' do
-      expect(ApplicationFormMailer).to receive(:new_application).with(application).and_return(mail)
-      notify
-    end
-
-    it 'calls the mailer to send an email to each student' do
-      expect(ApplicationFormMailer).to(
-        receive(:submitted).
-        with(application: application, student: students.first)
-        .and_return(mail)
-      )
-      expect(ApplicationFormMailer).to(
-        receive(:submitted).
-        with(application: application, student: students.second)
-        .and_return(mail)
-      )
-      notify
-    end
-  end
 end

--- a/spec/services/create_application_from_draft_spec.rb
+++ b/spec/services/create_application_from_draft_spec.rb
@@ -1,18 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe CreatesApplicationFromDraft, type: :model do
+RSpec.describe CreateApplicationFromDraft, type: :service do
   let(:application_draft) { build :application_draft }
 
   subject { described_class.new application_draft }
 
-  describe 'its constructor' do
-    it 'sets the application draft' do
-      subject = described_class.new application_draft
-      expect(subject.application_draft).to eql application_draft
-    end
-  end
-
-  describe '#save' do
+  describe '#call' do
     let(:application_draft) { create :application_draft, :appliable, :with_two_projects }
     let(:team)              { create :team, :applying_team }
 
@@ -20,11 +13,11 @@ RSpec.describe CreatesApplicationFromDraft, type: :model do
       let(:application_draft) { ApplicationDraft.new }
 
       it 'will not create an application' do
-        expect { subject.save }.not_to change { ApplicationDraft.count }
+        expect { subject.call }.not_to change { Application.count }
       end
 
       it 'returns nil' do
-        expect(subject.save).to be_falsey
+        expect(subject.call).to be_falsey
       end
     end
 
@@ -40,7 +33,7 @@ RSpec.describe CreatesApplicationFromDraft, type: :model do
         end
       end
 
-      before { described_class.new(application_draft).save }
+      before { described_class.new(application_draft).call }
 
       subject { Application.last }
 


### PR DESCRIPTION
As said in https://github.com/rails-girls-summer-of-code/rgsoc-teams/pull/917 _(and mention in a comment by @carpodaster)_: creating an `Application` from an `ApplicationDraft` and then sending out emails to both submitters and the orga team could / should be done in the `ApplicationDraft` model instead of the controller.

This PR moves all the callback-logic related to an `ApplicationDraft` moving from `draft` to `applied` into the already existing state machine in the `ApplicationDraft` model.
I as a small drive-by-refactoring™ also moved `CreatesApplicationFromDraft` into a `service`. I just think having this a a "callable" object makes the usage and intention a bit more obvious.