### PR TITLE
Add bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'jquery-ui-rails'
 gem 'bootstrap-sass'
 gem 'font-awesome-sass'
 gem 'pretender'
+gem 'bootsnap', require: false
 
 gem 'sass-rails'
 gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.1.8)
+      msgpack (~> 1.0)
     bootstrap-kaminari-views (0.0.5)
       kaminari (>= 0.13)
       rails (>= 3.1)
@@ -170,6 +172,7 @@ GEM
     minitest (5.11.3)
     money (6.10.1)
       i18n (>= 0.6.4, < 1.0)
+    msgpack (1.2.2)
     multi_json (1.13.0)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -371,6 +374,7 @@ DEPENDENCIES
   aws-sdk (~> 2.10)
   better_errors
   binding_of_caller
+  bootsnap
   bootstrap-kaminari-views
   bootstrap-sass
   byebug

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
While working on #946 I realized it takes a lot of time to start the test suite *(which is a bit frustrating when doing TDD and having to run the certain tests over and over)* 🐌 

So I added Spotify's [bootsnap](https://github.com/Shopify/bootsnap). It's a drop in solution for basically a faster start of the app (and does not conflict with spring) and will be part of the default Gemfile in the upcoming Rails version.

Small proof of concept 😉 :
```shell
# on master
~/code/rgsoc/rgsoc-teams master
❯ time rake environment
rake environment  2.30s user 1.08s system 96% cpu 3.506 total

# on this branch
~/code/rgsoc/rgsoc-teams add-bootsnap*
❯ time rake environment
rake environment  1.19s user 0.33s system 92% cpu 1.634 total
```