### PR TITLE
Fix bug where valid mentor comments weren't shown

### DIFF
--- a/app/controllers/reviewers/applications_controller.rb
+++ b/app/controllers/reviewers/applications_controller.rb
@@ -70,7 +70,7 @@ module Reviewers
     end
 
     def mentor_comments
-      Mentor::Comment.where(commentable_id: @application.id).where('created_at > ?', Date.parse('2018.03.12'))
+      Mentor::Comment.where(commentable_id: @application.id).where('created_at >= ?', Date.parse('2018.02.28'))
     end
 
     def persist_order


### PR DESCRIPTION
Some mentor comments weren't being shown because they were younger than the cutoff date. However, since some are younger than the given date, and we [fixed the transparency notice](#959) on 28.02.2018, we can show earlier ones. 