### PR TITLE
[#892] Migrate `team.project_name` to `team.project_id`

### DIFF
--- a/app/controllers/organizers/teams_controller.rb
+++ b/app/controllers/organizers/teams_controller.rb
@@ -85,7 +85,7 @@ module Organizers
         :name, :twitter_handle, :github_handle, :description, :post_info, :event_id,
         :checked, :'starts_on(1i)', :'starts_on(2i)', :'starts_on(3i)',
         :'finishes_on(1i)', :'finishes_on(2i)', :'finishes_on(3i)', :invisible,
-        :project_name, :season_id, :kind,
+        :project_id, :season_id, :kind,
         conference_preference_attributes: [:id, :terms_of_ticket, :terms_of_travel, :first_conference_id, :second_conference_id, :lightning_talk, :comment, :_destroy],
         roles_attributes: [:id, :name, :github_handle, :_destroy],
         conference_attendances_attributes: [:id, :orga_comment, :conference_id, :_destroy],

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -87,7 +87,6 @@ class TeamsController < ApplicationController
       :name, :twitter_handle, :github_handle, :description, :post_info, :event_id,
       :checked, :'starts_on(1i)', :'starts_on(2i)', :'starts_on(3i)',
       :'finishes_on(1i)', :'finishes_on(2i)', :'finishes_on(3i)', :invisible,
-      :project_name,
       roles_attributes: role_attributes_list,
       conference_preference_attributes: [:id, :terms_of_ticket, :terms_of_travel, :first_conference_id, :second_conference_id, :lightning_talk, :comment, :_destroy],
       sources_attributes: [:id, :kind, :url, :_destroy]

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -12,7 +12,7 @@ class Application < ApplicationRecord
 
   has_many :comments, -> { order(:created_at) }, as: :commentable, dependent: :destroy
 
-  validates :team, :application_data, presence: true
+  validates :application_data, presence: true
 
   before_validation :remove_duplicate_flags
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -6,7 +6,7 @@ class Application < ApplicationRecord
   COACHING_COMPANY_WEIGHT = ENV['COACHING_COMPANY_WEIGHT'] || 2
   MENTOR_PICK_WEIGHT = ENV['MENTOR_PICK_WEIGHT'] || 2
 
-  belongs_to :application_draft, optional: true
+  belongs_to :application_draft
   belongs_to :team, inverse_of: :applications, counter_cache: true
   belongs_to :project, optional: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -45,8 +45,7 @@ class Project < ApplicationRecord
   #
   # @param season [Season] the season to query, defaults to the current one.
   def self.selected(season: Season.current)
-    project_names = Team.in_season(season).accepted.pluck(:project_name)
-    in_season(season).accepted.where(name: project_names)
+    in_season(season).accepted.where(id: Team.in_season(season).accepted.pluck(:project_id))
   end
 
   def taglist

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -90,8 +90,9 @@ class Team < ApplicationRecord
     super.to_s.inquiry
   end
 
+  # TODO: refactor me...
   def display_name
-    chunks = [name, project_name].select(&:present?)
+    chunks = [name, project&.name].select(&:present?)
     chunks[1] = "(#{chunks[1]})" if chunks[1]
     chunks << "[#{season.name}]" if season && season != Season.current
 

--- a/app/views/organizers/teams/_form.html.slim
+++ b/app/views/organizers/teams/_form.html.slim
@@ -36,7 +36,8 @@
   .form-group.form-btn-group
     = f.link_to_add 'Add another member', :roles, class: 'btn btn-primary col-sm-offset-3'
 
-  = f.input :project_name, placeholder: 'Name of your project', label: 'Project Name'
+  = f.association :project, label: 'Project', collection: Project.in_season(@team.season).accepted, prompt: 'Choose a Project'
+
   = f.input :github_handle, placeholder: '', hint: 'Should your team have an organization'
   = f.input :twitter_handle, placeholder: '@', hint: 'Should your team have one'
   = f.input :description, label: 'Introduction', placeholder: 'Tell the world about your team (eg. about the project you will be working on)', input_html: { rows: 10 }, hint: "This is just for your public team profile. You can use basic #{link_to 'Markdown', "https://en.wikipedia.org/wiki/Markdown", target: :blank} here.".html_safe

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -39,7 +39,6 @@
     = f.link_to_add 'Add another member', :roles, class: 'btn btn-primary col-sm-offset-3'
 
   - if f.object.accepted?
-    = f.input :project_name, placeholder: 'Name of your project', label: 'Project Name'
     = f.input :github_handle, placeholder: '', hint: 'Should your team have an organization'
     = f.input :twitter_handle, placeholder: '@', hint: 'Should your team have one'
     = f.input :description, label: 'Introduction', placeholder: 'Tell the world about your team (eg. about the project you will be working on)', input_html: { rows: 10 }, hint: "This is just for your public team profile. You can use basic #{link_to 'Markdown', "https://en.wikipedia.org/wiki/Markdown", target: :blank} here.".html_safe

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -39,6 +39,7 @@
     = f.link_to_add 'Add another member', :roles, class: 'btn btn-primary col-sm-offset-3'
 
   - if f.object.accepted?
+    = f.association :project, readonly: true, include_blank: false
     = f.input :github_handle, placeholder: '', hint: 'Should your team have an organization'
     = f.input :twitter_handle, placeholder: '@', hint: 'Should your team have one'
     = f.input :description, label: 'Introduction', placeholder: 'Tell the world about your team (eg. about the project you will be working on)', input_html: { rows: 10 }, hint: "This is just for your public team profile. You can use basic #{link_to 'Markdown', "https://en.wikipedia.org/wiki/Markdown", target: :blank} here.".html_safe

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -39,7 +39,7 @@
     = f.link_to_add 'Add another member', :roles, class: 'btn btn-primary col-sm-offset-3'
 
   - if f.object.accepted?
-    = f.association :project, readonly: true, include_blank: false
+    = f.association :project, disabled: true, include_blank: false
     = f.input :github_handle, placeholder: '', hint: 'Should your team have an organization'
     = f.input :twitter_handle, placeholder: '@', hint: 'Should your team have one'
     = f.input :description, label: 'Introduction', placeholder: 'Tell the world about your team (eg. about the project you will be working on)', input_html: { rows: 10 }, hint: "This is just for your public team profile. You can use basic #{link_to 'Markdown', "https://en.wikipedia.org/wiki/Markdown", target: :blank} here.".html_safe

--- a/db/migrate/20180706121823_remove_project_name_from_teams.rb
+++ b/db/migrate/20180706121823_remove_project_name_from_teams.rb
@@ -1,0 +1,35 @@
+class RemoveProjectNameFromTeams < ActiveRecord::Migration[5.1]
+  def up
+    migrate_project_name_to_project_id
+    remove_column :teams, :project_name, :string
+  end
+
+  def down
+    add_column :teams, :project_name, :string
+    migrate_project_id_to_project_name
+  end
+
+  private
+
+  def migrate_project_name_to_project_id
+    execute <<~SQL
+      UPDATE teams
+      SET project_id = projects.id
+      FROM projects
+      WHERE teams.project_name IS NOT NULL
+      AND projects.name = teams.project_name
+      AND teams.season_id = projects.season_id
+    SQL
+  end
+
+  def migrate_project_id_to_project_name
+    execute <<~SQL
+      UPDATE teams
+      SET project_name = projects.name
+      FROM projects
+      WHERE teams.project_id IS NOT NULL
+      AND projects.id = teams.project_id
+      AND teams.season_id = projects.season_id
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180603124843) do
+ActiveRecord::Schema.define(version: 20180706121823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -266,7 +266,6 @@ ActiveRecord::Schema.define(version: 20180603124843) do
     t.integer "season_id"
     t.boolean "invisible", default: false
     t.integer "applications_count", default: 0, null: false
-    t.string "project_name"
     t.bigint "project_id"
     t.index ["applications_count"], name: "index_teams_on_applications_count"
     t.index ["kind"], name: "index_teams_on_kind"

--- a/lib/tasks/single_run.rake
+++ b/lib/tasks/single_run.rake
@@ -65,16 +65,4 @@ namespace :single_run do
       end
     end
   end
-
-  desc '2017-08-15: Change project_name to project_id'
-  task add_project_id_to_team: :environment do
-    Team.accepted.where.not(project_name: [nil, '']).each do |team|
-      begin
-        team.project = Project.where(season_id: team.season_id).find_by!(name: team.project_name)
-        team.save
-      rescue ActiveRecord::RecordNotFound => e
-        puts "#{e} for #{team.name} with project_name #{team.project_name}"
-      end
-    end
-  end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe ProjectsController, type: :controller do
   let(:project) { create(:project) }
 
   describe 'GET index' do
-
     context 'between seasons' do
       before { Timecop.travel Date.parse('2015-12-15') }
 
@@ -28,8 +27,8 @@ RSpec.describe ProjectsController, type: :controller do
 
       let!(:proposed) { create(:project, season: Season.succ, name: 'proposed project') }
       let!(:selected) { create(:project, :accepted, :in_current_season, name: "selected by a team") }
-      let!(:no_team) { create(:project, :accepted, :in_current_season, name: "project without team") }
-      let!(:team) { create(:team, :in_current_season, project_name: selected.name) }
+      let!(:no_team)  { create(:project, :accepted, :in_current_season, name: "project without team") }
+      let!(:team)     { create(:team, :in_current_season, project: selected) }
 
       it 'shows selected projects only' do
         get :index
@@ -41,12 +40,12 @@ RSpec.describe ProjectsController, type: :controller do
     end
 
     context 'with a season filter' do
-      let!(:season2017) { Season.find_or_create_by(name: '2017') }
-      let!(:proposed) { create(:project, :in_current_season, name: 'proposed project') }
+      let!(:season2017)   { Season.find_or_create_by(name: '2017') }
+      let!(:proposed)     { create(:project, :in_current_season, name: 'proposed project') }
       let!(:selected2017) { create(:project, :accepted, season: season2017, name: "selected by a team 2017") }
-      let!(:selected) { create(:project, :accepted, :in_current_season, name: "selected by a team (current)") }
-      let!(:no_team) { create(:project, :accepted, season: season2017, name: "project without team 2017") }
-      let!(:team) { create(:team, season: season2017, project_name: selected2017.name) }
+      let!(:selected)     { create(:project, :accepted, :in_current_season, name: "selected by a team (current)") }
+      let!(:no_team)      { create(:project, :accepted, season: season2017, name: "project without team 2017") }
+      let!(:team)         { create(:team, season: season2017, project: selected2017) }
 
       it 'shows selected projects in past season only' do
         get :index, params: { filter: '2017' }

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
-
   factory :activity do
     team
 

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :application do
+    application_draft
     team
     application_data {{
       student0_application_coding_level: 2,

--- a/spec/features/organizers/teams/edit_spec.rb
+++ b/spec/features/organizers/teams/edit_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'Editing Teams', type: :feature do
+  let(:user)            { create(:organizer) }
+  let(:season)          { Season.current }
+  let(:other_season)    { create(:season) }
+  let(:team)            { create(:team, name: 'Team Yay', season: season) }
+  let(:selection_phase) { season.applications_close_at + 1.day }
+  let!(:exercism)       { create(:project, :accepted, name: 'Exercism', season: season) }
+
+  before do
+    create(:project, :accepted, name: 'Some Old Project', season: other_season)
+    create(:project, name: 'Non-Accepted', season: season)
+    create(:project, :accepted, name: 'Open Source Dropbox', season: season)
+
+    Timecop.travel(selection_phase)
+  end
+
+  after { Timecop.return }
+
+  it 'allows to set the project for a team (from the same season)' do
+    login_as user
+    visit edit_organizers_team_path(team)
+
+    expect(page).not_to have_content('Some Old Project')
+    expect(page).not_to have_content('Non-Accepted')
+    expect(team.project).to be_nil
+
+    select 'Exercism', from: 'Project'
+    fill_in 'URL', with: 'https://example.com'
+    click_on 'Save'
+
+    expect(page).to have_content('Team was successfully updated')
+    expect(page).to have_content('https://example.com')
+    expect(team.reload.project).to eq(exercism)
+
+    visit projects_path
+
+    expect(page).to have_content('Non-Accepted')
+    expect(page).to have_content('Open Source Dropbox')
+    expect(page).to have_content('Exercism')
+    expect(page).not_to have_content('Some Old Project')
+
+    expect(page).to have_content('Team Yay')
+  end
+end

--- a/spec/features/teams/edit_spec.rb
+++ b/spec/features/teams/edit_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Editing Teams', type: :feature do
+  let(:user) { create(:user) }
+
+  before do
+    create(:role, name: 'student', team: team, user: user)
+    login_as user
+  end
+
+  context 'when the team has been accepted and a project assigned' do
+    let(:team)    { create(:team, kind: 'full_time', project: project) }
+    let(:project) { create(:project, name: 'Unicorn Prompt') }
+
+    it 'displays a readonly field for the project' do
+      visit edit_team_path(team)
+
+      expect(page).to have_field('Project', with: project.id, readonly: true)
+      expect(page).to have_content('Unicorn Prompt')
+    end
+  end
+
+  context 'when the team has been accepted but no project assigned yet' do
+    let(:team) { create(:team, kind: 'full_time', project: nil) }
+
+    it 'displays an empty readonly field for the project' do
+      visit edit_team_path(team)
+
+      expect(page).to have_field('Project', with: nil, readonly: true)
+    end
+  end
+end

--- a/spec/features/teams/edit_spec.rb
+++ b/spec/features/teams/edit_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Editing Teams', type: :feature do
     it 'displays a readonly field for the project' do
       visit edit_team_path(team)
 
-      expect(page).to have_field('Project', with: project.id, readonly: true)
+      expect(page).to have_field('Project', with: project.id, disabled: true)
       expect(page).to have_content('Unicorn Prompt')
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe 'Editing Teams', type: :feature do
     it 'displays an empty readonly field for the project' do
       visit edit_team_path(team)
 
-      expect(page).to have_field('Project', with: nil, readonly: true)
+      expect(page).to have_field('Project', with: nil, disabled: true)
     end
   end
 end

--- a/spec/features/users/guest_user_spec.rb
+++ b/spec/features/users/guest_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Guest User', type: :feature do
   let!(:activity)       { create(:status_update, :published, team: team1) }
   let(:other_user)      { create(:user) }
   let!(:project)        { create(:project, :in_current_season, :accepted, submitter: other_user) }
-  let!(:team1)          { create(:team, :in_current_season, name: 'Cheesy forever', project: project, project_id: project.id) }
+  let!(:team1)          { create(:team, :in_current_season, name: 'Cheesy forever', project: project) }
   let!(:out_of_season)  { Season.current.starts_at - 1.week }
   let!(:summer_season)  { Season.current.starts_at + 1.week }
 

--- a/spec/features/users/guest_user_spec.rb
+++ b/spec/features/users/guest_user_spec.rb
@@ -1,16 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Guest User', type: :feature do
-
-  let!(:activity) { create(:status_update, :published, team: team1) }
-  let(:other_user) { create(:user) }
-  let!(:project)       { create(:project, :in_current_season, :accepted, submitter: other_user) }
-  let!(:team1)         { create(:team, :in_current_season, name: 'Cheesy forever', project_name: project.name, project_id: project.id) }
+  let!(:activity)       { create(:status_update, :published, team: team1) }
+  let(:other_user)      { create(:user) }
+  let!(:project)        { create(:project, :in_current_season, :accepted, submitter: other_user) }
+  let!(:team1)          { create(:team, :in_current_season, name: 'Cheesy forever', project: project, project_id: project.id) }
   let!(:out_of_season)  { Season.current.starts_at - 1.week }
   let!(:summer_season)  { Season.current.starts_at + 1.week }
 
-  context "when visiting public pages" do
-
+  context 'when visiting public pages' do
     context 'All Year' do
       before { Timecop.travel(out_of_season) }
       after  { Timecop.return }

--- a/spec/features/users/unconfirmed_sign_in_user_spec.rb
+++ b/spec/features/users/unconfirmed_sign_in_user_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Unconfirmed User', type: :feature do
   let(:other_user)        { create(:user, hide_email: false) }
   let(:hidden_email_user) { create(:user, hide_email: true) }
   let!(:project)          { create(:project, :in_current_season, :accepted, submitter: other_user) }
-  let!(:team1)            { create(:team, :in_current_season, name: 'Cheesy forever', project: project, project_id: project.id) }
+  let!(:team1)            { create(:team, :in_current_season, name: 'Cheesy forever', project: project) }
   let!(:out_of_season)    { Season.current.starts_at - 1.week }
   let!(:summer_season)    { Season.current.starts_at + 1.week }
 

--- a/spec/features/users/unconfirmed_sign_in_user_spec.rb
+++ b/spec/features/users/unconfirmed_sign_in_user_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Unconfirmed User', type: :feature do
   let(:other_user)        { create(:user, hide_email: false) }
   let(:hidden_email_user) { create(:user, hide_email: true) }
   let!(:project)          { create(:project, :in_current_season, :accepted, submitter: other_user) }
-  let!(:team1)            { create(:team, :in_current_season, name: 'Cheesy forever', project_name: project.name, project_id: project.id) }
+  let!(:team1)            { create(:team, :in_current_season, name: 'Cheesy forever', project: project, project_id: project.id) }
   let!(:out_of_season)    { Season.current.starts_at - 1.week }
   let!(:summer_season)    { Season.current.starts_at + 1.week }
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -88,17 +88,20 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe '.link_to_user_roles' do
+    let(:team1)   { create(:team, name: '29-enim', project: project) }
+    let(:team2)   { create(:team, name: '28-enim') }
+    let(:user)    { create(:user, name: 'Trung Le') }
+    let(:project) { create(:project, name: 'Sinatra') }
+
     before do
-      @team  = create(:team, name: '29-enim', project_name: 'Sinatra')
-      @user1 = create(:user, name: 'Trung Le')
-      @role2 = create(:coach_role,  user: @user1, team: @team)
-      @role3 = create(:mentor_role, user: @user1, team: @team)
+      create(:coach_role,  user: user, team: team1)
+      create(:mentor_role, user: user, team: team2)
     end
 
     it 'should return link_to role based on student' do
-      expect(link_to_user_roles(@user1)).to eq(
-        "<a href=\"/community?role=coach\">Coach</a> at <a href=\"/teams/#{@team.id}\">Team 29-enim (Sinatra)</a>, " +
-        "<a href=\"/community?role=mentor\">Mentor</a> at <a href=\"/teams/#{@team.id}\">Team 29-enim (Sinatra)</a>"
+      expect(link_to_user_roles(user)).to eq(
+        "<a href=\"/community?role=coach\">Coach</a> at <a href=\"/teams/#{team1.id}\">Team 29-enim (Sinatra)</a>, " +
+        "<a href=\"/community?role=mentor\">Mentor</a> at <a href=\"/teams/#{team2.id}\">Team 28-enim</a>"
       )
     end
   end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Application, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:team).inverse_of(:applications).counter_cache(true) }
     it { is_expected.to belong_to(:project).optional }
-    it { is_expected.to belong_to(:application_draft).optional }
+    it { is_expected.to belong_to(:application_draft) }
     it { is_expected.to have_many(:comments).dependent(:destroy).order(:created_at) }
   end
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Application, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:application_data) }
-    it { is_expected.to validate_presence_of(:team) }
   end
 
   describe 'scopes' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Team, type: :model do
+RSpec.describe Team, type: :model, wip: true do
   it_behaves_like 'HasSeason'
 
   describe 'associations' do
@@ -422,42 +422,46 @@ RSpec.describe Team, type: :model do
   end
 
   describe '#display_name' do
-    context 'with a project name' do
-      before { subject.project_name = 'Sinatra' }
+    subject(:display_name) { team.display_name }
 
-      it 'returns "Team Sinatra" if no name given' do
-        expect(subject.display_name).to eql 'Team Sinatra'
-      end
+    let(:team)    { build(:team, :in_current_season, name: 'Blue') }
+    let(:project) { build(:project, name: 'Sinatra') }
 
-      it 'returns "Team Blue" if name given' do
-        subject.name = 'Blue'
-        expect(subject.display_name).to eql 'Team Blue (Sinatra)'
+    it 'returns "Team" and the name' do
+      expect(display_name).to eq('Team Blue')
+    end
+
+    context 'when the name already contains "Team"' do
+      let(:team) { build(:team, name: 'Team Paperplane') }
+
+      it 'does no prepend "Team"' do
+        expect(display_name).to eq('Team Paperplane')
       end
     end
 
-    context 'with season information' do
-      subject { described_class.new season: season, name: 'Cheesy' }
+    context 'with a project assigned' do
+      before { team.project = project }
 
-      context 'for a current team' do
-        let(:season) { Season.current }
-
-        it 'will not display the year' do
-          expect(subject.display_name).to eql 'Team Cheesy'
-        end
-      end
-
-      context 'for a past team' do
-        let(:season) { create :season, name: Date.today.year - 1 }
-
-        it 'will append the year' do
-          expect(subject.display_name).to eql "Team Cheesy [#{season.name}]"
-        end
+      it 'prepends the project name' do
+        expect(display_name).to eq('Team Blue (Sinatra)')
       end
     end
 
-    it 'will not prepend "Team" if already in place' do
-      subject.name = "Team Three Headed Monkey"
-      expect(subject.display_name).to eql "Team Three Headed Monkey"
+    context 'with a project but no name' do
+      let(:team) { build(:team, name: nil, project: project) }
+
+      it 'uses only the project name if the team name is missing' do
+        expect(display_name).to eq('Team Sinatra')
+      end
+    end
+
+    context 'when from a past season' do
+      let(:team)   { build(:team, name: 'Cheesy', season: season, project: project) }
+      let(:season) { build(:season, name: '1999') }
+
+      it 'appends the season name' do
+        expect(display_name).to eq('Team Cheesy (Sinatra) [1999]')
+      end
     end
   end
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Team, type: :model, wip: true do
+RSpec.describe Team, type: :model do
   it_behaves_like 'HasSeason'
 
   describe 'associations' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -447,14 +447,6 @@ RSpec.describe Team, type: :model do
       end
     end
 
-    context 'with a project but no name' do
-      let(:team) { build(:team, name: nil, project: project) }
-
-      it 'uses only the project name if the team name is missing' do
-        expect(display_name).to eq('Team Sinatra')
-      end
-    end
-
     context 'when from a past season' do
       let(:team)   { build(:team, name: 'Cheesy', season: season, project: project) }
       let(:season) { build(:season, name: '1999') }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,9 +1,16 @@
 require 'capybara-screenshot/rspec'
 require 'selenium/webdriver'
 
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[headless disable-gpu --window-size=1024,1300] }
+  )
+  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
+end
+
 Capybara.configure do |config|
-  config.default_driver = :selenium_chrome_headless
-  config.javascript_driver = :selenium_chrome_headless
+  config.default_driver = :headless_chrome
+  config.javascript_driver = :headless_chrome
 
   config.server_port = 8888 + ENV['TEST_ENV_NUMBER'].to_i
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -8,6 +8,11 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
 end
 
+# Enable new driver to save screenshots
+Capybara::Screenshot.register_driver(:headless_chrome) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+
 Capybara.configure do |config|
   config.default_driver = :headless_chrome
   config.javascript_driver = :headless_chrome


### PR DESCRIPTION
This is supposed to fix #892 : replaying `team#project_name` with an actual _(already existing but not used)_ association between `project` and `team`. 

This includes:
- migrating existing data
- enabling orga to choose the project for a team
  _(one can only a project from the same season as the team)_
- ⚠️ no longer allow teams to change their project
  _(not sure if this was allowed on purpose before - it does not really make sense to me)_
- some new settings for our headless Chrome driver 🤡 
  _(we have to set the window size to something closer to real-world -> otherwise bootstrap will hide certain elements and make expectations harder..)_

I'm pretty sure this will also require some more changes to where certain links are displayed, etc. But for now I think this simply migrates the existing behavior to a new datamodel.

One potential 💣 I found on the way: the `HasSeason` concern does not **require** things to have a season... However, I think in most cases this should actually be enforced in order to not break half of the queries we're doing.
☝️ If anyone knows reason why this was not required - please tell me 🙏 