### PR TITLE
Temp Fix to restrict access for unconfirmed users

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -108,7 +108,6 @@ class Ability
       cannot :create, Project if !user.confirmed?
 
       # activities
-      # can :read, :feed_entry
       can :read, :mailing if signed_in?(user)
 
       # applications

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-# See the wiki for details:
-# https://github.com/ryanb/cancan/wiki/Defining-Abilities
 
 class Ability
   include CanCan::Ability
@@ -10,102 +8,111 @@ class Ability
 
     alias_action :create, :read, :update, :destroy, to: :crud
 
-    can :crud, User, id: user.id
-    can :crud, User if user.admin?
+    can :read, User
+    can :update, User, id: user.id
     can :resend_confirmation_instruction, User, id: user.id
-    can :resend_confirmation_instruction, User if user.admin?
-
-    # visibility of email address in user profile
-    can :read_email, User, id: user.id if !user.hide_email?
-    can :read_email, User if user.admin?
-    can :read_email, User do |other_user|
-      user.confirmed? && (supervises?(other_user, user) || !other_user.hide_email?)
-    end
-
-    can :crud, Team do |team|
-      user.admin? || signed_in?(user) && team.new_record? || on_team?(user, team)
-    end
-
-    can :update_conference_preferences, Team do |team|
-      team.accepted? && team.students.include?(user)
-    end
-
-    can :see_offered_conferences, Team do |team|
-      user.admin? || team.students.include?(user) || team.supervisors.include?(user)
-    end
-
-    can :accept_or_reject_conference_offer, Team do |team|
-      team.students.include?(user)
-    end
-
-    cannot :create, Team do |team|
-      on_team_for_season?(user, team.season) || !user.confirmed?
-    end
-
-    can :join, Team do |team|
-      team.helpdesk_team? and signed_in?(user) and user.confirmed? and not on_team?(user, team)
-    end
-
-    can :crud, Role do |role|
-      user.admin? || on_team?(user, role.team)
-    end
-
-    can :crud, Source do |repo|
-      user.admin? || on_team?(user, repo.team)
-    end
-
-    can :supervise, Team do |team|
-      user.roles.organizer.any? || team.supervisors.include?(user)
-    end
-
-    can :crud, ConferencePreference do |preference|
-      user.admin? || (preference.team.students.include? user)
-    end
-
-    can :crud, Conference if user.admin? || user.current_student?
-
-    # todo add mailing controller and view for users in their namespace, where applicable
-    can :read, Mailing do |mailing|
-      mailing.recipient? user
-    end
-
-    can :crud, :comments if user.admin?
-    can :read, :users_info if user.admin? || user.supervisor?
-
-    # projects
-    can :crud, Project do |project|
-      user.admin? ||
-        (user.confirmed? && user == project.submitter)
-    end
-    can :use_as_template, Project do |project|
-      user == project.submitter && !project.season&.current?
-    end
-
-    can :create, Project if user.confirmed?
-    cannot :create, Project if !user.confirmed?
-
-    # activities
+    can :read, Team
+    can :read, Project
     can :read, :feed_entry
-    can :read, :mailing if signed_in?(user)
 
-    # applications
-    can :create, :application_draft if user.student? && user.application_drafts.in_current_season.none?
+
+    def signed_in?(user)
+      user.persisted?
+    end
+
+    def on_team?(user, team)
+      user.teams.include?(team)
+    end
+
+    def on_team_for_season?(user, season)
+      season && user.roles.student.joins(:team).pluck(:season_id).include?(season.id)
+    end
+
+    def supervises?(user, supervisor)
+      user.teams.in_current_season.any? { |team| team.supervisors.include?(supervisor) }
+    end
+
+    if user.confirmed?
+
+      can :crud, User, id: user.id
+      can :crud, User if user.admin?
+      can :resend_confirmation_instruction, User if user.admin?
+
+      # visibility of email address in user profile
+      can :read_email, User, id: user.id if !user.hide_email?
+      can :read_email, User if user.admin?
+      can :read_email, User do |other_user|
+        user.confirmed? && (supervises?(other_user, user) || !other_user.hide_email?)
+      end
+
+      can :crud, Team do |team|
+        user.admin? || signed_in?(user) && team.new_record? || on_team?(user, team)
+      end
+
+      can :update_conference_preferences, Team do |team|
+        team.accepted? && team.students.include?(user)
+      end
+
+      can :see_offered_conferences, Team do |team|
+        user.admin? || team.students.include?(user) || team.supervisors.include?(user)
+      end
+
+      can :accept_or_reject_conference_offer, Team do |team|
+        team.students.include?(user)
+      end
+
+      cannot :create, Team do |team|
+        on_team_for_season?(user, team.season) || !user.confirmed?
+      end
+
+      can :join, Team do |team|
+        team.helpdesk_team? and signed_in?(user) and user.confirmed? and not on_team?(user, team)
+      end
+
+      can :crud, Role do |role|
+        user.admin? || on_team?(user, role.team)
+      end
+
+      can :crud, Source do |repo|
+        user.admin? || on_team?(user, repo.team)
+      end
+
+      can :supervise, Team do |team|
+        user.roles.organizer.any? || team.supervisors.include?(user)
+      end
+
+      can :crud, ConferencePreference do |preference|
+        user.admin? || (preference.team.students.include? user)
+      end
+
+      can :crud, Conference if user.admin? || user.current_student?
+
+      # todo add mailing controller and view for users in their namespace, where applicable
+      can :read, Mailing do |mailing|
+        mailing.recipient? user
+      end
+
+      can :crud, :comments if user.admin?
+      can :read, :users_info if user.admin? || user.supervisor?
+
+      # projects
+      can :crud, Project do |project|
+        user.admin? ||
+          (user.confirmed? && user == project.submitter)
+      end
+      can :use_as_template, Project do |project|
+        user == project.submitter && !project.season&.current?
+      end
+
+      can :create, Project if user.confirmed?
+      cannot :create, Project if !user.confirmed?
+
+      # activities
+      # can :read, :feed_entry
+      can :read, :mailing if signed_in?(user)
+
+      # applications
+      can :create, :application_draft if user.student? && user.application_drafts.in_current_season.none?
+    end
   end
-
-  def signed_in?(user)
-    user.persisted?
-  end
-
-  def on_team?(user, team)
-    user.teams.include?(team)
-  end
-
-  def on_team_for_season?(user, season)
-    season && user.roles.student.joins(:team).pluck(:season_id).include?(season.id)
-  end
-
-  def supervises?(user, supervisor)
-    user.teams.in_current_season.any? { |team| team.supervisors.include?(supervisor) }
-  end
-
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -15,23 +15,6 @@ class Ability
     can :read, Project
     can :read, :feed_entry
 
-
-    def signed_in?(user)
-      user.persisted?
-    end
-
-    def on_team?(user, team)
-      user.teams.include?(team)
-    end
-
-    def on_team_for_season?(user, season)
-      season && user.roles.student.joins(:team).pluck(:season_id).include?(season.id)
-    end
-
-    def supervises?(user, supervisor)
-      user.teams.in_current_season.any? { |team| team.supervisors.include?(supervisor) }
-    end
-
     if user.confirmed?
 
       can :crud, User, id: user.id
@@ -113,5 +96,21 @@ class Ability
       # applications
       can :create, :application_draft if user.student? && user.application_drafts.in_current_season.none?
     end
+  end
+
+  def signed_in?(user)
+    user.persisted?
+  end
+
+  def on_team?(user, team)
+    user.teams.include?(team)
+  end
+
+  def on_team_for_season?(user, season)
+    season && user.roles.student.joins(:team).pluck(:season_id).include?(season.id)
+  end
+
+  def supervises?(user, supervisor)
+    user.teams.in_current_season.any? { |team| team.supervisors.include?(supervisor) }
   end
 end

--- a/spec/controllers/mailings_controller_spec.rb
+++ b/spec/controllers/mailings_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MailingsController, type: :controller do
 
   describe 'GET index' do
     context 'with user logged in' do
-      include_context 'with user logged in'
+      include_context 'with confirmed user logged in'
 
       it 'renders the index' do
         get :index

--- a/spec/controllers/organizers/teams_controller_spec.rb
+++ b/spec/controllers/organizers/teams_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Organizers::TeamsController, type: :controller do
   let(:valid_attributes) { build(:team).attributes.merge(roles_attributes: [{ name: 'coach', github_handle: 'tobias' }]) }
 
   before do
+    user.confirm
     user.roles.create(name: 'student', team: team)
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -84,5 +84,9 @@ FactoryBot.define do
         create(:reviewer_role, user: user)
       end
     end
+
+    trait :unconfirmed do
+      confirmed_at { nil }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user, aliases: [:member] do
-    github_handle { FFaker::InternetSE.user_name_variant_short }
+    github_handle { FFaker::InternetSE.unique.user_name_variant_short }
     name     { FFaker::Name.name }
     email    { FFaker::Internet.email }
     location { FFaker::Address.city }

--- a/spec/features/users/guest_users_spec.rb
+++ b/spec/features/users/guest_users_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'Guest Users', type: :feature do
+  let!(:user)          { create(:user) } # not the guest user; don't sign_in user
+  let!(:project)       { create(:project, :in_current_season, :accepted, submitter: user) }
+  let!(:team1)         { create(:team, name: 'Cheesy forever') }
+  let!(:activity)     { create(:status_update, :published, team: team1) }
+  let(:out_of_season) { Season.current.starts_at - 1.week }
+  let(:summer_season) { Season.current.starts_at + 1.week }
+
+  context "when visiting public pages" do
+
+    context 'all year' do
+      before { Timecop.travel(out_of_season) }
+      after  { Timecop.return }
+
+      it 'has restricted access to Activities page' do
+        visit root_path
+        expect(page).to have_css('h1', text: 'Activities')
+        find('.title', match: :smart).click
+        expect(page).to have_content(activity.title)
+        expect(page).to have_content('You must be logged in to add a comment.')
+      end
+
+      it 'has restricted access to Community page' do
+        visit community_path
+        expect(page).to have_css('h1', text: 'Community')
+        find_link(user.name, match: :first).click
+        expect(page).to have_content("About me")
+        expect(page).to have_link("All participants")
+        expect(page).not_to have_link("Edit") # check
+      end
+
+      it 'has access to Projects page' do
+        visit projects_path
+        expect(page).to have_css('h1', text: 'Projects') # can be empty table
+      end
+
+      it 'has a menu with public links' do
+        visit root_path
+        expect(page).to have_link("Activities")
+        find_link("Summer of Code").click
+        expect(page).to have_link("Teams")
+        expect(page).to have_link("Community")
+        expect(page).to have_link("Help")
+      end
+
+      it 'has access to sign in link' do
+        visit root_path
+        expect(page).to have_link('Sign in')
+        # story continues in sign_in_confirmed_user || sign_in_unconfirmed_user || sign_in_fail
+      end
+    end
+
+    context 'in season' do
+      before do
+        Timecop.travel(summer_season)
+        allow_any_instance_of(Project).to receive(:selected).and_return(:project)
+      end
+      after { Timecop.return }
+
+      it 'has access to Projects index and show' do
+        pending 'Stub needs updating; project not visible on page'
+        visit projects_path
+        expect(page).to have_css('h1', text: 'Projects')
+        find_link(project.name, match: :smart).click
+        expect(page).to have_content project.description
+        expect(page).not_to have_link("Edit")
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe Ability, type: :model do
 
       describe 'she/he is not allowed to CRUD on someone else account' do
         let(:other_user) { create(:user) }
-        it { expect(ability).not_to be_able_to(:show, other_user) }
+
+        it { expect(ability).to be_able_to(:show, other_user) }
+        it { expect(ability).not_to be_able_to(:update, other_user) }
       end
 
 
@@ -69,6 +71,7 @@ RSpec.describe Ability, type: :model do
               allow(user).to receive(:confirmed?).and_return(false)
             end
             it 'allows to see not hidden email address' do
+              pending "Fails. Unconfirmed user has no access"
               other_user.hide_email = false
               expect(ability).to be_able_to(:read_email, other_user)
             end
@@ -80,6 +83,7 @@ RSpec.describe Ability, type: :model do
               allow(user).to receive(:confirmed?).and_return(true)
             end
             it 'allows to see not hidden email address' do
+              # pending "Fails. Not sure if this is the behaviour we still want?"
               other_user.hide_email = false
               expect(ability).to be_able_to(:read_email, other_user)
             end
@@ -383,7 +387,7 @@ RSpec.describe Ability, type: :model do
       end
 
       context 'when using a project as a template' do
-        let(:user) { build :user }
+        let(:user) { create :user }
 
         context 'for the original project submitter' do
           let(:project) { build :project, submitter: user }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe Ability, type: :model do
               allow(user).to receive(:confirmed?).and_return(true)
             end
             it 'allows to see not hidden email address' do
-              # pending "Fails. Not sure if this is the behaviour we still want?"
               other_user.hide_email = false
               expect(ability).to be_able_to(:read_email, other_user)
             end
@@ -96,7 +95,6 @@ RSpec.describe Ability, type: :model do
             end
           end
         end
-
       end
 
       describe 'who is disallowed to see email address in user profile' do
@@ -131,9 +129,7 @@ RSpec.describe Ability, type: :model do
             end
           end
         end
-
       end
-
 
       context 'resend_confirmation_instruction' do
         let(:other_user) { create(:user) }
@@ -171,7 +167,6 @@ RSpec.describe Ability, type: :model do
           let!(:other_user) { create(:user)}
           let!(:conference_preference) { create(:conference_preference, team: team)}
           it { expect(ability).not_to be_able_to(:crud, other_user) }
-
         end
       end
 
@@ -318,6 +313,7 @@ RSpec.describe Ability, type: :model do
             end
           end
         end
+
         context 'when user guest (not persisted)' do
           let(:user) { build :user }
 
@@ -369,7 +365,6 @@ RSpec.describe Ability, type: :model do
           user.save
           expect(subject).not_to be_able_to :crud, Project.new(submitter: user)
         end
-
       end
 
       context 'create' do
@@ -383,7 +378,6 @@ RSpec.describe Ability, type: :model do
           user.save
           expect(subject).not_to be_able_to :create, Project.new
         end
-
       end
 
       context 'when using a project as a template' do

--- a/spec/support/shared_contexts/with_confirmed_user_logged_in.rb
+++ b/spec/support/shared_contexts/with_confirmed_user_logged_in.rb
@@ -1,0 +1,8 @@
+RSpec.shared_context 'with confirmed user logged in' do
+  let(:current_user) { create(:user) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+    allow(current_user).to receive(:confirmed?).and_return(true)
+  end
+end


### PR DESCRIPTION
Related issue #991 (Break Down step 2)

We need to restrict access for unconfirmed users but let them update their email address nevertheless. 
- Changed Ability class to catch unconfirmed users.
- Added a 'confirmed user' context for controller tests
- Updated the controller tests that failed; left others alone
- Extra: added first feature test, for guest user. 
Note: I would appreciate help with the feature tests.  This is a first attempt.
 
<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->
Follow up issues:
- [ ] check if we need the `can :read, :feed_entry`, or else remove its `can?` check in views. (Public activities shouldn't be restricted at all.)
- [ ] check controller tests and use either 'confirmed user' or 'unconfirmed user' contexts
- [ ] Fix pending specs and todo's in ability_spec
