### PR TITLE
Revisit associations pt. 1

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -9,19 +9,9 @@ class Activity < ApplicationRecord
 
   delegate :students, to: :team
 
-  class << self
-    def with_kind(kind)
-      where(kind: kind)
-    end
-
-    def by_team(team_id)
-      where(team_id: team_id)
-    end
-
-    def ordered
-      order('published_at DESC, id DESC')
-    end
-  end
+  scope :with_kind, ->(kind) { where(kind: kind) }
+  scope :by_team, ->(team_id) { where(team_id: team_id) }
+  scope :ordered, -> { order('published_at DESC, id DESC') }
 
   def to_param
     "#{id}-#{title.to_s.parameterize}"

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -81,7 +81,7 @@ class ApplicationDraft < ApplicationRecord
   belongs_to :updater, class_name: 'User'
   belongs_to :project1, class_name: 'Project'
   belongs_to :project2, class_name: 'Project'
-  has_one    :application
+  has_one :application
 
   scope :in_current_season, -> { where(season: Season.current) }
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 class Comment < ApplicationRecord
   belongs_to :user
-  belongs_to :project
   belongs_to :commentable, polymorphic: true
 
   scope :recent, -> { order('created_at DESC').limit(3) }
+  scope :ordered, -> { order('created_at DESC, id DESC') }
 
   before_save :set_checked
   after_commit :notify!
@@ -13,24 +13,15 @@ class Comment < ApplicationRecord
     commentable.is_a? Application
   end
 
-  class << self
-    def ordered
-      order('created_at DESC, id DESC')
-    end
-  end
-
   private
 
   def notify!
-    case commentable
-    when Project
-      ProjectMailer.comment(project, self).deliver_later
-    end
+    return unless commentable.is_a?(Project)
+    ProjectMailer.comment(commentable, self).deliver_later
   end
 
   def set_checked
-    return unless commentable.is_a? Team
-    commentable.checked = user
-    commentable.save
+    return unless commentable.is_a?(Team)
+    commentable.update(checked: user)
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -29,7 +29,7 @@ class Team < ApplicationRecord
   end
   has_many :sources, dependent: :destroy
   has_many :activities, dependent: :destroy
-  has_many :comments, as: :commentable
+  has_many :comments, as: :commentable, dependent: :destroy
   has_many :status_updates, -> { where(kind: 'status_update') }, class_name: 'Activity'
   has_many :conference_attendances, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,13 +7,13 @@ class User < ApplicationRecord
   URL_PREFIX_PATTERN = /\A(http|https).*\z/i
 
   ORDERS = {
-    name:           "LOWER(users.name)",
-    team:           "teams.name",
-    github:         "users.github_handle",
-    irc:            "COALESCE(users.irc_handle, '')",
-    location:       "users.location",
-    interested_in:  "users.interested_in",
-    country:        "users.country",
+    name:          'LOWER(users.name)',
+    team:          'teams.name',
+    github:        'users.github_handle',
+    irc:           'COALESCE(users.irc_handle, '')',
+    location:      'users.location',
+    interested_in: 'users.interested_in',
+    country:       'users.country',
   }
 
   INTERESTS = {

--- a/db/migrate/20180514195656_destroy_orphaned_activities.rb
+++ b/db/migrate/20180514195656_destroy_orphaned_activities.rb
@@ -1,0 +1,5 @@
+class DestroyOrphanedActivities < ActiveRecord::Migration[5.1]
+  def up
+    execute 'DELETE FROM activities WHERE team_id IS NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180307150111) do
+ActiveRecord::Schema.define(version: 20180514195656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -3,12 +3,12 @@ FactoryBot.define do
     user
     text { FFaker::CheesyLingo.paragraph }
 
-    factory :team_comment do
-      association :commentable, factory: :team
+    trait :for_application do
+      association :commentable, factory: :application
     end
 
-    factory :application_comment do
-      association :commentable, factory: :application
+    trait :for_team do
+      association :commentable, factory: :team
     end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Activity, type: :model do
-  it { is_expected.to belong_to(:team) }
+  describe 'associations', :wip do
+    it { is_expected.to belong_to(:team) }
+    it { is_expected.to have_many(:comments).dependent(:destroy) }
+
+    it { is_expected.to delegate_method(:students).to(:team) }
+  end
 
   context 'with validations' do
     context 'for kind "status_update"' do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Activity, type: :model do
-  describe 'associations', :wip do
+  describe 'associations' do
     it { is_expected.to belong_to(:team) }
     it { is_expected.to have_many(:comments).dependent(:destroy) }
 
     it { is_expected.to delegate_method(:students).to(:team) }
   end
 
-  context 'with validations' do
+  describe 'validations' do
     context 'for kind "status_update"' do
       subject { described_class.new kind: 'status_update' }
 

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe ApplicationDraft, type: :model do
   it_behaves_like 'HasSeason'
 
   describe 'associations' do
+    it { is_expected.to belong_to(:team) }
     it { is_expected.to belong_to(:updater).class_name('User') }
     it { is_expected.to belong_to(:project1).class_name('Project') }
     it { is_expected.to belong_to(:project2).class_name('Project') }
+    it { is_expected.to have_one(:application) }
   end
 
   describe 'validations' do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Application, type: :model do
     it { is_expected.to belong_to(:team).inverse_of(:applications).counter_cache(true) }
     it { is_expected.to belong_to(:project) }
     it { is_expected.to belong_to(:application_draft) }
-    it { is_expected.to belong_to(:application_draft) }
     it { is_expected.to have_many(:comments).dependent(:destroy).order(:created_at) }
   end
 

--- a/spec/models/mentor/comment_spec.rb
+++ b/spec/models/mentor/comment_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Mentor::Comment, type: :model do
 
     it 'has a default scope to include only comments on Mentor::Applications' do
       create(:comment)
-      create(:team_comment)
-      create(:application_comment)
+      create(:comment, :for_team)
+      create(:comment, :for_application)
       comment = described_class.create
 
       expect(described_class.all).to contain_exactly comment

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Team, type: :model do
 
     it { is_expected.to have_many(:activities).dependent(:destroy) }
     it { is_expected.to have_many(:sources).dependent(:destroy) }
-    it { is_expected.to have_many(:comments) }
+    it { is_expected.to have_many(:comments).dependent(:destroy) }
 
     it { is_expected.to have_many(:roles).dependent(:destroy).inverse_of(:team) }
     it { is_expected.to have_many(:members).through(:roles).source(:user) }


### PR DESCRIPTION
As a side-effect of the whole [GDPR party](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) we want to have a working _chain of associations_ for a user: deleting a user should a) be possible and b) also remove / unpersonalize all their associated data.

For starters I'm having a look at the current setup and document it in the specs. This PR looks at the first few models, documents their associations in the specs and of course sneaks in some drive-by-fixes here and there 🚜 

As a first **effect** we can also already delete `Activities` where the `team` no longer exists - we have a few of them in the production DB.