### PR TITLE
Fixes #1024 : Resolves Bug in Activity Section

### DIFF
--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -90,8 +90,3 @@ nav.page
     span Activities
     = link_to '<span>Atom Feed</span>'.html_safe, activities_path(format: :atom, team_id: @team.id), class: 'atom'
   = render 'activities/activities', object: @team.activities.ordered
-- if @team.activities.any?
-  h3
-    span Activities
-    = link_to '<span>Atom Feed</span>'.html_safe, activities_path(format: :atom, team_id: @team.id), class: 'atom'
-  = render 'activities/activities', object: @team.activities.ordered


### PR DESCRIPTION
Activity in the team section seems to appear twice beacause of some repeated code in
the `show.html.slim` file. This commit resolves this bug by deleting the extra bit of repeated code.

Cheers!

Related issue #1024 

<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
 - Tests are much appreciated. 
 - Add screenshots if your PR includes visual/UI changes
---->

