### PR TITLE
Fix setting the @user in UsersController

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class UsersController < ApplicationController
-  before_action :set_user, only: [:show, :edit, :update, :destroy, :impersonate]
-
-  load_and_authorize_resource except: [:index, :show, :impersonate, :stop_impersonating]
+  load_and_authorize_resource except: [:impersonate, :stop_impersonating]
 
   def show
   end
@@ -60,6 +58,7 @@ class UsersController < ApplicationController
   end
 
   def impersonate
+    set_user
     impersonate_user(@user)
     redirect_to community_path, notice: "Now impersonating #{@user.name}. You can find the link to stop impersonation on the user menu."
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user, aliases: [:member] do
-    github_handle { FFaker::InternetSE.user_name_variant_short }
+    sequence(:github_handle) { FFaker::InternetSE.user_name_variant_short }
     name     { FFaker::Name.name }
     email    { FFaker::Internet.email }
     location { FFaker::Address.city }


### PR DESCRIPTION
Related issue: User Registrations Overhaul 
 #991 .5 in Overhaul Break Down
Branch off of #992 

This is an example for the authorisation issues mentioned in # 991 5). 
Setting the @user happened in two before_actions:  both in Cancancan's `load_resource` method and in  `set_user` . The two before_actions were confusing, because some crud actions were called in both of them; so: sometimes with authorization, sometimes without. That caused some weird behaviour in the authorisations.  (Possibly the reason for some of the extra 'signed_in` checks in Ability.)
-  Now the @user is set only once in each controller action. 
-  Specs were flaky, because of a GitHub user name validation error in the Factory. Changed that to a sequence. 

@pgaspar
When logged in as an unconfirmed user, see the difference between the behaviour on the Teams pages compared to the new behaviour on the Users pages. 
This is what I meant here: https://github.com/rails-girls-summer-of-code/rgsoc-teams/pull/989#issuecomment-388581753

- [ ] Follow up: Find all the other controllers that have the same ambiguity and solve them.  
<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->
