### PR TITLE
Flick the switch on belongs_to pt.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :test do
   gem 'rspec-html-matchers'
   gem 'rubocop', require: false
   gem 'selenium-webdriver'
-  gem 'shoulda-matchers'
+  gem 'shoulda-matchers', git: 'https://github.com/thoughtbot/shoulda-matchers.git'
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/thoughtbot/shoulda-matchers.git
+  revision: c0960bd72dd41c4e9bd8b4375254f539776bfe95
+  specs:
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -319,8 +326,6 @@ GEM
       rubyzip (~> 1.2)
     sentry-raven (2.7.3)
       faraday (>= 0.7.6, < 1.0)
-    shoulda-matchers (3.1.2)
-      activesupport (>= 4.0.0)
     simple_form (4.0.0)
       actionpack (> 4)
       activemodel (> 4)
@@ -423,7 +428,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   sentry-raven
-  shoulda-matchers
+  shoulda-matchers!
   simple_form
   simplecov
   slim-rails

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,7 +2,7 @@
 class Activity < ApplicationRecord
   KINDS = %w(feed_entry mailing status_update)
 
-  belongs_to :team
+  belongs_to :team, optional: true
   has_many :comments, -> { ordered }, as: :commentable, dependent: :destroy
 
   validates :content, :title, :team, presence: { if: ->(act) { act.kind == 'status_update' } }

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -6,9 +6,9 @@ class Application < ApplicationRecord
   COACHING_COMPANY_WEIGHT = ENV['COACHING_COMPANY_WEIGHT'] || 2
   MENTOR_PICK_WEIGHT = ENV['MENTOR_PICK_WEIGHT'] || 2
 
-  belongs_to :application_draft
+  belongs_to :application_draft, optional: true
   belongs_to :team, inverse_of: :applications, counter_cache: true
-  belongs_to :project
+  belongs_to :project, optional: true
 
   has_many :comments, -> { order(:created_at) }, as: :commentable, dependent: :destroy
 

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -78,9 +78,9 @@ class ApplicationDraft < ApplicationRecord
                      :project2_id, :plan_project2, :why_selected_project2]
 
   belongs_to :team
-  belongs_to :updater, class_name: 'User'
-  belongs_to :project1, class_name: 'Project'
-  belongs_to :project2, class_name: 'Project'
+  belongs_to :updater, class_name: 'User', optional: true
+  belongs_to :project1, class_name: 'Project', optional: true
+  belongs_to :project2, class_name: 'Project', optional: true
   has_one :application
 
   scope :in_current_season, -> { where(season: Season.current) }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Comment < ApplicationRecord
-  belongs_to :user
-  belongs_to :commentable, polymorphic: true
+  belongs_to :user, optional: true
+  belongs_to :commentable, polymorphic: true, optional: true
 
   scope :recent, -> { order('created_at DESC').limit(3) }
   scope :ordered, -> { order('created_at DESC, id DESC') }

--- a/app/models/concerns/has_season.rb
+++ b/app/models/concerns/has_season.rb
@@ -3,7 +3,7 @@ module HasSeason
   extend ActiveSupport::Concern
 
   included do
-    belongs_to :season
+    belongs_to :season, optional: true
 
     # @param season [#name, String, Integer]
     # @return [ActiveRecord::Relation]

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Conference < ApplicationRecord
+  include HasSeason
+
   REGION_LIST = [
     "Africa",
     "South America",
@@ -7,8 +9,6 @@ class Conference < ApplicationRecord
     "Europe",
     "Asia Pacific"
   ]
-
-  include HasSeason
 
   has_many :conference_attendances, dependent: :destroy
   has_many :first_choice_conference_preferences, class_name: 'ConferencePreference', foreign_key: 'first_conference_id', dependent: :destroy

--- a/app/models/conference_attendance.rb
+++ b/app/models/conference_attendance.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 class ConferenceAttendance < ApplicationRecord
-  belongs_to :team
-  belongs_to :conference
+  belongs_to :team, optional: true
+  belongs_to :conference, optional: true
 end

--- a/app/models/conference_preference.rb
+++ b/app/models/conference_preference.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class ConferencePreference < ApplicationRecord
-  belongs_to :team
-  belongs_to :first_conference, class_name: 'Conference'
-  belongs_to :second_conference, class_name: 'Conference'
+  belongs_to :team, optional: true
+  belongs_to :first_conference, class_name: 'Conference', optional: true
+  belongs_to :second_conference, class_name: 'Conference', optional: true
 
   validates :terms_of_ticket, inclusion: { in: [true] }, if: :conference_exists?
   validates :terms_of_travel, inclusion: { in: [true] }, if: :conference_exists?

--- a/app/models/maintainership.rb
+++ b/app/models/maintainership.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Maintainership < ApplicationRecord
-  belongs_to :project
-  belongs_to :user
+  belongs_to :project, optional: true
+  belongs_to :user, optional: true
 
   validates :project, :user, presence: true
   validates :project_id, uniqueness: { scope: :user_id }

--- a/app/models/maintainership.rb
+++ b/app/models/maintainership.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
-
 class Maintainership < ApplicationRecord
-  belongs_to :project, optional: true
-  belongs_to :user, optional: true
+  belongs_to :project
+  belongs_to :user
 
-  validates :project, :user, presence: true
   validates :project_id, uniqueness: { scope: :user_id }
 end

--- a/app/models/mentor/comment.rb
+++ b/app/models/mentor/comment.rb
@@ -8,7 +8,7 @@ module Mentor
     COMMENTABLE_TYPE = 'Mentor::Application'
 
     attribute :commentable_type, :string, default: COMMENTABLE_TYPE
-    belongs_to :user
+    belongs_to :user, optional: true
 
     after_update_commit { |comment| comment.destroy if comment.text.blank? }
   end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class Note < ApplicationRecord
-
   def self.notepad(user)
     Note.find_or_create_by(user_id: user.id)
   end
-
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 class Project < ApplicationRecord
   include HasSeason
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Project < ApplicationRecord
   include HasSeason
+  include AASM
 
   belongs_to :submitter, class_name: 'User'
   has_many :maintainerships, dependent: :nullify
@@ -20,8 +21,6 @@ class Project < ApplicationRecord
 
   before_validation :sanitize_url
   after_create :add_submitter_to_maintainers_list
-
-  include AASM
 
   aasm whiny_transitions: false do
     state :proposed, initial: true

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Rating < ApplicationRecord
-  belongs_to :application, required: true
-  belongs_to :user, required: true
+  belongs_to :application
+  belongs_to :user
 
   serialize :data
 

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 class Rating < ApplicationRecord
-  belongs_to :application
-  belongs_to :user
-
-  serialize :data
-
   FIELDS = ActiveSupport::HashWithIndifferentAccess.new({
     diversity:
       RatingCriterium.new( 0.05, {
@@ -107,9 +102,14 @@ class Rating < ApplicationRecord
     end
   end
 
-  before_validation :set_data
+  belongs_to :application
+  belongs_to :user
+
+  serialize :data
 
   validates :user_id, uniqueness: { scope: :application_id }
+
+  before_validation :set_data
 
   scope :by, -> (user) { where(user_id: user.id) }
 

--- a/app/models/rating_criterium.rb
+++ b/app/models/rating_criterium.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 class RatingCriterium
-  attr_reader :weight
-
   MIN_POINTS = 0
   MAX_POINTS = 10
+
+  attr_reader :weight
 
   def initialize(weight, point_names = {})
     if !weight.is_a? Numeric || ( weight < 0 || weight > 1 )

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -12,7 +12,7 @@ class Role < ApplicationRecord
   CONTRIBUTOR_ROLES = ADMIN_ROLES + GUIDE_ROLES
 
   belongs_to :user
-  belongs_to :team
+  belongs_to :team, optional: true
 
   delegate :github_handle, to: :user, allow_nil: true
 

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 class Season < ApplicationRecord
-  has_many :projects
-
-  validates :name, presence: true, uniqueness: true, inclusion: { in: ('1999'..'2050') }
-
-  before_validation :set_application_dates
-
   # Season's moments: [month, day]
   SUMMER_OPEN    = [7, 1]
   SUMMER_CLOSE   = [9, 30]
@@ -14,6 +8,12 @@ class Season < ApplicationRecord
   APPL_LETTER    = [5, 1]
   PROJECTS_OPEN  = [12, 1]
   PROJECTS_CLOSE = [2, 1]
+
+  has_many :projects
+
+  validates :name, presence: true, uniqueness: true, inclusion: { in: ('1999'..'2050') }
+
+  before_validation :set_application_dates
 
   class << self
     def current

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class Season < ApplicationRecord
-
   has_many :projects
 
   validates :name, presence: true, uniqueness: true, inclusion: { in: ('1999'..'2050') }

--- a/app/models/skill_level.rb
+++ b/app/models/skill_level.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class SkillLevel
-
   MATRIX = {
     1   => ['I understand and can explain the difference between data types (strings, booleans, integers)',
             'I have heard of the MVC (Model View Controller) pattern',

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -4,7 +4,7 @@ class Source < ApplicationRecord
 
   KINDS = %w(page repository blog)
 
-  belongs_to :team
+  belongs_to :team, optional: true
 
   validates :url, presence: true
   validates :kind, presence: true

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 class Submission < ApplicationRecord
-  class << self
-    def unsent
-      where(sent_at: nil)
-    end
-  end
-
-  belongs_to :mailing
+  belongs_to :mailing, optional: true
 
   after_commit :enqueue, on: :create
+
+  scope :unsent, -> { where(sent_at: nil) }
 
   def enqueue
     Rails.logger.info "Enqueueing submission: #{id}"

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,7 +2,7 @@
 class Team < ApplicationRecord
   include ProfilesHelper, HasSeason
 
-  attr_accessor :checked
+  KINDS = %w(full_time part_time)
 
   belongs_to :project, optional: true
 
@@ -29,7 +29,7 @@ class Team < ApplicationRecord
   delegate :full_time?, to: :kind
   delegate :part_time?, to: :kind
 
-  KINDS = %w(full_time part_time)
+  attr_accessor :checked
 
   validates :name, presence: true, uniqueness: true
   validate :disallow_multiple_student_roles

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,20 +2,9 @@
 class Team < ApplicationRecord
   include ProfilesHelper, HasSeason
 
-  delegate :full_time?, to: :kind
-  delegate :part_time?, to: :kind
-
-  KINDS = %w(full_time part_time)
-
-  validates :name, presence: true, uniqueness: true
-  validate :disallow_multiple_student_roles
-  validate :disallow_duplicate_members
-  validate :limit_number_of_students
-  validate :limit_number_of_coaches
-
   attr_accessor :checked
 
-  belongs_to :project
+  belongs_to :project, optional: true
 
   has_one :last_activity, -> { order('id DESC') }, class_name: 'Activity'
   has_one :conference_preference, dependent: :destroy
@@ -36,6 +25,17 @@ class Team < ApplicationRecord
   accepts_nested_attributes_for :conference_preference, allow_destroy: true
   accepts_nested_attributes_for :roles, :sources, allow_destroy: true
   accepts_nested_attributes_for :conference_attendances, allow_destroy: true, reject_if: proc { |attributes| attributes[:conference_id].blank? }
+
+  delegate :full_time?, to: :kind
+  delegate :part_time?, to: :kind
+
+  KINDS = %w(full_time part_time)
+
+  validates :name, presence: true, uniqueness: true
+  validate :disallow_multiple_student_roles
+  validate :disallow_duplicate_members
+  validate :limit_number_of_students
+  validate :limit_number_of_coaches
 
   before_create :set_number
   before_save :set_last_checked, if: :checked

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -3,8 +3,8 @@ class Todo < ApplicationRecord
   BLACK_FLAGS = %w(remote_team male_gender age_below_18 less_than_two_coaches zero_community)
   SIGN_OFFS   = %w(signed_off_at_project1 signed_off_at_project2)
 
-  belongs_to :user, required: true
-  belongs_to :application, required: true
+  belongs_to :user
+  belongs_to :application
 
   delegate :application_data, :season, to: :application
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module RgsocTeams
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    # config.load_defaults 5.1
+    config.load_defaults 5.1
 
     config.autoload_paths += %W(#{config.root}/app)
 

--- a/config/initializers/new_framework_defaults_5_1.rb
+++ b/config/initializers/new_framework_defaults_5_1.rb
@@ -10,8 +10,7 @@
 Rails.application.config.action_view.form_with_generates_remote_forms = false
 
 # The belongs_to associations are required by default in Rails 5
-# we cannot opt into this right now, but it would be a goal for the future
-Rails.application.config.active_record.belongs_to_required_by_default = false
+Rails.application.config.active_record.belongs_to_required_by_default = true
 
 # Unknown asset fallback will return the path passed in when the given
 # asset is not present in the asset pipeline.

--- a/config/initializers/new_framework_defaults_5_1.rb
+++ b/config/initializers/new_framework_defaults_5_1.rb
@@ -9,9 +9,6 @@
 # Make `form_with` generate non-remote forms.
 Rails.application.config.action_view.form_with_generates_remote_forms = false
 
-# The belongs_to associations are required by default in Rails 5
-Rails.application.config.active_record.belongs_to_required_by_default = true
-
 # Unknown asset fallback will return the path passed in when the given
 # asset is not present in the asset pipeline.
 # Rails.application.config.assets.unknown_asset_fallback = false

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Activity, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:team) }
+    it { is_expected.to belong_to(:team).optional }
     it { is_expected.to have_many(:comments).dependent(:destroy) }
 
     it { is_expected.to delegate_method(:students).to(:team) }

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe ApplicationDraft, type: :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:team) }
-    it { is_expected.to belong_to(:updater).class_name('User') }
-    it { is_expected.to belong_to(:project1).class_name('Project') }
-    it { is_expected.to belong_to(:project2).class_name('Project') }
+    it { is_expected.to belong_to(:updater).class_name('User').optional }
+    it { is_expected.to belong_to(:project1).class_name('Project').optional }
+    it { is_expected.to belong_to(:project2).class_name('Project').optional }
     it { is_expected.to have_one(:application) }
   end
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Application, type: :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:team).inverse_of(:applications).counter_cache(true) }
-    it { is_expected.to belong_to(:project) }
-    it { is_expected.to belong_to(:application_draft) }
+    it { is_expected.to belong_to(:project).optional }
+    it { is_expected.to belong_to(:application_draft).optional }
     it { is_expected.to have_many(:comments).dependent(:destroy).order(:created_at) }
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:commentable) }
+    it { is_expected.to belong_to(:user).optional }
+    it { is_expected.to belong_to(:commentable).optional }
   end
 
   describe 'scopes' do

--- a/spec/models/conference_attendance_spec.rb
+++ b/spec/models/conference_attendance_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ConferenceAttendance, type: :model do
-  it { is_expected.to belong_to(:team) }
-  it { is_expected.to belong_to(:conference) }
+  it { is_expected.to belong_to(:team).optional }
+  it { is_expected.to belong_to(:conference).optional }
 end

--- a/spec/models/conference_preference_spec.rb
+++ b/spec/models/conference_preference_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe ConferencePreference, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:team) }
-    it { is_expected.to belong_to(:first_conference) }
-    it { is_expected.to belong_to(:second_conference) }
+    it { is_expected.to belong_to(:team).optional }
+    it { is_expected.to belong_to(:first_conference).optional }
+    it { is_expected.to belong_to(:second_conference).optional }
   end
 
   describe 'validates terms of ticket and terms of travel' do

--- a/spec/models/mailing_spec.rb
+++ b/spec/models/mailing_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Mailing, type: :model do
   describe 'associations and attributes' do
     it { is_expected.to have_many(:submissions).dependent(:destroy) }
-    # TODO: add these back in once shoulda-matchers is updated
-    xit { is_expected.to define_enum_for(:group).with_values(everyone: 0, selected_teams: 1, unselected_teams: 2) }
-    xit { is_expected.to serialize(:to) }
+
+    it { is_expected.to define_enum_for(:group).with_values(everyone: 0, selected_teams: 1, unselected_teams: 2) }
+    it { is_expected.to serialize(:to) }
     it { is_expected.to delegate_method(:emails).to(:recipients) }
   end
 

--- a/spec/models/maintainership_spec.rb
+++ b/spec/models/maintainership_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe Maintainership, type: :model do
   end
 
   describe 'its validations' do
-    it { is_expected.to validate_presence_of :project }
-    it { is_expected.to validate_presence_of :user }
-
     it { is_expected.to validate_uniqueness_of(:project_id).scoped_to(:user_id) }
   end
 end

--- a/spec/models/mentor/comment_spec.rb
+++ b/spec/models/mentor/comment_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Mentor::Comment, type: :model do
   end
 
   describe 'associations' do
-    it { is_expected.to belong_to :user }
-    it { is_expected.not_to belong_to :commentable }
+    it { is_expected.to belong_to(:user).optional }
+    it { is_expected.not_to belong_to(:commentable).optional }
   end
 
   describe 'attributes' do

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Rating, type: :model do
-  describe 'associations' do
+  describe 'associations and attributes' do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:application) }
+
+    it { is_expected.to serialize(:data) }
   end
 
   describe 'validations' do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Role, type: :model do
   let(:user) { create(:user) }
   let(:team) { create(:team) }
 
-  it { is_expected.to belong_to(:team) }
+  it { is_expected.to belong_to(:team).optional }
   it { is_expected.to belong_to(:user) }
   it { is_expected.to validate_presence_of(:user) }
   it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Source, type: :model do
-  it { is_expected.to belong_to(:team) }
+  it { is_expected.to belong_to(:team).optional }
+
   it { is_expected.to validate_presence_of(:url) }
 
   describe '.for_accepted_teams' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Team, type: :model do
   it_behaves_like 'HasSeason'
 
   describe 'associations' do
-    it { is_expected.to belong_to(:project) }
+    it { is_expected.to belong_to(:project).optional }
 
     it { is_expected.to have_many(:applications).dependent(:nullify).inverse_of(:team) }
     it { is_expected.to have_many(:application_drafts).dependent(:nullify) }

--- a/spec/support/shared_examples/has_season.rb
+++ b/spec/support/shared_examples/has_season.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples 'HasSeason' do
-  it { expect(subject).to belong_to :season }
+  it { is_expected.to belong_to(:season).optional }
 
   describe '.in_season' do
     it 'returns a relation' do


### PR DESCRIPTION
This is part one of enabling the new defaults introduced with Rails 5: `belongs_to` associations are required by default now.

This PR flicks the switch to enable this new default on adjusts all models and their tests accordingly to this new behavior (while the app stays exactly the same).

Based on this, I'll prepare more PRs for:
- remove unused belongs_to associations (e.g. `applications` <-> `projects`)
- make certain `belongs_to` associations actually required (the hard part 😉 )

If the context for the current changes is not super obvious in some places, it may be easier to look at the individual commits (with their messages)...