### PR TITLE
Hotfix: Broken routes to Notepad on Supervisor Dashboard 

### DIFF
--- a/app/views/supervisors/dashboard/index.html.slim
+++ b/app/views/supervisors/dashboard/index.html.slim
@@ -27,7 +27,7 @@ div.row
                 td
                   '= Red alert
           div.col-sm-6 class=("col-lg-4 padding" if supervised_teams.count > 2)
-            = simple_form_for Note.notepad(current_user), url: supervisor_notes_path do |f|
+            / = simple_form_for Note.notepad(current_user), url: supervisors_notes_path do |f|
               == render 'supervisors/notes/form', f: f
 
 div.row
@@ -43,7 +43,7 @@ div.row
             p = "You last checked on them #{ time_ago_in_words(t.comments.last.created_at) } ago."
           - else
             p You didn't check on them yet.
-          = simple_form_for Comment.new(commentable: t), url: supervisor_comments_path do |f|
+          = simple_form_for Comment.new(commentable: t), url: supervisors_comments_path do |f|
             == render 'supervisors/comments/form', f: f
             - if t.comments.any?
               p = render t.comments.recent

--- a/app/views/supervisors/dashboard/index.html.slim
+++ b/app/views/supervisors/dashboard/index.html.slim
@@ -27,7 +27,7 @@ div.row
                 td
                   '= Red alert
           div.col-sm-6 class=("col-lg-4 padding" if supervised_teams.count > 2)
-            / = simple_form_for Note.notepad(current_user), url: supervisors_notes_path do |f|
+            = simple_form_for Note.notepad(current_user), url: supervisors_notes_path do |f|
               == render 'supervisors/notes/form', f: f
 
 div.row

--- a/app/views/supervisors/dashboard/index.html.slim
+++ b/app/views/supervisors/dashboard/index.html.slim
@@ -47,7 +47,7 @@ div.row
             == render 'supervisors/comments/form', f: f
             - if t.comments.any?
               p = render t.comments.recent
-              = link_to 'Archive', supervisor_comments_path(team_id: t.id)
+              = link_to 'Archive', supervisors_comments_path(team_id: t.id)
         section.dashboard
           h4 Activity
           - if t.activities.any?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,10 +101,10 @@ Rails.application.routes.draw do
     end
   end
 
+  patch 'supervisors/notes', to: 'supervisors/notes#update'
   namespace :supervisors do
     root to: 'dashboard#index', as: :dashboard
     resources :comments, only: [:index, :create]
-    resources :notes, only: [:update]
   end
 
   namespace :mentors do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,10 +101,10 @@ Rails.application.routes.draw do
     end
   end
 
-  patch 'supervisors/notes', to: 'supervisors/notes#update'
   namespace :supervisors do
     root to: 'dashboard#index', as: :dashboard
     resources :comments, only: [:index, :create]
+    resource :notes, only: :update
   end
 
   namespace :mentors do


### PR DESCRIPTION
The Supervisor Dashboard didn't work anymore, because the routes to the notepad and the comments were broken (after the namespace makeover in #893).
Fixed the route reference for comments, and reverted the removal of the separate `patch` notes route.
This may not be the optimal solution, but now the dashboard is working again. Ready to roll for the Summer! 🌞 


<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->
