### PR TITLE
FIX codeclimate.yml gone wrong in previous PR

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,15 +2,3 @@ version: "2"
 plugins:
   rubocop:
     enabled: true
-exclude_patterns:
-- "config/"
-- "db/"
-- "dist/"
-- "features/"
-- "**/node_modules/"
-- "script/"
-- "**/spec/"
-- "**/test/"
-- "**/tests/"
-- "**/vendor/"
-- "**/*.d.ts"

--- a/app/.codeclimate.yml
+++ b/app/.codeclimate.yml
@@ -1,4 +1,0 @@
-version: "2"
-plugins:
-  rubocop:
-    enabled: true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   after_action :store_location

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   after_action :store_location


### PR DESCRIPTION
Related PR #883
In the previous PR, I added 2 codeclimate.yml files; 1 in the wrong location and 1 with redundant `exclude_patterns`. 

Now, CC reports violations:
<img width="728" alt="screen shot 2018-03-11 at 23 48 56" src="https://user-images.githubusercontent.com/6314687/37259473-1baa6570-2587-11e8-97b4-263ee0357f42.png">




<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->
