### PR TITLE
Update comment from /mentors/applications/:id page

### DIFF
--- a/app/controllers/mentors/comments_controller.rb
+++ b/app/controllers/mentors/comments_controller.rb
@@ -7,7 +7,7 @@ module Mentors
     end
 
     def update
-      comment = mentor_comments.update(params[:id], update_params)
+      comment = mentor_comments.update(params[:mentor_comment][:commentable_id], update_params)
       redirect_to path_for(comment)
     end
 
@@ -20,7 +20,7 @@ module Mentors
     end
 
     def update_params
-      params.require(:mentor_comment).permit(:text)
+      params.require(:mentor_comment).permit(:id, :text)
     end
 
     def path_for(comment)

--- a/app/views/mentors/applications/_comment.html.slim
+++ b/app/views/mentors/applications/_comment.html.slim
@@ -1,7 +1,8 @@
 hr(id="#{dom_id comment}")
-= simple_form_for comment, url: mentors_comments_path do |f|
+= simple_form_for comment, :url => comment.new_record? ? url_for(action: 'create', controller: 'mentors/comments') :url_for(action: 'update', controller: 'mentors/comments') do |f|
   .form-inputs.clearfix
     = f.input :commentable_id, as: :hidden, value: comment.commentable_id
+    = f.input :id, as: :hidden, value: comment.id
     = f.input :text, as: :text, label: 'My Comment', input_html: { rows: 5 }, hint: 'This is a place for you to take notes for yourself about this application. Your comment is only visible to yourself as well as the selection committee and you can update and remove it as you like.'
   .form-actions
     = f.button :submit

--- a/spec/controllers/mentors/comments_controller_spec.rb
+++ b/spec/controllers/mentors/comments_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Mentors::CommentsController, type: :controller do
 
       context 'when comment exists' do
         let!(:comment) { Mentor::Comment.create(user: user, commentable_id: 1, text: 'something') }
-        let(:params)   {{ id: comment.id, mentor_comment: { text: 'something else' } }}
+        let(:params)   {{ id: comment.id, mentor_comment: { text: 'something else', commentable_id: comment.id } }}
 
         subject { put :update, params: params }
 


### PR DESCRIPTION
Related issue #960 
 - It enables a mentor to update an application comment while reviewing an application.
- It fixes bug #960 


