### PR TITLE
Generate dasherized Github handles on User factory

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user, aliases: [:member] do
-    github_handle { FFaker::Name.name.parameterize }
+    github_handle { FFaker::InternetSE.user_name_variant_short }
     name     { FFaker::Name.name }
     email    { FFaker::Internet.email }
     location { FFaker::Address.city }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user, aliases: [:member] do
-    github_handle { FFaker::Name.name.underscore }
+    github_handle { FFaker::Name.name.parameterize }
     name     { FFaker::Name.name }
     email    { FFaker::Internet.email }
     location { FFaker::Address.city }


### PR DESCRIPTION
This is a very small change for something I noticed when looking at some seed data: I was seeing names strings like `rodney o'keefe` in the User's `github_handle` attribute.

The change I'm proposing will create handles that are closer to what Github allows, for example: `rodney-o-keefe`.

It seems the `underscore` method will not do exactly what one might expect it to do, as is described in this issue: https://github.com/rails/rails/issues/4519

Replacing it with `parameterize` will turn something like `Becki O'Hara Zí` into `becki-o-hara-zi`, which would be a valid Github handle (it seems Github doesn't allow underscores).

There may be a reason for the original `underscore` method that I may be missing here - please let me know 🐱 