### PR TITLE
Fix typo (RSGoC -> RGSoC) in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Looking for your help!**
 
-For RSGoC we are building an app that aggregates daily status updates, commit activity and other sources into an activity stream.
+For RGSoC we are building an app that aggregates daily status updates, commit activity and other sources into an activity stream.
 
 Main goals are:
 


### PR DESCRIPTION
Hi :wave: 

Just saw @alicetragedy's [talk at ReasonConf 2018](https://www.youtube.com/watch?v=dUCErIbL_r4) & I noticed a typo in this README that is used as an example.

Thanks for the talk & keep up the good work :muscle: !