### PR TITLE
Silence deprecation warnings

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,7 +100,7 @@ class User < ApplicationRecord
         order = ORDERS.fetch(:name)
       end
 
-      scope = order("#{order} #{direction}").references(:teams)
+      scope = order(Arel.sql("#{order} #{direction}")).references(:teams)
       scope = scope.joins(:teams).references(:teams) if order == :team
       scope
     end

--- a/app/services/exporters/conference_preferences.rb
+++ b/app/services/exporters/conference_preferences.rb
@@ -4,7 +4,6 @@ module Exporters
   class ConferencePreferences < Base
     def current
       preferences = ConferencePreference.current_teams
-      team_max_offer = Team.joins(:conference_attendances).group("teams.id").order("count(teams.id) DESC").first
       max_offer = team_max_offer&.conference_attendances&.size || 0
 
       header = 'Team name', 'Team location', 'Project name', 'Conference primary choice', 'Conference secondary choice', 'We would like to give a LT', 'Comments', 'Terms accepted'
@@ -21,6 +20,15 @@ module Exporters
         end
         team_preferences
       end
+    end
+
+    private
+
+    def team_max_offer
+      Team.joins(:conference_attendances)
+          .group('teams.id')
+          .order(Arel.sql('count(teams.id) DESC'))
+          .first
     end
   end
 end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe ActivitiesController, type: :controller do
     context 'as feed' do
       it 'renders json' do
         get :index, format: :json
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
       end
 
       it 'renders atom' do
         get :index, format: :atom
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
       end
 
       it 'will not display mailings' do

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ConferencesController, type: :controller do
 
     it 'displays all of this season\'s conferences' do
       get :index
-      expect(response).to be_success
+      expect(response).to have_http_status(:success)
       expect(assigns(:conferences)).to match_array [current_conference]
     end
   end

--- a/spec/controllers/organizers/conferences_controller_spec.rb
+++ b/spec/controllers/organizers/conferences_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Organizers::ConferencesController, type: :controller do
     describe 'GET index' do
       it 'renders the index template' do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response).to render_template 'index'
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Organizers::ConferencesController, type: :controller do
 
       it 'refuses other formats' do
         post :import, format: :json, params: { file: file }
-        expect(response).not_to be_success
+        expect(response).not_to have_http_status(:success)
       end
 
       it 'catches error when file is omitted' do

--- a/spec/controllers/organizers/exports_controller_spec.rb
+++ b/spec/controllers/organizers/exports_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Organizers::ExportsController, type: :controller do
     describe 'GET index' do
       it 'renders a form' do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
       end
     end
 
@@ -19,7 +19,7 @@ RSpec.describe Organizers::ExportsController, type: :controller do
       it 'sends CSV data as attachment' do
         filename_matcher = /attachment; filename="exporters-teams_current\.csv/
         post :create, params: { export: "Exporters::Teams#current" }
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response.headers["Content-Disposition"]).to match filename_matcher
         expect(response.headers["Content-Type"]).to eq "text/csv"
       end

--- a/spec/controllers/organizers/mailings_controller_spec.rb
+++ b/spec/controllers/organizers/mailings_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Organizers::MailingsController, type: :controller do
     describe 'GET index' do
       it 'renders the index template' do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response).to render_template 'index'
       end
     end
@@ -21,7 +21,7 @@ RSpec.describe Organizers::MailingsController, type: :controller do
     describe 'GET show' do
       it 'shows a mailing' do
         get :show, params: { id: mailing.to_param }
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response).to render_template 'show'
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe Organizers::MailingsController, type: :controller do
     describe 'GET edit' do
       it 'renders the edit template' do
         get :edit, params: { id: mailing.to_param }
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response).to render_template 'edit'
       end
     end

--- a/spec/controllers/organizers/projects_controller_spec.rb
+++ b/spec/controllers/organizers/projects_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Organizers::ProjectsController, type: :controller do
     describe 'GET index' do
       it 'renders the index template' do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response).to render_template 'index'
       end
     end

--- a/spec/controllers/organizers/seasons_controller_spec.rb
+++ b/spec/controllers/organizers/seasons_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Organizers::SeasonsController, type: :controller do
     describe 'GET new' do
       it 'renders the new template' do
         get :new
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response).to render_template 'new'
       end
     end
@@ -21,7 +21,7 @@ RSpec.describe Organizers::SeasonsController, type: :controller do
     describe 'GET index' do
       it 'renders the index template' do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response).to render_template 'index'
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe Organizers::SeasonsController, type: :controller do
     describe 'GET edit' do
       it 'renders the edit template' do
         get :edit, params: { id: season.to_param }
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response).to render_template 'edit'
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe Organizers::SeasonsController, type: :controller do
     describe 'GET show' do
       it 'renders the show template' do
         get :show, params: { id: season.to_param }
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response).to render_template 'show'
       end
     end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ProjectsController, type: :controller do
 
       it 'hides rejected projects' do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response.body).to include 'proposed project'
         expect(response.body).to include 'accepted project'
         expect(response.body).not_to include 'rejected project'
@@ -32,7 +32,7 @@ RSpec.describe ProjectsController, type: :controller do
 
       it 'shows selected projects only' do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response.body).to include "selected by a team"
         expect(response.body).not_to include 'project without team'
         expect(response.body).not_to include 'proposed project'
@@ -49,7 +49,7 @@ RSpec.describe ProjectsController, type: :controller do
 
       it 'shows selected projects in past season only' do
         get :index, params: { filter: '2017' }
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response.body).to include "selected by a team 2017"
         expect(response.body).not_to include "selected by a team (current)"
         expect(response.body).not_to include 'project without team 2017'
@@ -67,7 +67,7 @@ RSpec.describe ProjectsController, type: :controller do
       it 'requires a login' do
         expect { get :new }.to \
           change { session[:previous_url_login_required] }
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(response.body).to match user_github_omniauth_authorize_path
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe ProjectsController, type: :controller do
 
         it 'returns success' do
           get :new
-          expect(response).to be_success
+          expect(response).to have_http_status(:success)
         end
 
         it "assigns a new project as @project" do
@@ -96,7 +96,7 @@ RSpec.describe ProjectsController, type: :controller do
   describe 'GET show' do
     it 'returns the project page' do
       get :show, params: { id: project.to_param }
-      expect(response).to be_success
+      expect(response).to have_http_status(:success)
     end
   end
 

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe TeamsController, type: :controller do
 
       it 'only displays this season\'s accepted teams' do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
         expect(assigns(:teams)).to match_array [full_time_team]
       end
     end
@@ -87,7 +87,7 @@ RSpec.describe TeamsController, type: :controller do
 
     it 'lists the team conference preferences' do
       get :show, params: { id: team.id }
-      expect(response).to be_success
+      expect(response).to have_http_status(:success)
       expect(response.body).to match preference.first_conference.name
       expect(response.body).to match preference.second_conference.name
     end
@@ -111,7 +111,7 @@ RSpec.describe TeamsController, type: :controller do
       it "assigns the requested team as @team" do
         get :edit, params: { id: team.to_param }
         expect(assigns(:team)).to eq(team)
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
       end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UsersController, type: :controller do
         # attendences used to stick around when their conference was deleted
         it 'will not list conferences preferences w/o conference' do
           get :show, params: { id: user.to_param }
-          expect(response).to be_success
+          expect(response).to have_http_status(:success)
           expect(response.body).not_to match conference.name
         end
       end

--- a/spec/requests/application_process_spec.rb
+++ b/spec/requests/application_process_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'The Application Process', type: :request do
 
             it 'complains about the user data being incomplete' do
               get '/apply'
-              expect(response).to be_success
+              expect(response).to have_http_status(:success)
               expect(response.body).to include 'Your user profile is incomplete'
             end
           end

--- a/spec/requests/frontpage_spec.rb
+++ b/spec/requests/frontpage_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Browsing the front page', type: :request do
 
     it 'renders the activity log' do
       get '/'
-      expect(response).to be_success
+      expect(response).to have_http_status(:success)
     end
 
     context 'as a user with a funny timezone' do
@@ -16,7 +16,7 @@ RSpec.describe 'Browsing the front page', type: :request do
 
       it 'will not fail on timezone settings' do
         get '/'
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
       end
     end
   end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ProjectsController, type: :request do
 
           it 'returns to the previous page' do
             get use_as_template_project_path(project)
-            expect(response).to be_success
+            expect(response).to have_http_status(:success)
             expect(response.body).to match project.name
           end
         end

--- a/spec/support/shared_examples/redirect_for_non_admins.rb
+++ b/spec/support/shared_examples/redirect_for_non_admins.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples 'redirects for non-admins' do |method: 'get', action: 'ind
 
       it 'allows the controller action' do
         send(method, action, *args)
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
       end
     end
   end

--- a/spec/support/shared_examples/redirect_for_non_students.rb
+++ b/spec/support/shared_examples/redirect_for_non_students.rb
@@ -55,7 +55,7 @@ RSpec.shared_examples 'redirects for non-users' do
 
       it 'allows access' do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:success)
       end
     end
   end


### PR DESCRIPTION
Another follow up to #1137 : silence the deprecation warnings this update introduce. These are mainly two things:
1. get rid of the `success` predicate method in specs _(in favor of `have_http_status(:success)`)_
2. Wrap raw SQL snippets in `Arel.sql`

**Note**: this is based upon #1141 