### PR TITLE
Add pre-validation hook to ensure application flags are unique

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -22,6 +22,8 @@ class Application < ApplicationRecord
 
   validates :team, :application_data, presence: true
 
+  before_validation :ensure_flags_unique
+
   scope :hidden, -> { where('applications.hidden IS NOT NULL and applications.hidden = ?', true) }
   scope :visible, -> { where('applications.hidden IS NULL or applications.hidden = ?', false) }
 
@@ -81,5 +83,9 @@ class Application < ApplicationRecord
 
   def project2
     Project.find_by(id: application_data['project2_id'])
+  end
+
+  def ensure_flags_unique
+    flags.uniq!
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -22,7 +22,7 @@ class Application < ApplicationRecord
 
   validates :team, :application_data, presence: true
 
-  before_validation :ensure_flags_unique
+  before_validation :remove_duplicate_flags
 
   scope :hidden, -> { where('applications.hidden IS NOT NULL and applications.hidden = ?', true) }
   scope :visible, -> { where('applications.hidden IS NULL or applications.hidden = ?', false) }
@@ -85,7 +85,7 @@ class Application < ApplicationRecord
     Project.find_by(id: application_data['project2_id'])
   end
 
-  def ensure_flags_unique
+  def remove_duplicate_flags
     flags.uniq!
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -85,6 +85,8 @@ class Application < ApplicationRecord
     Project.find_by(id: application_data['project2_id'])
   end
 
+  private
+
   def remove_duplicate_flags
     flags.uniq!
   end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe Application, type: :model do
       subject.send(:"#{flag}=", '0')
       expect(subject.flags).not_to include(flag)
     end
+
+    it 'ensures flags are unique' do
+      flag = flags.sample.to_s
+      subject.flags = [flag, flag]
+      subject.save!
+      expect(subject.flags).to contain_exactly(flag)
+    end
   end
 
   describe 'proxy methods' do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -79,8 +79,7 @@ RSpec.describe Application, type: :model do
     it 'ensures flags are unique' do
       flag = flags.sample.to_s
       subject.flags = [flag, flag]
-      subject.save!
-      expect(subject.flags).to contain_exactly(flag)
+      expect { subject.validate }.to change(subject, :flags).from([flag, flag]).to([flag])
     end
   end
 


### PR DESCRIPTION
Related issue https://github.com/rails-girls-summer-of-code/selection_process/issues/58

This runs a pre-validation hook on applications to ensure that the flags are unique.

The reason I went with `before_validation` is as described in the [Rails docs](http://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html), that this is the step where attributes should be adapted.
