### PR TITLE
Issue #659: GH "Fork me" ribbon

### DIFF
--- a/app/assets/stylesheets/partials/_github-ribbon.sass
+++ b/app/assets/stylesheets/partials/_github-ribbon.sass
@@ -16,7 +16,7 @@
   text-indent: -999999px
 
   // Animations
-  @media (max-width:1400px)
+  @media (max-width:1430px)
     visibility: hidden
     opacity:  0
     -webkit-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
@@ -25,7 +25,7 @@
     -o-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
     transition: visibility 0s linear 0.2s,  opacity 0.2s linear
 
-  @media (min-width:1400px)
+  @media (min-width:1430px)
     visibility: visible
     -webkit-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
     -moz-transition: visibility 0s linear 0.2s,  opacity 0.2s linear

--- a/app/assets/stylesheets/partials/_github-ribbon.sass
+++ b/app/assets/stylesheets/partials/_github-ribbon.sass
@@ -16,7 +16,7 @@
   text-indent: -999999px
 
   // Animations
-  @media (max-width:1360px)
+  @media (max-width:1400px)
     visibility: hidden
     opacity:  0
     -webkit-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
@@ -25,7 +25,7 @@
     -o-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
     transition: visibility 0s linear 0.2s,  opacity 0.2s linear
 
-  @media (min-width:1360px)
+  @media (min-width:1400px)
     visibility: visible
     -webkit-transition: visibility 0s linear 0.2s,  opacity 0.2s linear
     -moz-transition: visibility 0s linear 0.2s,  opacity 0.2s linear

--- a/app/assets/stylesheets/partials/_github-ribbon.sass
+++ b/app/assets/stylesheets/partials/_github-ribbon.sass
@@ -37,7 +37,7 @@
   position: absolute
   display: block
   width: 15.38em
-  height: 2.2em
+  height: 1.8em
 
   top: 2.70em
   right: -3.76em
@@ -74,7 +74,7 @@
   // Set the text properties
   color: white
   font: 700 1em "Helvetica Neue", Helvetica, Arial, sans-serif
-  line-height: 2.2em
+  line-height: 1.8em
   text-decoration: none
   text-align: center
   text-indent: 0

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -17,7 +17,7 @@ html
   body class=controller.controller_name
     = render 'navigation'
 
-    a.ribbon href='//github.com/rails-girls-summer-of-code/rgsoc-teams' title='Fork me on GitHub'
+    a.ribbon href='//github.com/rails-girls-summer-of-code/rgsoc-teams' title='Fork me on GitHub' target='_blank'
 
     div#wrap
       section.container#content


### PR DESCRIPTION
Related issue #659 
Previous PR #894 with additional remarks

This PR prevents the Github "fork me" ribbon from overlapping the sign-in button.
I opted to make the ribbon a bit smaller to keep ribbon visible on the existing media breakpoints.

- Bonus: the link now opens in a new tab/window

- Note: 
When logged in, the ribbon still overlaps the profile image, however, the profile menu is fully accessible. The only thing not visible is the little dropdown arrow. Not sure if that's problematic. If yes, indeed the media breakpoint needs to be changed to 1400px.


Screenshot - not logged in - viewport size 1361px:
<img width="486" alt="gh-ribbbon-signedout" src="https://user-images.githubusercontent.com/2246045/39393495-23af2792-4ac6-11e8-8def-d61e5dbcabd7.png">

Screenshot - logged in - viewport size 1361px:
<img width="452" alt="gh-ribbbon-signedin" src="https://user-images.githubusercontent.com/2246045/39393499-2a09abe4-4ac6-11e8-81f7-8d3c7ca9e2b8.png">
