### PR TITLE
Allow infinite confirmation period

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -103,7 +103,7 @@ Devise.setup do |config|
   # able to access the website for two days without confirming his account,
   # access will be blocked just in the third day. Default is 0.days, meaning
   # the user cannot access the website without confirming his account.
-  config.allow_unconfirmed_access_for = 30.days
+  config.allow_unconfirmed_access_for = nil
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm


### PR DESCRIPTION
Related issues #869 #983 #981 #980

Relatively small, but what's worth considering here:
- All actions outside of updating the profile now require being confirmed
- The confirmation period has been set to indefinite (nil), but with the above limitation, we can only allow profile completion
- Navigating the teams app while unconfirmed offers to resend the confirmation email