### PR TITLE
Filter full/part time teams

### DIFF
--- a/app/controllers/organizers/teams_controller.rb
+++ b/app/controllers/organizers/teams_controller.rb
@@ -17,8 +17,6 @@ module Organizers
         @teams = Team.in_current_season.full_time.ordered
       elsif params[:filter] == 'part_time'
         @teams = Team.in_current_season.part_time.ordered
-      elsif params[:filter] != 'all'
-        @teams = Team.in_current_season.selected.ordered
       end
     end
 

--- a/app/controllers/organizers/teams_controller.rb
+++ b/app/controllers/organizers/teams_controller.rb
@@ -17,6 +17,8 @@ module Organizers
         @teams = Team.in_current_season.full_time.ordered
       elsif params[:filter] == 'part_time'
         @teams = Team.in_current_season.part_time.ordered
+      else
+        @teams = Team.in_current_season.ordered
       end
     end
 

--- a/app/controllers/organizers/teams_controller.rb
+++ b/app/controllers/organizers/teams_controller.rb
@@ -12,7 +12,12 @@ module Organizers
       else
         @teams = Team.order(:kind, :name)
       end
-      if params[:filter] != 'all'
+
+      if params[:filter] == 'full_time'
+        @teams = Team.in_current_season.full_time.ordered
+      elsif params[:filter] == 'part_time'
+        @teams = Team.in_current_season.part_time.ordered
+      elsif params[:filter] != 'all'
         @teams = Team.in_current_season.selected.ordered
       end
     end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -46,6 +46,8 @@ class Team < ApplicationRecord
   }
 
   scope :accepted, -> { where(kind: %w(full_time part_time)) }
+  scope :full_time, -> { where(kind: 'full_time') }
+  scope :part_time, -> { where(kind: 'part_time') }
 
   scope :by_season, ->(year_or_season) do
     case year_or_season

--- a/app/views/organizers/teams/index.html.slim
+++ b/app/views/organizers/teams/index.html.slim
@@ -4,7 +4,8 @@ nav.actions
   ul.list-inline
     li = link_to icon('plus', 'New Team'), new_organizers_team_path, class: 'btn btn-default btn-sm'
     li = link_to 'Show all teams', organizers_teams_path(filter: :all)
-    li = link_to 'Show only selected teams', organizers_teams_path
+    li = link_to 'Show full-time teams', organizers_teams_path(filter: :full_time)
+    li = link_to 'Show part-time teams', organizers_teams_path(filter: :part_time)
     li = link_to 'Teams organizers info &rarr;'.html_safe, teams_info_path
 
 = render 'teams/table', namespace: :organizers

--- a/app/views/teams/_table.html.slim
+++ b/app/views/teams/_table.html.slim
@@ -17,7 +17,7 @@ table.table.table-striped.table-bordered.table-condensed
 
   - @teams.each do |team|
     tr
-      td = link_to team.display_name, [namespace, team].compact, class: "team #{team.kind}"
+      td = link_to team.display_name, [namespace, team].compact, class: "team #{team.kind.humanize.parameterize}"
       - @display_roles.each do |role|
         td
           ul

--- a/spec/controllers/organizers/teams_controller_spec.rb
+++ b/spec/controllers/organizers/teams_controller_spec.rb
@@ -19,15 +19,21 @@ RSpec.describe Organizers::TeamsController, type: :controller do
 
     describe 'GET index' do
       let!(:full_time_team) { create :team, :in_current_season, kind: 'full_time' }
+      let!(:part_time_team) { create :team, :in_current_season, kind: 'part_time' }
 
-      it 'assigns only selected teams as @teams' do
+      it 'assigns all teams as @teams' do
         get :index
-        expect(assigns(:teams)).to match_array [full_time_team]
+        expect(assigns(:teams)).to match_array [full_time_team, part_time_team, team]
       end
 
-      it 'assigns all teams as @teams when requested' do
-        get :index, params: { filter: 'all' }
-        expect(assigns(:teams)).to match_array [full_time_team, team]
+      it 'assigns part_time teams as @teams when requested' do
+        get :index, params: { filter: 'part_time' }
+        expect(assigns(:teams)).to match_array [part_time_team]
+      end
+
+      it 'assigns full_time teams as @teams when requested' do
+        get :index, params: { filter: 'full_time' }
+        expect(assigns(:teams)).to match_array [full_time_team]
       end
     end
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -268,6 +268,30 @@ RSpec.describe Team, type: :model do
   context 'with scopes' do
     let!(:team) { create :team, kind: nil }
 
+    describe '.full_time' do
+      before { team.update(kind: 'full_time') }
+
+      it 'returns teams that are full-time' do
+        expect(described_class.full_time).to eq [team]
+      end
+
+      it 'returns teams that are part-time' do
+        expect(described_class.part_time).to eq []
+      end
+    end
+
+    describe '.part_time' do
+      before { team.update(kind: 'part_time') }
+
+      it 'returns teams that are full-time' do
+        expect(described_class.full_time).to eq []
+      end
+
+      it 'returns teams that are part-time' do
+        expect(described_class.part_time).to eq [team]
+      end
+    end
+
     describe '.visible' do
 
       it 'returns teams that are not marked invisible' do


### PR DESCRIPTION
Related issue #925

The orga dashboard of the teams app will now show full and part time teams and allow filtering thereof.

There was also a bug where the star icon wasn't being correctly shown.

<img width="1197" alt="screen shot 2018-02-26 at 09 52 49" src="https://user-images.githubusercontent.com/656318/36661257-1c0758b8-1adb-11e8-93ac-40047e9fb1bd.png">

