### PR TITLE
Temporarily disable student submitted notification

### DIFF
--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -173,7 +173,10 @@ class ApplicationDraft < ApplicationRecord
       end
 
       after do
-        notify_orga_and_submitters
+        # TODO: There was an incident where students were sent the opposite
+        # info with their names on it. This will be off until we can figure out
+        # how this happened and how we can prevent it.
+        notify_orga
       end
 
       transitions from: :draft, to: :applied, guard: :ready?

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -232,9 +232,9 @@ RSpec.describe ApplicationDraftsController, type: :controller do
             expect(application.application_draft).to eql draft
           end
 
-          it 'sends 3 mails (1 to orga and 1 to each student)' do
+          it 'sends 1 mail to orga' do
             expect { put :apply, { params: { id: draft.id } } }.to \
-              change { enqueued_jobs.size }.by(3)
+              change { enqueued_jobs.size }.by(1)
           end
 
           it 'flags the draft as applied' do

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -327,23 +327,13 @@ RSpec.describe ApplicationDraft, type: :model do
         expect(application).to have_attributes(application_draft: application_draft)
       end
 
-      it 'updates the state to :applied and sends notification emails to orga and submitters' do
+      it 'updates the state to :applied and sends notification email to orga' do
         expect { submit_application }.to change { application_draft.state }.from('draft').to('applied')
 
         submitted_application = application_draft.reload.application
 
         expect(ActionMailer::DeliveryJob).to have_been_enqueued.with(
           'ApplicationFormMailer', 'new_application', 'deliver_now', submitted_application
-        )
-        expect(ActionMailer::DeliveryJob).to have_been_enqueued.with(
-          'ApplicationFormMailer', 'submitted', 'deliver_now',
-          application: submitted_application,
-          student:     students.first
-        )
-        expect(ActionMailer::DeliveryJob).to have_been_enqueued.with(
-          'ApplicationFormMailer', 'submitted', 'deliver_now',
-          application: submitted_application,
-          student:     students.second
         )
       end
     end


### PR DESCRIPTION
There was an incident where students got their names on the opposite application forms. 

In the interest of privacy, we'll disable this feature until we can figure this one out.
