### PR TITLE
Migrate old team "kinds" to new datamodel

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -28,7 +28,7 @@ class ActivitiesController < ApplicationController
   end
 
   def teams
-    Team.in_current_season.selected.order(:name)
+    Team.in_current_season.accepted.order(:name)
   end
   helper_method :teams
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -87,7 +87,7 @@ class UsersController < ApplicationController
 
   def teams
     all_teams = Team.all.order(:name)
-    selected_teams = Team.in_current_season.selected.order(:name)
+    selected_teams = Team.in_current_season.accepted.order(:name)
     current_season.active? ? selected_teams : all_teams
   end
   helper_method :teams

--- a/app/exporters/users.rb
+++ b/app/exporters/users.rb
@@ -19,7 +19,7 @@ module Exporters
       students = User.joins(roles: :team)
         .references(:roles, :teams)
         .where('roles.name' => 'student')
-        .where('teams.kind' => %w(full_time part_time))
+        .merge(Team.accepted)
         .where('teams.season_id' => season)
 
       generate(students, 'User ID', 'Name', 'Email', 'Country', 'Locality', 'Address', 'T-shirt size', 'T-shirt cut') do |u|

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -9,13 +9,9 @@ class Source < ApplicationRecord
   validates :url, presence: true
   validates :kind, presence: true
 
-  scope :for_accepted_teams, ->() { joins(:team).where("teams.kind" => %w(full_time part_time)) }
+  scope :for_accepted_teams, ->() { joins(:team).merge(Team.accepted) }
 
   def url=(url)
     super(normalize_url(url))
   end
-
-  # def name
-  #   @name ||= url.split('/')[-2, 2].join('/')
-  # end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -45,9 +45,9 @@ class Team < ApplicationRecord
     where.not(id: Activity.where(kind: ['status_update', 'feed_entry']).where("created_at > ?", 26.hours.ago).pluck(:team_id))
   }
 
-  scope :accepted, -> { where(kind: %w(full_time part_time)) }
-  scope :full_time, -> { where(kind: 'full_time') }
-  scope :part_time, -> { where(kind: 'part_time') }
+  scope :full_time, -> { where(kind: %w(full_time sponsored)) }
+  scope :part_time, -> { where(kind: %w(part_time voluntary)) }
+  scope :accepted, -> { full_time.or(part_time) }
 
   scope :by_season, ->(year_or_season) do
     case year_or_season

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -48,6 +48,8 @@ class Team < ApplicationRecord
   scope :full_time, -> { where(kind: %w(full_time sponsored)) }
   scope :part_time, -> { where(kind: %w(part_time voluntary)) }
   scope :accepted, -> { full_time.or(part_time) }
+  scope :visible, -> { where.not(invisible: true).or(accepted) }
+  scope :in_current_season, -> { where(season: Season.current) }
 
   scope :by_season, ->(year_or_season) do
     case year_or_season
@@ -65,10 +67,6 @@ class Team < ApplicationRecord
       order([sort[:order] || 'kind, name', sort[:direction] || 'asc'].join(' '))
     end
 
-    def visible
-      where("teams.invisible IS NOT TRUE OR teams.kind IN (?)", KINDS)
-    end
-
     # Returns a base scope reflecting the relevant teams depending on what
     # phase of the running season we're currently in.
     def by_season_phase
@@ -77,10 +75,6 @@ class Team < ApplicationRecord
       else
         Team.in_current_season.visible
       end
-    end
-
-    def in_current_season
-      where(season: Season.current)
     end
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -16,23 +16,23 @@ class Team < ApplicationRecord
 
   attr_accessor :checked
 
+  belongs_to :project
+
+  has_one :last_activity, -> { order('id DESC') }, class_name: 'Activity'
+  has_one :conference_preference, dependent: :destroy
+
   has_many :applications, dependent: :nullify, inverse_of: :team
   has_many :application_drafts, dependent: :nullify
   has_many :roles, dependent: :destroy, inverse_of: :team
-  has_many :members, class_name: 'User', through: :roles, source: :user
+  has_many :members, through: :roles, source: :user
   Role::ROLES.each do |role|
-    has_many role.pluralize.to_sym, -> { where(roles: { name: role }) }, class_name: 'User', through: :roles, source: :user
+    has_many role.pluralize.to_sym, -> { where(roles: { name: role }) }, through: :roles, source: :user
   end
   has_many :sources, dependent: :destroy
   has_many :activities, dependent: :destroy
-  has_one :last_activity, -> { order('id DESC') }, class_name: 'Activity'
   has_many :comments, as: :commentable
   has_many :status_updates, -> { where(kind: 'status_update') }, class_name: 'Activity'
   has_many :conference_attendances, dependent: :destroy
-
-  has_one :conference_preference, dependent: :destroy
-  has_many :conferences, through: :conference_preference
-  belongs_to :project
 
   accepts_nested_attributes_for :conference_preference, allow_destroy: true
   accepts_nested_attributes_for :roles, :sources, allow_destroy: true

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -73,7 +73,7 @@ class Team < ApplicationRecord
     # phase of the running season we're currently in.
     def by_season_phase
       if Time.now.utc > Season.current.acceptance_notification_at
-        Team.in_current_season.selected
+        Team.in_current_season.accepted
       else
         Team.in_current_season.visible
       end
@@ -81,10 +81,6 @@ class Team < ApplicationRecord
 
     def in_current_season
       where(season: Season.current)
-    end
-
-    def selected
-      where(kind: %w(full_time part_time))
     end
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -8,7 +8,6 @@ class Team < ApplicationRecord
   KINDS = %w(full_time part_time)
 
   validates :name, presence: true, uniqueness: true
-  # validate :must_have_members
   validate :disallow_multiple_student_roles
   validate :disallow_duplicate_members
   validate :limit_number_of_students

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -49,17 +49,7 @@ class Team < ApplicationRecord
   scope :accepted, -> { full_time.or(part_time) }
   scope :visible, -> { where.not(invisible: true).or(accepted) }
   scope :in_current_season, -> { where(season: Season.current) }
-
-  scope :by_season, ->(year_or_season) do
-    case year_or_season
-    when Integer, String
-      joins(:season).where('seasons.name': year_or_season)
-    when Season
-      where(season: year_or_season)
-    else
-      none
-    end
-  end
+  scope :by_season, ->(year) { joins(:season).where(seasons: { name: year }) }
 
   class << self
     def ordered(sort = {})

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,24 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  subject { Team.new(kind: 'full_time') }
+  describe 'associations' do
+    it { is_expected.to belong_to(:project) }
 
-  it { is_expected.to have_many(:activities) }
-  it { is_expected.to have_many(:sources) }
-  it { is_expected.to have_many(:members) }
-  it { is_expected.to have_many(:students) }
-  it { is_expected.to have_many(:coaches) }
-  it { is_expected.to have_many(:mentors) }
-  it { is_expected.to have_many(:helpdesks) }
-  it { is_expected.to have_many(:organizers) }
-  it { is_expected.to have_many(:supervisors) }
-  it { is_expected.to have_many(:status_updates) }
-  it { is_expected.to have_many(:roles).inverse_of(:team) }
-  it { is_expected.to have_many(:conference_attendances).dependent(:destroy) }
-  it { expect(subject).to have_one(:conference_preference).dependent(:destroy) }
-  it { is_expected.to belong_to(:project) }
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_uniqueness_of(:name) }
+    it { is_expected.to have_many(:applications).dependent(:nullify).inverse_of(:team) }
+    it { is_expected.to have_many(:application_drafts).dependent(:nullify) }
+
+    it { is_expected.to have_many(:activities).dependent(:destroy) }
+    it { is_expected.to have_many(:sources).dependent(:destroy) }
+    it { is_expected.to have_many(:comments) }
+
+    it { is_expected.to have_many(:roles).dependent(:destroy).inverse_of(:team) }
+    it { is_expected.to have_many(:members).through(:roles).source(:user) }
+    it { is_expected.to have_many(:students).through(:roles).source(:user) }
+    it { is_expected.to have_many(:coaches).through(:roles).source(:user) }
+    it { is_expected.to have_many(:mentors).through(:roles).source(:user) }
+    it { is_expected.to have_many(:helpdesks).through(:roles).source(:user) }
+    it { is_expected.to have_many(:organizers).through(:roles).source(:user) }
+    it { is_expected.to have_many(:supervisors).through(:roles).source(:user) }
+
+    it { is_expected.to have_many(:status_updates).class_name('Activity').conditions(kind: 'status_update') }
+
+    it { is_expected.to have_many(:conference_attendances).dependent(:destroy) }
+
+    it { is_expected.to have_one(:conference_preference).dependent(:destroy) }
+    it { is_expected.to have_one(:last_activity).class_name('Activity').order('id DESC') }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name) }
+  end
 
   context 'multiple team memberships' do
     let!(:existing_team) { role.team }

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Team, type: :model do
     end
   end
 
-  describe 'scopes' do
+  describe 'scopes', :wip do
     let!(:full_time) { create(:team, kind: 'full_time') }
     let!(:sponsored) { create(:team, kind: 'sponsored') }
     let!(:part_time) { create(:team, kind: 'part_time') }

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -347,20 +347,6 @@ RSpec.describe Team, type: :model do
           expect(teams).to match_array(teams2016)
         end
       end
-
-      context 'when passing season name' do
-        subject(:teams) { described_class.by_season(season2016.name) }
-
-        it 'returns only teams from the given season' do
-          expect(teams).to match_array(teams2016)
-        end
-      end
-
-      context 'when passing a non-supported type' do
-        subject(:teams) { described_class.by_season(Object.new) }
-
-        it { is_expected.to be_empty }
-      end
     end
 
     describe '.without_recent_log_update' do


### PR DESCRIPTION
As #942 reports, displaying teams based on the season currently does not really work, as the old records don't adhere to the new datamodel for `team` - we have different **kinds** now: `part_time` and `full_time`.

I checked with the production db and added a small migration to move `sponsored` to `full_time` and `voluntary` to `part_time`. Even though that's not a 💯 fit, I'd say it's a better option then redefining what an `accepted` team is, or not showing any past teams at all... What do you think @ramonh ?