### PR TITLE
Fine-tune year selector on teams page (Issue #895)

### DIFF
--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -39,7 +39,7 @@ class Season < ApplicationRecord
     end
 
     def all_years
-      pluck(:name)
+      where("name <= ?", Date.today.year.to_s).pluck(:name)    
     end
   end
 

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -39,7 +39,7 @@ class Season < ApplicationRecord
     end
 
     def all_years
-      where("name <= ?", Date.today.year.to_s).pluck(:name)    
+      where("name <= ?", Date.today.year.to_s).order(:name).pluck(:name)    
     end
   end
 

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -8,7 +8,7 @@ nav.actions
       | Select by Year
       span.caret<
     ul.dropdown-menu role="menu"
-      - Season.all_years.sort.each do |year|
+      - Season.all_years.each do |year|
         li
          a data-behaviour="switch-teams-year" data-value=year =year
 

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -5,10 +5,10 @@ nav.actions
     = 'Sign up to create your own team!' unless current_user
   div.pull-right.dropdown
     button.btn.btn-default.dropdown-toggle data-toggle="dropdown"
-      | Past Teams
+      | Select by Year
       span.caret<
     ul.dropdown-menu role="menu"
-      - Season.all_years.each do |year|
+      - Season.all_years.sort.each do |year|
         li
          a data-behaviour="switch-teams-year" data-value=year =year
 

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -233,9 +233,11 @@ RSpec.describe Season, type: :model do
   end
 
   describe '.all_years' do
-    it 'return array of years' do
+    it 'returns array of years that includes succeeding year only if succeeding year is equal to current year' do
+      next_year = (Date.today.year + 1).to_s
       create :season, name: '2015'
       create :season, name: '2016'
+      create :season, name: next_year
       expect(Season.all_years).to match_array ['2015', '2016']
     end
   end


### PR DESCRIPTION
Related issue #895 

Addresses the following items from the above-referenced issue:
- [x]   Change the text on the button to 'Select by year'
- [x]   Display the years in order
  - Add `order(:name)` clause to `Season.all_years` query
- [x]   Do not display the succeeding year in the dropdown list, unless the succeeding year is the current year
  - Add `where` clause to `Season.all_years` to filter out succeeding years that are not equal to the current year. `Season.all_years` is only invoked in the teams index, so it seemed more appropriate to revise the method versus create a new method. 
  - Add objects to `Season.all_years` test in  season_spec to ensure filtering functionality works. Update text in `it` block to more accurately describe what the method achieves.


**NOTE:** Tests were run locally. All are passing with the exception of `1) Season.transition? on New Year's should not be transition (#./spec/models/season_spec.rb:208)`, which I can confirm was failing prior to the above changes.


