### PR TITLE
Spring cleaning users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,13 +11,6 @@ class ApplicationController < ActionController::Base
     session[:redirect_to] = redirect_to if redirect_to.present?
   end
 
-  # workaround fix for cancan on rails4 - https://github.com/ryanb/cancan/issues/835
-  before_action do
-    resource = controller_path.singularize.gsub('/', '_').to_sym
-    method = "#{resource}_params"
-    params[resource] &&= send(method) if respond_to?(method, true)
-  end
-
   before_action :set_timezone
 
   # Allow users to impersonate other uses in a non-production environment.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class UsersController < ApplicationController
-  before_action :set_user, only: [:show, :edit, :update, :destroy, :impersonate]
+  before_action :set_user, only: [:show, :edit, :update, :destroy, :impersonate, :resend_confirmation_instruction]
 
-  load_and_authorize_resource except: [:index, :show, :impersonate, :stop_impersonating]
+  authorize_resource except: [:index, :show, :impersonate, :stop_impersonating]
 
   def show
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy, :impersonate, :resend_confirmation_instruction]
 
-  authorize_resource except: [:index, :show, :impersonate, :stop_impersonating]
+  authorize_resource except: [:impersonate, :stop_impersonating]
 
   def show
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 class UsersController < ApplicationController
-  before_action :set_user, only: [:show, :edit, :update, :destroy, :impersonate, :resend_confirmation_instruction]
 
-  authorize_resource except: [:impersonate, :stop_impersonating]
+  load_and_authorize_resource except: [:impersonate, :stop_impersonating]
 
   def show
   end
@@ -60,6 +59,7 @@ class UsersController < ApplicationController
   end
 
   def impersonate
+    set_user
     impersonate_user(@user)
     redirect_to community_path, notice: "Now impersonating #{@user.name}. You can find the link to stop impersonation on the user menu."
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,13 +16,13 @@ class Ability
     # unconfirmed, logged in user
     can [:update, :destroy], User, id: user.id
     can :resend_confirmation_instruction, User, id: user.id
-    can :read_email, User, hide_email: false
 
     return unless user.confirmed?
 
     # confirmed user
     can [:update, :destroy], User, id: user.id
     can :resend_confirmation_instruction, User, id: user.id
+    cannot :read_email, User, hide_email: true
     can :create, Project
     can [:join, :create], Team
     can :index, Mailing

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,7 +22,7 @@ class Ability
     # confirmed user
     can [:update, :destroy], User, id: user.id
     can :resend_confirmation_instruction, User, id: user.id
-    cannot :read_email, User, hide_email: true
+    can :read_email, User, hide_email: false
     can :create, Project
     can [:join, :create], Team
     can :index, Mailing
@@ -71,7 +71,7 @@ class Ability
       user.confirmed? && (supervises?(other_user, user) || !other_user.hide_email?)
     end
     can :read, :users_info if user.admin? || user.supervisor?
-    #
+
 
     can :update_conference_preferences, Team do |team|
       team.accepted? && team.students.include?(user)

--- a/app/views/application/_nav_signed_in.html.slim
+++ b/app/views/application/_nav_signed_in.html.slim
@@ -1,4 +1,4 @@
-li.dropdown
+li.dropdown id='user-links'
   a.dropdown-toggle-img.hidden-xs data-toggle='dropdown'
     = avatar_url(current_user, size: 45)
     span.caret

--- a/app/views/community/index.html.slim
+++ b/app/views/community/index.html.slim
@@ -16,7 +16,8 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
       th
       th = sortable :name
       th = sortable :interested_in
-      th = 'Email' if current_user&.confirmed?
+      - if current_user&.confirmed?
+        th = 'Email'
       th = sortable :github
       th = sortable :team
       th = sortable :country
@@ -30,7 +31,8 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
         td.image = avatar_url(user, size: 40)
         td = link_to user.name_or_handle, user
         td = user.interested_in.map { |key| User::INTERESTS[key].presence }.compact.join(', ')
-        td = mail_to user.email if can?(:read_email, user)
+        - if current_user&.confirmed?
+          td = mail_to user.email if can?(:read_email, user)
         td = link_to user.github_handle, "https://github.com/#{user.github_handle}"
         td = link_to_user_roles(user)
         td = user.country

--- a/app/views/community/index.html.slim
+++ b/app/views/community/index.html.slim
@@ -16,8 +16,7 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
       th
       th = sortable :name
       th = sortable :interested_in
-      - if current_user&.confirmed?
-        th Email
+      th = 'Email' if current_user&.confirmed?
       th = sortable :github
       th = sortable :team
       th = sortable :country

--- a/app/views/community/index.html.slim
+++ b/app/views/community/index.html.slim
@@ -31,7 +31,7 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
         td.image = avatar_url(user, size: 40)
         td = link_to user.name_or_handle, user
         td = user.interested_in.map { |key| User::INTERESTS[key].presence }.compact.join(', ')
-        td = mail_to user.email if can?(:read, user.email)
+        td = mail_to user.email if can?(:read_email, user)
         td = link_to user.github_handle, "https://github.com/#{user.github_handle}"
         td = link_to_user_roles(user)
         td = user.country

--- a/app/views/community/index.html.slim
+++ b/app/views/community/index.html.slim
@@ -16,7 +16,7 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
       th
       th = sortable :name
       th = sortable :interested_in
-      - if signed_in?
+      - if current_user&.confirmed?
         th Email
       th = sortable :github
       th = sortable :team
@@ -31,8 +31,7 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
         td.image = avatar_url(user, size: 40)
         td = link_to user.name_or_handle, user
         td = user.interested_in.map { |key| User::INTERESTS[key].presence }.compact.join(', ')
-        - if signed_in?
-          td = mail_to user.email unless user.hide_email?
+        td = mail_to user.email if can?(:read, user.email)
         td = link_to user.github_handle, "https://github.com/#{user.github_handle}"
         td = link_to_user_roles(user)
         td = user.country

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -40,7 +40,7 @@
   = f.input :homepage, as: :url, wrapper_html: { class: 'col-md-6' }
   = f.input :country, required: true, as: :country, label: "Country", prompt: "Select your country", wrapper_html: { class: 'col-md-6' }
   = f.input :timezone, as: :select, collection: list_all_timezones, label: "Timezone", prompt: "Select your timezone", wrapper_html: { class: 'col-md-6' }
-  = f.input :location, wrapper_html: { class: 'col-md-6' }
+  = f.input :location, required: true, wrapper_html: { class: 'col-md-6' }
   div.clearfix
 
   = f.input :hide_email, label: 'Never show my email address',  hint: 'Only signed-in users will see your email address anyway. People will have trouble contacting you.'

--- a/db/migrate/20180524190818_destroy_non_existing_git_hub_users.rb
+++ b/db/migrate/20180524190818_destroy_non_existing_git_hub_users.rb
@@ -1,0 +1,5 @@
+class DestroyNonExistingGitHubUsers < ActiveRecord::Migration[5.1]
+  def up
+    execute 'DELETE FROM users WHERE github_id IS NULL'
+  end
+end

--- a/db/migrate/20180524190818_destroy_non_existing_git_hub_users.rb
+++ b/db/migrate/20180524190818_destroy_non_existing_git_hub_users.rb
@@ -1,11 +1,8 @@
 class DestroyNonExistingGitHubUsers < ActiveRecord::Migration[5.1]
   def up
     unless ENV['RAILS_ENV'] == 'development'
-      User.find_each do |user|
-        if user.github_id == nil
-          puts "removing user #{user.id} from database"
-          user.destroy
-        end
+      User.where(github_id: nil).destroy_all.each do |user|
+        puts "removed user #{user.id} from database"
       end
     end
   end

--- a/db/migrate/20180524190818_destroy_non_existing_git_hub_users.rb
+++ b/db/migrate/20180524190818_destroy_non_existing_git_hub_users.rb
@@ -1,5 +1,12 @@
 class DestroyNonExistingGitHubUsers < ActiveRecord::Migration[5.1]
   def up
-    execute 'DELETE FROM users WHERE github_id IS NULL'
+    unless ENV['RAILS_ENV'] == 'development'
+      User.find_each do |user|
+        if user.github_id == nil
+          puts "removing user #{user.id} from database"
+          user.destroy
+        end
+      end
+    end
   end
 end

--- a/db/migrate/20180524190818_destroy_non_existing_git_hub_users.rb
+++ b/db/migrate/20180524190818_destroy_non_existing_git_hub_users.rb
@@ -1,6 +1,14 @@
 class DestroyNonExistingGitHubUsers < ActiveRecord::Migration[5.1]
+
   def up
-    unless ENV['RAILS_ENV'] == 'development'
+    return if ENV['RAILS_ENV'] == 'test'
+    if ENV['RAILS_ENV'] == 'development'
+      puts "Updating users with github_id ...."
+      users = User.all.select { |user| user.github_id.nil? }
+      users.each_with_index do |user, index|
+        user.update!(github_id: index + 10)
+      end
+    else
       User.where(github_id: nil).destroy_all.each do |user|
         puts "removed user #{user.id} from database"
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180514195656) do
+ActiveRecord::Schema.define(version: 20180524190818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/community_controller_spec.rb
+++ b/spec/controllers/community_controller_spec.rb
@@ -35,8 +35,10 @@ RSpec.describe CommunityController, type: :controller do
         user = create(:student, hide_email: false)
         user_opted_out = create(:user, hide_email: true)
         get :index
-        expect(response.body).to include user.email
-        expect(response.body).not_to include user_opted_out.email
+        # expect(response.body).to include user.email
+        # This expectation ^ fails, but should this be tested in a controller test in
+        # the first place?
+        expect(response.body).not_to include user_opted_out.email # false negative; also passes with hide_email: false
       end
 
       it 'shows user impersonation links when in development' do

--- a/spec/controllers/community_controller_spec.rb
+++ b/spec/controllers/community_controller_spec.rb
@@ -35,9 +35,8 @@ RSpec.describe CommunityController, type: :controller do
         user = create(:student, hide_email: false)
         user_opted_out = create(:user, hide_email: true)
         get :index
-        # expect(response.body).to include user.email
-        # This expectation ^ fails, but should this be tested in a controller test in
-        # the first place?
+        expect(response.body).to include user.email
+        # Should this be tested in a controller test?
         expect(response.body).not_to include user_opted_out.email # false negative; also passes with hide_email: false
       end
 

--- a/spec/controllers/community_controller_spec.rb
+++ b/spec/controllers/community_controller_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe CommunityController, type: :controller do
         user_opted_out = create(:user, hide_email: true)
         get :index
         expect(response.body).to include user.email
-        # Should this be tested in a controller test?
         expect(response.body).not_to include user_opted_out.email
       end
 

--- a/spec/controllers/community_controller_spec.rb
+++ b/spec/controllers/community_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CommunityController, type: :controller do
         get :index
         expect(response.body).to include user.email
         # Should this be tested in a controller test?
-        expect(response.body).not_to include user_opted_out.email # false negative; also passes with hide_email: false
+        expect(response.body).not_to include user_opted_out.email
       end
 
       it 'shows user impersonation links when in development' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:github_id, 123)
     name     { FFaker::Name.name }
     email    { FFaker::Internet.email }
+    hide_email false
     location { FFaker::Address.city }
     country  { FFaker::Address.country }
     bio      { FFaker::Lorem.paragraph }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :user, aliases: [:member] do
     github_handle { FFaker::InternetSE.unique.user_name_variant_short }
+    sequence(:github_id, 123)
     name     { FFaker::Name.name }
     email    { FFaker::Internet.email }
     location { FFaker::Address.city }

--- a/spec/features/users/guest_user_spec.rb
+++ b/spec/features/users/guest_user_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Guest User', type: :feature do
 
   let!(:activity)      { create(:status_update, :published, team: team1) }
-  let!(:other_user)    { create(:user) }
+  let(:other_user)    { create(:user, hide_email: false) }
   let!(:project)       { create(:project, :in_current_season, :accepted, submitter: other_user) }
   let!(:team1)         { create(:team, :in_current_season, name: 'Cheesy forever', project_name: project.name, project_id: project.id) }
   let!(:out_of_season)  { Season.current.starts_at - 1.week }
@@ -23,9 +23,10 @@ RSpec.describe 'Guest User', type: :feature do
         expect(page).to have_content('You must be logged in to add a comment.')
       end
 
-      it 'can view Community and User' do
+      it 'can view Community and User (no email addresses)' do
         visit community_path
         expect(page).to have_css('h1', text: 'Community')
+        expect(page).not_to have_content(other_user.email)
         find_link(other_user.name, match: :smart).click
         expect(page).to have_content("About me")
         expect(page).to have_link("All participants")

--- a/spec/features/users/guest_user_spec.rb
+++ b/spec/features/users/guest_user_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Guest User', type: :feature do
 
   let!(:activity) { create(:status_update, :published, team: team1) }
-  let(:other_user) { create(:user, hide_email: false) }
+  let(:other_user) { create(:user) }
   let!(:project)       { create(:project, :in_current_season, :accepted, submitter: other_user) }
   let!(:team1)         { create(:team, :in_current_season, name: 'Cheesy forever', project_name: project.name, project_id: project.id) }
   let!(:out_of_season)  { Season.current.starts_at - 1.week }

--- a/spec/features/users/guest_user_spec.rb
+++ b/spec/features/users/guest_user_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Guest User', type: :feature do
 
-  let!(:activity)      { create(:status_update, :published, team: team1) }
-  let(:other_user)    { create(:user, hide_email: false) }
+  let!(:activity) { create(:status_update, :published, team: team1) }
+  let(:other_user) { create(:user, hide_email: false) }
   let!(:project)       { create(:project, :in_current_season, :accepted, submitter: other_user) }
   let!(:team1)         { create(:team, :in_current_season, name: 'Cheesy forever', project_name: project.name, project_id: project.id) }
   let!(:out_of_season)  { Season.current.starts_at - 1.week }

--- a/spec/features/users/unconfirmed_sign_in_user_spec.rb
+++ b/spec/features/users/unconfirmed_sign_in_user_spec.rb
@@ -65,5 +65,3 @@ def resend_info
   "Please click on the link in the email we just sent to confirm your email address. Haven't received it? Click here
 to resend the email."
 end
-
-

--- a/spec/features/users/unconfirmed_sign_in_user_spec.rb
+++ b/spec/features/users/unconfirmed_sign_in_user_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Unconfirmed User', type: :feature do
       expect(page).to have_content("About me")
     end
 
-    it 'nothing happens when clicking on resend link' do
+    it 'user gets visual feedback when clicking on resend link' do
       find_link('Click here to resend the email.').click
       # todo: expect_to happen: something visible
     end

--- a/spec/features/users/unconfirmed_sign_in_user_spec.rb
+++ b/spec/features/users/unconfirmed_sign_in_user_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'Unconfirmed User', type: :feature do
+
+  let(:user) { create(:user, :unconfirmed) }
+
+  let!(:activity)         { create(:status_update, :published, team: team1) }
+  let(:other_user)        { create(:user, hide_email: false) }
+  let(:hidden_email_user) { create(:user, hide_email: true) }
+  let!(:project)          { create(:project, :in_current_season, :accepted, submitter: other_user) }
+  let!(:team1)            { create(:team, :in_current_season, name: 'Cheesy forever', project_name: project.name, project_id: project.id) }
+  let!(:out_of_season)    { Season.current.starts_at - 1.week }
+  let!(:summer_season)    { Season.current.starts_at + 1.week }
+
+  context "when signing in" do
+    it 'gets access and is redirected to profile page' do
+      visit root_path
+      expect(page).to have_link('Sign in')
+
+      # todo stub oath ; it should redirect to edit_users_path(user)
+      # click_on ('Sign in')
+      # and show 'authenticated' message:
+      # expect(page).to have_content 'Successfully authenticated'
+
+      sign_in(user)
+      visit edit_user_path(user)
+      expect(page).not_to have_link('Sign in')
+      expect(page).to have_css('#user-links')
+      expect(page).to have_content resend_info
+      expect(page).to have_link('Click here to resend the email')
+    end
+  end
+
+  context 'when sign in succeeded' do
+    before do
+      sign_in user
+      visit edit_user_path(user)
+    end
+
+    it 'is redirected to profile' do
+      expect(page).to have_content 'Edit your profile'
+      find_field("Email", with: user.email)
+      expect(page).to have_content("About you") # form field for About me
+    end
+
+    it 'can always update their email address' do
+      expect(page).to have_content 'Edit your profile'
+      email = find_field("Email", with: user.email)
+      email.set("newemail@example.com")
+      find_button("Save").click
+      expect(page).to have_content("updated")
+      expect(page).to have_content("Please click on the link in the email we just sent to confirm your email address. Haven't received it? Click here to resend the email.")
+      expect(page).to have_content("About me")
+    end
+
+    it 'nothing happens when clicking on resend link' do
+      find_link('Click here to resend the email.').click
+      # todo: expect_to happen: something visible
+    end
+  end
+  # story continues in: user_confirmed_via_link || user_resend_confirmation_mail || sign_in_fail
+end
+
+def resend_info
+  "Please click on the link in the email we just sent to confirm your email address. Haven't received it? Click here
+to resend the email."
+end
+
+

--- a/spec/models/ability/confirmed_user_spec.rb
+++ b/spec/models/ability/confirmed_user_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Ability, type: :model do
   let(:user) { build_stubbed(:user) }
   subject(:ability) { Ability.new(user) }
   let(:other_user) { build_stubbed(:user) }
+  let(:hidden) { build_stubbed(:user, hide_email: true) }
 
   describe "Confirmed user" do
 
@@ -22,6 +23,8 @@ RSpec.describe Ability, type: :model do
     it { expect(subject).not_to be_able_to([:update, :destroy], other_user) }
 
     # the perks of confirming
+    it { expect(subject).to be_able_to(:read_email, other_user) }
+    it { expect(subject).not_to be_able_to(:read_email, hidden) }
     it { expect(subject).to be_able_to([:join, :create], Team) }
     it { expect(subject).to be_able_to(:create, Comment) } # TODO needs work for polymorphism
     it { expect(subject).to be_able_to(:create, Project) }

--- a/spec/models/ability/guest_spec.rb
+++ b/spec/models/ability/guest_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Ability, type: :model do
 
     it_behaves_like 'has access to public features'
 
+    it { expect(subject).not_to be_able_to(:read, other_user.email) }
+
     it "can not modify things on public pages" do
       PUBLIC_INDEX_PAGES.each do |page|
         expect(subject).not_to be_able_to([:create, :update, :destroy], page)

--- a/spec/models/ability/guest_spec.rb
+++ b/spec/models/ability/guest_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Ability, type: :model do
 
     it_behaves_like 'has access to public features'
 
-    it { expect(subject).not_to be_able_to(:read, other_user.email) }
+    it { expect(subject).not_to be_able_to(:read_email, other_user) }
 
     it "can not modify things on public pages" do
       PUBLIC_INDEX_PAGES.each do |page|

--- a/spec/models/ability/unconfirmed_user_spec.rb
+++ b/spec/models/ability/unconfirmed_user_spec.rb
@@ -10,9 +10,12 @@ RSpec.describe Ability, type: :model do
   describe "User logged in, account unconfirmed" do
 
     let(:user){ create(:user, :unconfirmed) }
+    let(:other_user) { create(:user) }
     subject(:ability) { Ability.new(user) }
 
     it_behaves_like 'has access to public features'
+
+    it { expect(subject).not_to be_able_to(:read, other_user.email) }
 
     it "can not modify things on public pages" do
       PUBLIC_INDEX_PAGES.each do |page|

--- a/spec/models/ability/unconfirmed_user_spec.rb
+++ b/spec/models/ability/unconfirmed_user_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Ability, type: :model do
 
     it_behaves_like 'has access to public features'
 
-    it { expect(subject).not_to be_able_to(:read, other_user.email) }
+    it { expect(subject).not_to be_able_to(:read_email, other_user) }
 
     it "can not modify things on public pages" do
       PUBLIC_INDEX_PAGES.each do |page|

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -2,4 +2,6 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :feature
+
 end


### PR DESCRIPTION
Related issue #991
 
On the way to separating authentication from authorisation: 
- Straighten out the authorisation in User: now we authorise all user actions, so that the abilities can take care what is shown to who (for example: we want a supervisor to be able to see email addresses of team members in the show view, even if the team member choose to hide their email from regular users). 
- Added a feature test for the sign in process for unconfirmed users.

Also:
- UX: Added a client side validation for the city field, which already has a server side validation
- Database: Added migration to remove users without a github_handle.  
  Why? For accounts imported from GitHUb, the github_id is not nil. So if the id is nil, it is a fake 
  account or an input error. Related issue #979 
  @klappradla I never used a migration for removing data before. I copied one of your examples, can you double double check please?
- FIX:  only confirmed users can read email addresses in users index and show

ALERT 
- In Dev env, running the migration will remove the seeded users from your local database. If you want some of them to persist, give them a fake `github_id` < 100. 
- Run `rails db:migrate` and `rails db:seed` 
  
Background info:
- Cancancan's load_and_authorize_resource will load the resource, unless it is already set. That means: we don't need the separate `before_action: set_resource` for authorised actions.  (Note that my previous description about this behaviour where not 100% accurate 😇 )

Follow up:
- [ ] Update the hint in the form, and tell the user that a supervisor and admin will be able to see email, whether marked hidden or not. Check first if this statement is and should be true.
- [ ] Add message to slack dev channel that all user-seeds will be removed with the latest migration.  

<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->
