### PR TITLE
Fix minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ it 'is an interesting example', driver: :selenium_chrome do
 end
 ```
 
-### Code Analyzation
+### Code Analysis 
 
 You can run automatic code analyzers to check if your code complies to the project's guidelines and general best practice.
 


### PR DESCRIPTION
Unless I'm wrong, [analyzation](https://english.stackexchange.com/questions/314968/use-of-the-word-analyzation-in-formal-writing) isn't a correct use of the word. Should be analysis.
