### PR TITLE
Fixed issue of populating Team dropdown

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -32,6 +32,11 @@ class ActivitiesController < ApplicationController
   end
   helper_method :teams
 
+  def last_season_teams
+    Team.select {|t| t.season_id == Season.current.id + 1 && (t.kind == 'sponsored' || t.kind == 'voluntary' || t.kind == 'full_time' || t.kind == 'part_time')}
+  end
+  helper_method :last_season_teams
+
   def normalize_params
     params[:kind] = 'all' if params[:kind].blank?
   end

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -11,9 +11,12 @@ div.row
           label.radio
             = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
             = " " + kind == 'feed_entry' ? 'Blog Post' : kind.titleize
-        label.team_filter
-          ' Team:
-          = select_tag :team_id, options_for_select(teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: true, class: 'form-control'
+        - if teams.any?
+          label.team_filter
+            = select_tag :team_id, options_for_select(teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: 'Teams', class: 'form-control'
+        - else
+          label.team_filter
+            = select_tag :team_id, options_for_select(last_season_teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: 'Teams', class: 'form-control'
 
     p.pagination-info
       = page_entries_info @activities


### PR DESCRIPTION
Related issue #934
Also, refer #940 

When the there are no teams for the current season (i.e. between the two seasons) then drop down will show the teams of the most recent season. At present, when there is no selected team, the drop-down is empty thus acting as redundant for the activity page. 

Before:-

![rgsoc_teamapp](https://user-images.githubusercontent.com/18376639/36607103-ab981a36-18eb-11e8-9c0c-5291e6ee4868.png)

After:-

1)Between two seasons when there is no selected team, the drop-down will show past season teams.

![screenshot-2018-2-23 rgsoc - teams app 1](https://user-images.githubusercontent.com/18376639/36607242-0b8c49b2-18ec-11e8-8572-9d582b5a6379.png)

2) If current season teams are present then drop-down will show current season teams.

![screenshot-2018-2-23 rgsoc - teams app](https://user-images.githubusercontent.com/18376639/36607408-9490e43e-18ec-11e8-91a7-5e59258c66e2.png)

