### PR TITLE
Issue 1012 - Supervisor unable to see team member email if hide_email: true

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,6 +46,11 @@ class Ability
     end
 
     # supervisor
+    if user.supervisor?
+      can :read, :all, User do |other_user|
+        supervises?(User.find_by_email(other_user), user)
+      end
+    end
     # Use old code, see below
 
     # project submitter
@@ -67,9 +72,6 @@ class Ability
     # visibility of email address in user profile
     can :read_email, User, id: user.id if !user.hide_email?
     can :read_email, User if user.admin?
-    can :read_email, User do |other_user|
-      user.confirmed? && (supervises?(other_user, user) || !other_user.hide_email?)
-    end
     can :read, :users_info if user.admin? || user.supervisor?
 
 

--- a/spec/models/ability/team_member_spec.rb
+++ b/spec/models/ability/team_member_spec.rb
@@ -61,16 +61,12 @@ RSpec.describe Ability, type: :model do
       end
 
       context "when viewing user information" do
-
-        # FIXME see issue #1001
-        # The following specs should pass after fixing
         before do
           team_member.update!(hide_email: true)
           user_in_other_team.update!(hide_email: true)
         end
 
         it "can read email address of team members in current season, even when hidden" do
-          pending 'fails; To be solved with issue #1001'
           allow(subject).to receive(:supervises?).with(team_member, user).and_return true
           expect(subject).to be_able_to(:read, team_member.email)
         end


### PR DESCRIPTION
Related issue #1012

<!----Describe what this PR is about:
 - What feature does it add, which bug does it fix? 
    Supervisor was unable to see a team member's email if hide_email: true
 - Tests are much appreciated. 
    Test had already been built, but was pending.
 - Add screenshots if your PR includes visual/UI changes
---->

While this does result in a passing test, giving the supervisor the ability to see a team member's email regardless of hide_email flag being turned on, it also allows the supervisor to read all attributes for that team member. This is likely a result of me not fully understanding the codebase yet. I tried to emulate some of the other methodology/syntax present in the models/ability.rb file but was unsuccessful. The strangest part for me is that the 'other_user' (models/ability.rb:51-52) is only an email and not actually a User, hence the find_by_email. If this solution is unacceptable I would be happy to continue working on the issue until I have found the best option. Thanks!