### PR TITLE
Seeds and mailer preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development do
   gem 'binding_of_caller'
   gem 'spring'
   gem 'spring-commands-rspec'
+  gem 'letter_opener' # preview mail in browser instead of sending
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
     kaminari-core (1.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
+    letter_opener (1.6.0)
+      launchy (~> 2.2)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -400,6 +402,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   kaminari
+  letter_opener
   nested_form
   newrelic_rpm
   omniauth-github

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,5 +53,4 @@ Rails.application.configure do
   # with letter_opener
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
-  config.active_job.queue_adapter = :inline
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,11 +25,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.perform_caching = false
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
@@ -48,7 +43,15 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+
+  # Action Mailer
+  config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
+
+  # with letter_opener
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+  config.active_job.queue_adapter = :inline
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,9 +8,7 @@ FactoryBot.create(:team, :last_season, kind: "voluntary")
 
 # Users with different roles
 FactoryBot.create_list(:student, 6)
-FactoryBot.create_list(:student, 6)
 FactoryBot.create(:student, :unconfirmed)
-FactoryBot.create(:student, :unconfirmed, unconfirmed_email: "newer_email@example.com")
 
 FactoryBot.create_list(:coach, 3)
 FactoryBot.create(:coach, :unconfirmed)
@@ -23,6 +21,7 @@ FactoryBot.create(:supervisor)
 # To explore use cases where user has no role yet
 FactoryBot.create_list(:user, 3)
 FactoryBot.create(:user, :unconfirmed)
+FactoryBot.create(:user, unconfirmed_email: "newer_email@example.com")
 
 
 # Status updates for different teams

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,20 +1,29 @@
 # Teams
-FactoryBot.create_list(:team, 5, :in_current_season, kind: "sponsored")
-FactoryBot.create(:team, :in_current_season, kind: "voluntary")
+FactoryBot.create_list(:team, 5, :in_current_season, kind: "full_time")
+FactoryBot.create(:team, :in_current_season, kind: "part_time")
 FactoryBot.create(:team, :in_current_season) # not accepted
 
 FactoryBot.create(:team, :last_season, kind: "sponsored")
 FactoryBot.create(:team, :last_season, kind: "voluntary")
 
 # Users with different roles
-FactoryBot.create_list(:student, 12)
+FactoryBot.create_list(:student, 6)
+FactoryBot.create_list(:student, 6)
+FactoryBot.create(:student, :unconfirmed)
+FactoryBot.create(:student, :unconfirmed, unconfirmed_email: "newer_email@example.com")
+
 FactoryBot.create_list(:coach, 3)
+FactoryBot.create(:coach, :unconfirmed)
+FactoryBot.create(:coach, :unconfirmed, github_id: nil)
+
 FactoryBot.create_list(:organizer, 2)
 FactoryBot.create(:mentor)
 FactoryBot.create(:supervisor)
 
 # To explore use cases where user has no role yet
 FactoryBot.create_list(:user, 3)
+FactoryBot.create(:user, :unconfirmed)
+
 
 # Status updates for different teams
 5.times do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     github_handle { FFaker::InternetSE.unique.user_name_variant_short }
     sequence(:github_id, 123)
     name     { FFaker::Name.name }
-    email    { FFaker::Internet.email }
+    email    { "#{github_handle}@example.com"}
     hide_email false
     location { FFaker::Address.city }
     country  { FFaker::Address.country }


### PR DESCRIPTION
Related issue #

Dev happiness! 
- Update seeds with some unconfirmed users
- Update user factory's email field to `@example.com` (in case we'll want to send emails in the upcoming review apps)
- Add letter opener gem for supereasy previews of emails.  

<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->
