### PR TITLE
Delete Comments with User

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,12 +176,10 @@ module ApplicationHelper
   end
 
   def user_for_comment(comment)
-    if comment.user.nil?
-      "Deleted user"
-    elsif comment.user == current_user
-      "You"
+    if comment.user == current_user
+      'You'
     elsif comment.user.admin?
-      comment.user.name + " " + content_tag(:small) do
+      comment.user.name + ' ' + content_tag(:small) do
         content_tag(:span, 'RGSoC', class: 'label label-primary')
       end
     else

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Comment < ApplicationRecord
-  belongs_to :user, optional: true
-  belongs_to :commentable, polymorphic: true, optional: true
+  belongs_to :user
+  belongs_to :commentable, polymorphic: true
 
   scope :recent, -> { order('created_at DESC').limit(3) }
   scope :ordered, -> { order('created_at DESC, id DESC') }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,7 @@ class User < ApplicationRecord
   has_many :application_drafts, through: :teams
   has_many :applications, through: :teams
   has_many :todos, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   validates :github_handle, presence: true, uniqueness: { case_sensitive: false }
   validates :homepage, format: { with: URL_PREFIX_PATTERN }, allow_blank: true

--- a/db/migrate/20180714153306_remove_comments_without_user.rb
+++ b/db/migrate/20180714153306_remove_comments_without_user.rb
@@ -1,0 +1,9 @@
+class RemoveCommentsWithoutUser < ActiveRecord::Migration[5.1]
+  def up
+    execute <<~SQL
+      DELETE
+      FROM comments
+      WHERE user_id NOT IN (SELECT id FROM users)
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180706121823) do
+ActiveRecord::Schema.define(version: 20180714153306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-performing_deliveries = ActionMailer::Base.perform_deliveries
+# NOTE: we do not want to send any email when seeding the database
 ActionMailer::Base.perform_deliveries = false
 
 # Teams
@@ -50,5 +50,3 @@ FactoryBot.create(:project, :rejected, :in_current_season)
     ends_on: random_date + rand(2.days)
   )
 end
-
-ActionMailer::Base.perform_deliveries = performing_deliveries

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :comment do
+    association :commentable, factory: :project
     user
     text { FFaker::CheesyLingo.paragraph }
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
+  describe '#user_for_comment', :wip do
+    subject { helper.user_for_comment(comment) }
+
+    let(:user)    { create(:user, name: 'Alice') }
+    let(:comment) { create(:comment, user: user) }
+
+    before { allow(helper).to receive(:current_user) }
+
+    it { is_expected.to eq('Alice') }
+
+    context 'when the comment is by the current_user' do
+      before { allow(helper).to receive(:current_user).and_return(user) }
+
+      it { is_expected.to eq('You') }
+    end
+
+    context 'when the comment is by an admin' do
+      let(:user)       { create(:organizer, name: 'Eva') }
+      let(:with_label) { 'Eva <small><span class="label label-primary">RGSoC</span></small>' }
+
+      it { is_expected.to eq(with_label) }
+    end
+
+    context 'when the comment is by a currently logged in admin' do
+      let(:user) { create(:organizer, name: 'Eva') }
+
+      before { allow(helper).to receive(:current_user).and_return(user) }
+
+      it { is_expected.to eq('You') }
+    end
+  end
+
   describe '#application_disambiguation_link' do
     let(:draft) { create :application_draft }
     let(:user)  { create :user }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
-  describe '#user_for_comment', :wip do
+  describe '#user_for_comment' do
     subject { helper.user_for_comment(comment) }
 
     let(:user)    { create(:user, name: 'Alice') }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:user).optional }
-    it { is_expected.to belong_to(:commentable).optional }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:commentable) }
   end
 
   describe 'scopes' do

--- a/spec/models/mentor/application_spec.rb
+++ b/spec/models/mentor/application_spec.rb
@@ -180,7 +180,8 @@ RSpec.describe Mentor::Application, type: :model do
   end
 
   describe '#find_or_initialize_comment_by(mentor)' do
-    let(:mentor_application) { described_class.new(id: 1) }
+    let!(:application)       { create(:application) }
+    let(:mentor_application) { described_class.new(id: application.id) }
     let(:mentor)             { create(:mentor) }
 
     subject { mentor_application.find_or_initialize_comment_by(mentor) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:application_drafts).through(:teams) }
     it { is_expected.to have_many(:applications).through(:teams) }
     it { is_expected.to have_many(:todos).dependent(:destroy) }
+    it { is_expected.to have_many(:comments).dependent(:destroy) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
This is another quick _"fix"_ vaguely related to GDPR things: remove a user's comments when they delete their account. While that, I made both associations (`user` and `commentable`) required on the `comment` model. Comments without these two things are useless for us.

I also realized that the `seeds.rb` file somehow hangs forever for me... I simplified it a bit without breaking changes.

While looking at the comments table, I also realized that the whole `Mentor::Comment` thing is eventually too much of hack and may not be fully compatible with Rails 5 🙈. I'll probably look into refactoring this again next... 😉 