### PR TITLE
Tweak mentor comment text for transparency

### DIFF
--- a/app/views/mentors/applications/_comment.html.slim
+++ b/app/views/mentors/applications/_comment.html.slim
@@ -2,6 +2,6 @@ hr(id="#{dom_id comment}")
 = simple_form_for comment, url: mentors_comments_path do |f|
   .form-inputs.clearfix
     = f.input :commentable_id, as: :hidden, value: comment.commentable_id
-    = f.input :text, as: :text, label: 'My Comment', input_html: { rows: 5 }, hint: 'This is a place for you to take notes for yourself about this application. Your comment is only visible to you and you can update and remove it as you like.'
+    = f.input :text, as: :text, label: 'My Comment', input_html: { rows: 5 }, hint: 'This is a place for you to take notes for yourself about this application. Your comment is only visible to yourself as well as the selection committee and you can update and remove it as you like.'
   .form-actions
     = f.button :submit


### PR DESCRIPTION
As discussed with @alicetragedy, it makes sense to update this field to show that the selection committee will have access to these comments.
