### PR TITLE
Fix crash on review application index view caused by deleted accounts

### DIFF
--- a/app/models/concerns/rateable.rb
+++ b/app/models/concerns/rateable.rb
@@ -24,7 +24,7 @@ module Rateable
   end
 
   def ratings_short
-    ratings.includes(:user).map { |r| "#{r.user.name}: #{r.points.round(2)}" }
+    ratings.includes(:user).map { |r| "#{r.user&.name}: #{r.points&.round(2)}" }
   end
 
   def total_picks

--- a/spec/controllers/reviewers/applications_controller_spec.rb
+++ b/spec/controllers/reviewers/applications_controller_spec.rb
@@ -29,6 +29,28 @@ RSpec.describe Reviewers::ApplicationsController, type: :controller do
 
         expect(assigns :table).to be_a Selection::Table
         expect(response).to render_template :index
+
+      end
+
+      context 'given one of the users deleted their account' do
+        before do
+          application = applications.first
+          create(:student, team: application.team)
+          create(:student, team: application.team)
+          application.team.students.first.destroy!
+        end
+
+        it 'assigns an application table and renders the index view' do
+          expect(Application).to receive(:rateable)
+            .with(no_args)
+            .and_return(applications)
+
+          get :index
+
+          expect(assigns :table).to be_a Selection::Table
+          expect(response).to render_template :index
+
+        end
       end
 
       context 'when applying filters and sorting' do


### PR DESCRIPTION
It seems that one or two of the users were deleted, causing the list to crash.
