### PR TITLE
Bugfix/hide team on profile if invisible

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,10 +86,6 @@ class User < ApplicationRecord
     @github_import = import
   end
 
-  def visible_teams
-    teams.accepted.merge(teams.visible)
-  end
-
   class << self
     def ordered(order = nil, direction = 'asc')
       direction = direction == 'asc' ? 'ASC' : 'DESC'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,6 +86,10 @@ class User < ApplicationRecord
     @github_import = import
   end
 
+  def visible_teams
+    teams.accepted.merge(teams.visible)
+  end
+
   class << self
     def ordered(order = nil, direction = 'asc')
       direction = direction == 'asc' ? 'ASC' : 'DESC'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -46,7 +46,8 @@ nav.actions
     h4 Teams
     ul.teams
       - @user.teams.each do |team|
-        li #{link_to team.display_name, team} &ndash; #{role_names(team, @user)}
+        - if !team.invisible || team.sponsored?
+          li #{link_to team.display_name, team} &ndash; #{role_names(team, @user)}
 
   - if @user.interested_in.any?
     h4 Interested in

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -42,12 +42,11 @@ nav.actions
     h4 About me
     p = render_markdown(@user.bio).html_safe
 
-  - if @user.teams.any?
+  - if @user.visible_teams.any?
     h4 Teams
     ul.teams
-      - @user.teams.each do |team|
-        - if !team.invisible || team.sponsored?
-          li #{link_to team.display_name, team} &ndash; #{role_names(team, @user)}
+      - @user.visible_teams.each do |team|
+        li #{link_to team.display_name, team} &ndash; #{role_names(team, @user)}
 
   - if @user.interested_in.any?
     h4 Interested in

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -42,10 +42,10 @@ nav.actions
     h4 About me
     p = render_markdown(@user.bio).html_safe
 
-  - if @user.visible_teams.any?
+  - if @user.teams.visible.any?
     h4 Teams
     ul.teams
-      - @user.visible_teams.each do |team|
+      - @user.teams.visible.each do |team|
         li #{link_to team.display_name, team} &ndash; #{role_names(team, @user)}
 
   - if @user.interested_in.any?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -317,26 +317,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#visible_teams' do
-    it 'returns invisible accepted teams' do
-      team    = create(:team, :in_current_season, kind: 'sponsored', invisible: true)
-      student = create(:student, team: team)
-      expect(student.visible_teams).not_to be_empty
-    end
-
-    it 'does not return invisible teams' do
-      team    = create(:team, :in_current_season, kind: nil, invisible: true)
-      student = create(:student, team: team)
-      expect(student.visible_teams).to be_empty
-    end
-
-    it 'returns accepted teams' do
-      team    = create(:team, :in_current_season, kind: 'sponsored')
-      student = create(:student, team: team)
-      expect(student.visible_teams).not_to be_empty
-    end
-  end
-
   describe '#current_student?' do
     it 'returns false for users w/o a role' do
       expect(subject).not_to be_current_student

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -317,6 +317,25 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#visible_teams' do
+    it 'returns invisible accepted teams' do
+      team    = create(:team, :in_current_season, kind: 'sponsored', invisible: true)
+      student = create(:student, team: team)
+      expect(student.visible_teams).not_to be_empty
+    end
+
+    it 'does not return invisible teams' do
+      team    = create(:team, :in_current_season, kind: nil, invisible: true)
+      student = create(:student, team: team)
+      expect(student.visible_teams).to be_empty
+    end
+
+    it 'returns accepted teams' do
+      team    = create(:team, :in_current_season, kind: 'sponsored')
+      student = create(:student, team: team)
+      expect(student.visible_teams).not_to be_empty
+    end
+  end
 
   describe '#current_student?' do
     it 'returns false for users w/o a role' do


### PR DESCRIPTION
Related issue #932 

This aims to hide a user's team on their profile if invisible, unless they're accepted.
