### PR TITLE
Support OAuth callback proxy app

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,8 @@ The Heroku scheduler is set to run these tasks:
 ### Camo
 
 Both apps on Heroku use [camo](https://github.com/atmos/camo) to proxy insecure images in activity logs. For this to work, the `CAMO_HOST` and `CAMO_KEY` environment variables need to be set in Heroku's configuration for the app.
+
+### OAuth Callback for Review Apps
+
+In order to allow Github logins for our dynamically created PR review apps, the OAuth workflow is
+intercepted by [a simple web app that](https://github.com/rails-girls-summer-of-code/rgsoc-teams-oauth-callback-proxy). Please refer to its README for deployment and setup instructions.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,10 +4,15 @@
 GITHUB_APP_ID     = Rails.env.production? ? ENV['GITHUB_APP_ID']     : 'cc17063f6602cc4878ff'
 GITHUB_APP_SECRET = Rails.env.production? ? ENV['GITHUB_APP_SECRET'] : 'e93988593b6f7bfa1d0ff2cf10438ee3e547f8a4'
 
+# Set this to "https://rgsoc-teams-pr-oauth-proxy.herokuapp.com/oauth-proxy" for staging and review apps,
+# leave blank to stick with OmniAuth's default of "<scheme>://<host>/users/auth/github/callback":
+GITHUB_OAUTH_CALLBACK_URI = ENV['GITHUB_OAUTH_CALLBACK_URI']
+
 # OmniAuth.config.full_host = "http://localhost:3000" # wat, keeps missing the port for the redirect_uri without this
 
 Devise.setup do |config|
-  config.omniauth :github, GITHUB_APP_ID, GITHUB_APP_SECRET, scope: 'user:email'
+  config.omniauth :github, GITHUB_APP_ID, GITHUB_APP_SECRET, scope: 'user:email',
+    client_options: { redirect_uri: GITHUB_OAUTH_CALLBACK_URI }
   config.secret_key = ENV['DEVISE_SECRET'] || 'adc96b68ccb1630810f073823ea5f942df52649385b04e18223b845dd66c7f48ca9641ca2ed456ae4755fbb24f7b08e2ceaeaa21cac8e0aead38a9f60e831392'
 
   # ==> Mailer Configuration


### PR DESCRIPTION
# Why
* Github's OAuth apps (required to enable people to login with their Github account) allow only one callback url. We have different OAuth apps set up for dev, staging, and prod.
* The PR review apps are created with a dynamic hostname that will break the static, preconfigured callback setting.

# How
* We configure apps to redirect to an auxiliary app that does nothing more than doing a basic validity check and forwarding the validated OAuth request back to the staging or PR review app that initiated the OAuth process
* The code for that proxy app is here: https://github.com/rails-girls-summer-of-code/rgsoc-teams-oauth-callback-proxy 🔒 

# Testing / QA
* Configure [our OAuth app for staging](https://github.com/organizations/rails-girls-summer-of-code/settings/applications/48873) 🔒 to use the proxy app as its callback URI.
* Attempt to login with your github account from staging and a PR review app (should redirect to the proxy app when clicking on "login"; check your browser's network tab) as well as from a locally checked out Teams App running on localhost:3000 (should not touch the proxy app)