### PR TITLE
Remove 'Time now' and 'Conferences' columns from Community user listings table (#945)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -189,16 +189,6 @@ module ApplicationHelper
     end
   end
 
-  def time_for_user(user)
-    if !user.timezone.blank?
-      Time.use_zone(user.timezone) do
-        localize(Time.zone.now, format: '%I:%M %p')
-      end
-    else
-      '-'
-    end
-  end
-
   def list_all_timezones
     TIMEZONES
   end

--- a/app/views/community/index.html.slim
+++ b/app/views/community/index.html.slim
@@ -22,8 +22,6 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
       th = sortable :team
       th = sortable :country
       th = sortable :location, User.human_attribute_name(:location)
-      th Time now
-      / th Conferences
 
   tbody
     - @users.each do |user|
@@ -37,8 +35,6 @@ table.users.table.table-striped.table-bordered.table-condensed.table-hover
         td = link_to_user_roles(user)
         td = user.country
         td = user.location
-        td = time_for_user(user)
-        / td = links_to_conferences(user.conferences.in_current_season).join(', ').html_safe
         - if signed_in? && !Rails.env.production?
           td = render 'users/impersonate', user: user if user != current_user
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -142,26 +142,4 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(role_names(@team, @user)).to eql 'Coach, Mentor'
     end
   end
-
-  describe '.time_for_user' do
-    let(:user) { create(:user, timezone: "Europe/Rome") }
-
-    before do
-      Timecop.travel(Time.utc(2013, 5, 2, "12:00"))
-    end
-
-    it 'returns the time based on a users timezone' do
-      expect(time_for_user(user)).to eq("02:00 PM")
-    end
-
-    it 'returns a dash when no timezone set' do
-      allow(user).to receive(:timezone).and_return(nil)
-      expect(time_for_user(user)).to eq("-")
-    end
-
-    it 'returns a dash when timezone is empty' do
-      allow(user).to receive(:timezone).and_return("")
-      expect(time_for_user(user)).to eq("-")
-    end
-  end
 end


### PR DESCRIPTION
Related issue #945

Addresses the following items in the above-referenced issue:

- [x] Removes 'Time now' column from user listings table
- [x] Deletes previously commented-out 'Conferences' column from the user listings table

Additionally, as per the comments below, I have deleted the `time_for_user` helper method and associated spec, as it is no longer referenced in the application.

<img width="1260" alt="screen shot 2018-07-14 at 11 31 58 am" src="https://user-images.githubusercontent.com/19535775/42727277-d7277bc2-8760-11e8-9b60-a5d2157a1642.png">
