### PR TITLE
Fix flaky specs

### DIFF
--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -30,9 +30,5 @@ FactoryBot.define do
     trait :in_current_season do
       season { Season.current }
     end
-
-    trait :in_last_season do
-      season { Season.find_or_create_by name: (Date.today.year - 1) }
-    end
   end
 end

--- a/spec/factories/season.rb
+++ b/spec/factories/season.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   end
 
   trait :past do
-    name '2010'
+    name '1999'
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -23,18 +23,18 @@ RSpec.describe Project, type: :model do
       subject(:selected) { described_class.selected }
 
       let!(:current_season) { Season.current }
-      let!(:other_season)   { create(:season) }
+      let!(:past_season)    { create(:season, :past) }
 
       let!(:project1) { create(:project, season: current_season) }
       let!(:project2) { create(:project, :accepted, season: current_season) }
       let!(:project3) { create(:project, :accepted, season: current_season) }
       let!(:project4) { create(:project, :accepted, season: current_season) }
-      let!(:project5) { create(:project, :accepted, season: other_season) }
+      let!(:project5) { create(:project, :accepted, season: past_season) }
 
       before do
         create(:team, kind: 'full_time', project: project3, season: current_season)
         create(:team, kind: nil, project: project4, season: current_season)
-        create(:team, kind: 'full_time', project: project5, season: other_season)
+        create(:team, kind: 'full_time', project: project5, season: past_season)
       end
 
       it 'returns only accepted projects with accepted teams' do
@@ -42,7 +42,7 @@ RSpec.describe Project, type: :model do
       end
 
       context 'when passing a specific season' do
-        subject(:selected) { described_class.selected(season: other_season) }
+        subject(:selected) { described_class.selected(season: past_season) }
 
         it 'returns only accepted projects with accepted teams from that season' do
           expect(selected).to contain_exactly(project5)


### PR DESCRIPTION
This is supposed to prevent the flakyness visible in #1037. One can run into the failing specs with this seed:

    bundle exec rspec --seed 6251

The reason behind this: the traits in the `season` and `project` factories may result in colliding names for `seasons` -> which makes the record invalid.

To prevent this, I updated both factories, adapting the traits (removing an unused one).