### PR TITLE
Replace `sponsored` kind with full- and part-time

### DIFF
--- a/app/assets/stylesheets/controllers/teams.sass
+++ b/app/assets/stylesheets/controllers/teams.sass
@@ -10,7 +10,7 @@
 
 .team
   @include icon-before($star-empty)
-  &.sponsored
+  &.full-time
     @include icon-before($star)
 
 .hint
@@ -19,10 +19,10 @@
   i
     margin-right: 0.25em
 
-.icon-star-sponsored
+.icon-star-full-time
   @include icon-before($star)
   color: $railsred
 
-.icon-star-volunteer
+.icon-star-part-time
   @include icon-before($star-empty)
   color: $railsred

--- a/app/exporters/users.rb
+++ b/app/exporters/users.rb
@@ -19,7 +19,7 @@ module Exporters
       students = User.joins(roles: :team)
         .references(:roles, :teams)
         .where('roles.name' => 'student')
-        .where('teams.kind' => %w(sponsored))
+        .where('teams.kind' => %w(full_time part_time))
         .where('teams.season_id' => season)
 
       generate(students, 'User ID', 'Name', 'Email', 'Country', 'Locality', 'Address', 'T-shirt size', 'T-shirt cut') do |u|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -118,7 +118,7 @@ module ApplicationHelper
 
   def links_to_user_teams(user)
     user.teams.map do |team|
-      link_to(team.name || team.project, team, class: "team #{team.sponsored? ? 'sponsored' : ''}")
+      link_to(team.name || team.project, team, class: "team #{team.accepted? ? 'sponsored' : ''}")
     end.map(&:html_safe)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -118,7 +118,7 @@ module ApplicationHelper
 
   def links_to_user_teams(user)
     user.teams.map do |team|
-      link_to(team.name || team.project, team, class: "team #{team.accepted? ? 'sponsored' : ''}")
+      link_to(team.name || team.project, team, class: "team #{team.accepted? ? 'full-time' : ''}")
     end.map(&:html_safe)
   end
 

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -9,7 +9,7 @@ class Source < ApplicationRecord
   validates :url, presence: true
   validates :kind, presence: true
 
-  scope :for_accepted_teams, ->() { joins(:team).where("teams.kind" => %w(sponsored)) }
+  scope :for_accepted_teams, ->() { joins(:team).where("teams.kind" => %w(full_time part_time)) }
 
   def url=(url)
     super(normalize_url(url))

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,9 +2,10 @@
 class Team < ApplicationRecord
   include ProfilesHelper, HasSeason
 
-  delegate :sponsored?, to: :kind
+  delegate :full_time?, to: :kind
+  delegate :part_time?, to: :kind
 
-  KINDS = %w(sponsored)
+  KINDS = %w(full_time part_time)
 
   validates :name, presence: true, uniqueness: true
   # validate :must_have_members
@@ -44,7 +45,7 @@ class Team < ApplicationRecord
     where.not(id: Activity.where(kind: ['status_update', 'feed_entry']).where("created_at > ?", 26.hours.ago).pluck(:team_id))
   }
 
-  scope :accepted, -> { where(kind: %w(sponsored)) }
+  scope :accepted, -> { where(kind: %w(full_time part_time)) }
 
   scope :by_season, ->(year_or_season) do
     case year_or_season
@@ -81,7 +82,7 @@ class Team < ApplicationRecord
     end
 
     def selected
-      where(kind: %w(sponsored))
+      where(kind: %w(full_time part_time))
     end
   end
 
@@ -116,7 +117,7 @@ class Team < ApplicationRecord
   end
 
   def accepted?
-    sponsored?
+    full_time? || part_time?
   end
 
   def admin_team?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,7 +169,7 @@ class User < ApplicationRecord
 
   def current_student?
     roles.joins(:team).
-      where("teams.season_id" => Season.current.id, "teams.kind" => %w(sponsored)).
+      where("teams.season_id" => Season.current.id, "teams.kind" => %w(full_time part_time)).
       student.any?
   end
 

--- a/app/views/organizers/users_info/index.html.slim
+++ b/app/views/organizers/users_info/index.html.slim
@@ -9,7 +9,7 @@ h1.header User info
         = role.capitalize
 
     h5 Type
-    - %w(all sponsored).each do |kind|
+    - %w(all full_time part_time).each do |kind|
       label.radio
         = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
         = kind.capitalize

--- a/app/views/teams/_table.html.slim
+++ b/app/views/teams/_table.html.slim
@@ -33,5 +33,5 @@ table.table.table-striped.table-bordered.table-condensed
         td = render "supervisors/shared/performance_icon", status: team.performance.evaluation.to_s
 
 p.hint
-  | <span class="icon-star-sponsored"></span>Sponsored team &nbsp;&nbsp;
-  | <span class="icon-star-volunteer"></span>Volunteering team
+  | <span class="icon-star-full-time"></span>Full-time team &nbsp;&nbsp;
+  | <span class="icon-star-part-time"></span>Part-time team

--- a/app/views/teams_info/index.html.slim
+++ b/app/views/teams_info/index.html.slim
@@ -24,5 +24,5 @@ table.table.table-striped.table-bordered.table-condensed
         td = team.post_info
 
 p.hint
-  | <span class="icon-star-sponsored"></span>Sponsored team &nbsp;&nbsp;
-  | <span class="icon-star-volunteer"></span>Volunteering team
+  | <span class="icon-star-full-time"></span>Full-time team &nbsp;&nbsp;
+  | <span class="icon-star-part-time"></span>Part-time team

--- a/spec/controllers/organizers/teams_controller_spec.rb
+++ b/spec/controllers/organizers/teams_controller_spec.rb
@@ -18,16 +18,16 @@ RSpec.describe Organizers::TeamsController, type: :controller do
     include_context 'with admin logged in'
 
     describe 'GET index' do
-      let!(:sponsored_team) { create :team, :in_current_season, kind: 'full_time' }
+      let!(:full_time_team) { create :team, :in_current_season, kind: 'full_time' }
 
       it 'assigns only selected teams as @teams' do
         get :index
-        expect(assigns(:teams)).to match_array [sponsored_team]
+        expect(assigns(:teams)).to match_array [full_time_team]
       end
 
       it 'assigns all teams as @teams when requested' do
         get :index, params: { filter: 'all' }
-        expect(assigns(:teams)).to match_array [sponsored_team, team]
+        expect(assigns(:teams)).to match_array [full_time_team, team]
       end
     end
 

--- a/spec/controllers/organizers/teams_controller_spec.rb
+++ b/spec/controllers/organizers/teams_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Organizers::TeamsController, type: :controller do
     include_context 'with admin logged in'
 
     describe 'GET index' do
-      let!(:sponsored_team) { create :team, :in_current_season, kind: 'sponsored' }
+      let!(:sponsored_team) { create :team, :in_current_season, kind: 'full_time' }
 
       it 'assigns only selected teams as @teams' do
         get :index

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TeamsController, type: :controller do
       let(:last_season)      { Season.create name: Date.today.year - 1 }
       let!(:invisble_team)   { create :team, :in_current_season, kind: nil, invisible: true }
       let!(:unaccepted_team) { create :team, :in_current_season, kind: nil}
-      let!(:last_years_team) { create :team, kind: 'sponsored', season: last_season }
+      let!(:last_years_team) { create :team, kind: 'part_time', season: last_season }
 
       before do
         Season.current.update acceptance_notification_at: 1.day.from_now
@@ -61,9 +61,9 @@ RSpec.describe TeamsController, type: :controller do
 
     context 'after acceptance letters have been sent' do
       let(:last_season) { Season.create name: Date.today.year - 1 }
-      let!(:sponsored_team) { create :team, :in_current_season, kind: 'sponsored' }
+      let!(:sponsored_team) { create :team, :in_current_season, kind: 'full_time' }
       let!(:unaccepted_team) { create :team, :in_current_season, kind: nil}
-      let!(:last_years_team) { create :team, kind: 'sponsored', season: last_season }
+      let!(:last_years_team) { create :team, kind: 'full_time', season: last_season }
 
       before do
         Season.current.update acceptance_notification_at: 1.day.ago

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe TeamsController, type: :controller do
 
     context 'after acceptance letters have been sent' do
       let(:last_season) { Season.create name: Date.today.year - 1 }
-      let!(:sponsored_team) { create :team, :in_current_season, kind: 'full_time' }
+      let!(:full_time_team) { create :team, :in_current_season, kind: 'full_time' }
       let!(:unaccepted_team) { create :team, :in_current_season, kind: nil}
       let!(:last_years_team) { create :team, kind: 'full_time', season: last_season }
 
@@ -72,7 +72,7 @@ RSpec.describe TeamsController, type: :controller do
       it 'only displays this season\'s accepted teams' do
         get :index
         expect(response).to be_success
-        expect(assigns(:teams)).to match_array [sponsored_team]
+        expect(assigns(:teams)).to match_array [full_time_team]
       end
 
     end

--- a/spec/exporters/applications_spec.rb
+++ b/spec/exporters/applications_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Exporters::Applications do
 
   let(:old_season)        { create :season, name: "2015" }
-  let(:selected_team)     { create :team,   kind: 'sponsored' }
+  let(:selected_team)     { create :team,   kind: 'full_time' }
   let(:not_selected_team) { create :team,   kind: nil }
 
   let!(:selected_application) do

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :team do
-    kind 'sponsored'
+    kind 'part_time'
     sequence(:name) { |i| "#{i}-#{FFaker::CheesyLingo.word.capitalize}" }
 
     trait :helpdesk do

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ReminderMailer, type: :mailer do
   let(:student_2_email) { 'free@hat.com' }
 
   let(:team) {
-    team = create :team, kind: 'sponsored'
+    team = create :team, kind: 'full_time'
     create :student, team: team, email: student_1_email
     create :student, team: team, email: student_2_email
     team

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Source, type: :model do
   it { is_expected.to validate_presence_of(:url) }
 
   describe '.for_accepted_teams' do
-    let!(:accepted_team)   { create :team, kind: %w(full_time).sample }
+    let!(:accepted_team)   { create :team, kind: 'full_time' }
     let!(:accepted_source) { create :source, team: accepted_team }
 
     let!(:unaccepted_team)   { create :team, kind: nil }

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Source, type: :model do
   it { is_expected.to validate_presence_of(:url) }
 
   describe '.for_accepted_teams' do
-    let!(:accepted_team)   { create :team, kind: %w(sponsored).sample }
+    let!(:accepted_team)   { create :team, kind: %w(full_time).sample }
     let!(:accepted_source) { create :source, team: accepted_team }
 
     let!(:unaccepted_team)   { create :team, kind: nil }

--- a/spec/models/team_performance_spec.rb
+++ b/spec/models/team_performance_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TeamPerformance, type: :model do
   end
 
   let :team_nothing do
-    create :team, kind: 'sponsored'
+    create :team, kind: 'part_time'
   end
 
   let :team_activitiy do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  subject { Team.new(kind: 'sponsored') }
+  subject { Team.new(kind: 'full_time') }
 
   it { is_expected.to have_many(:activities) }
   it { is_expected.to have_many(:sources) }
@@ -455,16 +455,14 @@ RSpec.describe Team, type: :model do
       expect(subject).not_to be_accepted
     end
 
-    it 'returns true for a sponsored team' do
-      subject.kind = 'sponsored'
+    it 'returns true for a full_time team' do
+      subject.kind = 'full_time'
       expect(subject).to be_accepted
     end
-  end
 
-  describe '#sponsored?' do
-    it 'returns true' do
-      subject.kind = 'sponsored'
-      expect(subject).to be_sponsored
+    it 'returns true for a part_time team' do
+      subject.kind = 'part_time'
+      expect(subject).to be_accepted
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe User, type: :model do
     end
 
     it 'returns true if user is among this season\'s accepted students' do
-      team    = create(:team, :in_current_season, kind: 'sponsored')
+      team    = create(:team, :in_current_season, kind: 'part_time')
       student = create(:student, team: team)
       expect(student).to be_current_student
     end

--- a/spec/requests/navigation_spec.rb
+++ b/spec/requests/navigation_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Navigation', type: :request do
     end
 
     context 'for students' do
-      let(:team) { create :team, :in_current_season, kind: 'sponsored' }
+      let(:team) { create :team, :in_current_season, kind: 'full_time' }
       let(:user) { create(:student_role, team: team).user }
 
       before do

--- a/spec/support/shared_contexts/with_student_logged_in.rb
+++ b/spec/support/shared_contexts/with_student_logged_in.rb
@@ -1,5 +1,5 @@
 RSpec.shared_context 'with student logged in' do
-  let(:team) { create :team, kind: 'sponsored' }
+  let(:team) { create :team, kind: 'full_time' }
   let(:current_user) { create(:student_role, team: team).user }
 
   before do

--- a/spec/support/shared_examples/redirect_for_non_students.rb
+++ b/spec/support/shared_examples/redirect_for_non_students.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples 'redirects for non-users' do
   # OPTIMIZE test actions other than 'index'
 
-  let(:accepted_team) { create :team, :in_current_season, kind: 'sponsored' }
+  let(:accepted_team) { create :team, :in_current_season, kind: 'part_time' }
 
   shared_examples_for 'disallows access to students namespace' do
     before do
@@ -44,7 +44,7 @@ RSpec.shared_examples 'redirects for non-users' do
 
     context 'who is part of an accepted team from last season' do
       let(:last_season)   { Season.create name: Date.today.year - 1 }
-      let(:accepted_team) { create :team, season: last_season, kind: 'sponsored' }
+      let(:accepted_team) { create :team, season: last_season, kind: 'part_time' }
       let(:user)          { create(:student_role, team: accepted_team).user }
       it_behaves_like 'disallows access to students namespace'
     end


### PR DESCRIPTION
Related issue #925 

This is the first of a series of steps towards rolling out the new team kinds, replacing the team logic for sponsored and volunteering teams with full and part-time teams
