### PR TITLE
Fix issue populating Team dropdown

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -28,7 +28,7 @@ class ActivitiesController < ApplicationController
   end
 
   def teams
-    Team.accepted.in_nearest_season.order(:name)
+    @teams ||= Team.accepted.in_nearest_season.order(:name)
   end
   helper_method :teams
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -28,14 +28,9 @@ class ActivitiesController < ApplicationController
   end
 
   def teams
-    Team.in_current_season.accepted.order(:name)
+    (Team.in_current_season.accepted.presence || Team.in_previous_season.accepted).order(:name)
   end
   helper_method :teams
-
-  def last_season_teams
-    Team.select {|t| t.season_id == Season.current.id + 1 && (t.kind == 'sponsored' || t.kind == 'voluntary' || t.kind == 'full_time' || t.kind == 'part_time')}
-  end
-  helper_method :last_season_teams
 
   def normalize_params
     params[:kind] = 'all' if params[:kind].blank?

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -28,7 +28,7 @@ class ActivitiesController < ApplicationController
   end
 
   def teams
-    (Team.in_current_season.accepted.presence || Team.in_previous_season.accepted).order(:name)
+    Team.accepted.in_nearest_season.order(:name)
   end
   helper_method :teams
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -32,6 +32,11 @@ class ActivitiesController < ApplicationController
   end
   helper_method :teams
 
+  def last_season_teams
+    Team.select {|t| t.season_id == Season.current.id + 1 && (t.kind == 'sponsored' || t.kind == 'voluntary' || t.kind == 'full_time' || t.kind == 'part_time')}
+  end
+  helper_method :last_season_teams
+
   def normalize_params
     params[:kind] = 'all' if params[:kind].blank?
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -51,6 +51,7 @@ class Team < ApplicationRecord
   scope :in_current_season, -> { where(season: Season.current) }
   scope :in_previous_season, -> { by_season(Date.today.year - 1) }
   scope :by_season, ->(year) { joins(:season).where(seasons: { name: year }) }
+  scope :in_nearest_season, -> { in_current_season.presence || in_previous_season }
 
   class << self
     def ordered(sort = {})

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -49,6 +49,7 @@ class Team < ApplicationRecord
   scope :accepted, -> { full_time.or(part_time) }
   scope :visible, -> { where.not(invisible: true).or(accepted) }
   scope :in_current_season, -> { where(season: Season.current) }
+  scope :in_previous_season, -> { by_season(Date.today.year - 1) }
   scope :by_season, ->(year) { joins(:season).where(seasons: { name: year }) }
 
   class << self

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -11,9 +11,12 @@ div.row
           label.radio
             = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
             = " " + kind == 'feed_entry' ? 'Blog Post' : kind.titleize
-        label.team_filter
-          ' Team:
-          = select_tag :team_id, options_for_select(teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: true, class: 'form-control'
+        - if teams.any?
+          label.team_filter
+            = select_tag :team_id, options_for_select(teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: 'Teams', class: 'form-control'
+        - else
+          label.team_filter
+            = select_tag :team_id, options_for_select(last_season_teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: 'Teams', class: 'form-control'
 
     p.pagination-info
       = page_entries_info @activities

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -11,12 +11,8 @@ div.row
           label.radio
             = radio_button_tag :kind, kind == 'all' ? '' : kind, params[:kind] == kind
             = " " + kind == 'feed_entry' ? 'Blog Post' : kind.titleize
-        - if teams.any?
-          label.team_filter
-            = select_tag :team_id, options_for_select(teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: 'Teams', class: 'form-control'
-        - else
-          label.team_filter
-            = select_tag :team_id, options_for_select(last_season_teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: 'Teams', class: 'form-control'
+        label.team_filter
+          = select_tag :team_id, options_for_select(teams.map { |t| [t.display_name, t.id] }, params[:team_id]), include_blank: 'Teams', class: 'form-control'
 
     p.pagination-info
       = page_entries_info @activities

--- a/db/migrate/20180602225032_index_teams_on_kind.rb
+++ b/db/migrate/20180602225032_index_teams_on_kind.rb
@@ -1,0 +1,5 @@
+class IndexTeamsOnKind < ActiveRecord::Migration[5.1]
+  def change
+    add_index :teams, :kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180524190818) do
+ActiveRecord::Schema.define(version: 20180602225032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -271,6 +271,7 @@ ActiveRecord::Schema.define(version: 20180524190818) do
     t.string "project_name"
     t.bigint "project_id"
     t.index ["applications_count"], name: "index_teams_on_applications_count"
+    t.index ["kind"], name: "index_teams_on_kind"
     t.index ["project_id"], name: "index_teams_on_project_id"
     t.index ["season_id"], name: "index_teams_on_season_id"
   end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -349,6 +349,29 @@ RSpec.describe Team, type: :model do
       end
     end
 
+    describe '.in_nearest_season' do
+      let(:current_season) { create(:season, name: Date.today.year) }
+      let!(:current_teams) { create_list(:team, 2, season: current_season) }
+      let(:prev_season) { create(:season, name: Date.today.year - 1) }
+      let!(:prev_teams) { create_list(:team, 2, season: prev_season) }
+
+      subject(:returned_teams) { described_class.in_nearest_season }
+
+      context 'when current season has teams' do
+        it 'returns those teams' do
+          expect(returned_teams).to match_array(current_teams)
+        end
+      end
+
+      context 'when current season has no teams' do
+        before { current_teams.each(&:destroy) }
+
+        it 'returns last season\'s teams' do
+          expect(returned_teams).to match_array(prev_teams)
+        end
+      end
+    end
+
     describe '.without_recent_log_update' do
       let(:team_without) { create :team }
 


### PR DESCRIPTION
This PR is the continuation of the work started by @simransinghal and @ArushiSinghal on #941 👍
Related issue #934 

**Problem:** the teams dropdown on the Activities page becomes empty between seasons.

<img width="1188" alt="screen shot 2018-06-02 at 17 24 45" src="https://user-images.githubusercontent.com/31735/40878485-e4a49fe8-6689-11e8-82e0-a018443b5b3b.png">

**Solution** (from #934):

1. During the current season, the dropdown is populated with the teams that are accepted in the current season
2. Until the current season starts, the dropdown is populated with the teams that were accepted in the previous season

**PS:** let's please add the original contributors as co-authors when we merge 🙌