### PR TITLE
Temporarily silence flaky spec

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,28 +32,6 @@ Layout/AlignParameters:
     - 'spec/models/mentor/application_spec.rb'
     - 'spec/support/shared_examples/rateable.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleAlignWith.
-# SupportedStylesAlignWith: either, start_of_block, start_of_line
-Layout/BlockAlignment:
-  Exclude:
-    - 'spec/controllers/organizers/teams_controller_spec.rb'
-    - 'spec/models/ability_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/ClosingParenthesisIndentation:
-  Exclude:
-    - 'app/controllers/application_drafts_controller.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-Layout/CommentIndentation:
-  Exclude:
-    - 'app/controllers/teams_info_controller.rb'
-    - 'app/models/team_performance.rb'
-
 # Offense count: 20
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
@@ -682,15 +660,6 @@ Rails/FilePath:
     - 'config/environments/development.rb'
     - 'spec/rails_helper.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/FindBy:
-  Exclude:
-    - 'app/models/student.rb'
-    - 'app/models/team.rb'
-
 # Offense count: 6
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb
@@ -700,14 +669,6 @@ Rails/HasManyOrHasOneDependent:
     - 'app/models/project.rb'
     - 'app/models/season.rb'
     - 'app/models/user.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: numeric, symbolic
-Rails/HttpStatus:
-  Exclude:
-    - 'spec/controllers/conferences_controller_spec.rb'
 
 # Offense count: 9
 # Configuration parameters: Include.
@@ -746,18 +707,6 @@ Rails/OutputSafety:
     - 'app/helpers/applications_helper.rb'
     - 'app/helpers/projects_helper.rb'
     - 'app/inputs/character_limited_input.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Rails/PluralizationGrammar:
-  Exclude:
-    - 'spec/helpers/nav_helper_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Rails/Presence:
-  Exclude:
-    - 'app/models/application.rb'
 
 # Offense count: 7
 # Configuration parameters: Blacklist.
@@ -848,12 +797,6 @@ Style/BracesAroundHashParameters:
     - 'spec/models/todo_spec.rb'
     - 'spec/models/user_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/ColonMethodCall:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-
 # Offense count: 9
 # Cop supports --auto-correct.
 # Configuration parameters: Keywords.
@@ -902,12 +845,6 @@ Style/DoubleNegation:
     - 'app/models/mentor/application.rb'
     - 'app/models/user.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/EmptyLambdaParameter:
-  Exclude:
-    - 'app/models/source.rb'
-
 # Offense count: 13
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
@@ -923,12 +860,6 @@ Style/EmptyMethod:
     - 'app/controllers/students/status_updates_controller.rb'
     - 'app/controllers/users_controller.rb'
     - 'db/migrate/20180307150111_add_submitters_as_maintainers.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/EvenOdd:
-  Exclude:
-    - 'app/models/concerns/rateable.rb'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -979,47 +910,10 @@ Style/IfUnlessModifier:
     - 'app/models/rating_criterium.rb'
     - 'lib/redcarpet_camo_renderer.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: line_count_dependent, lambda, literal
-Style/Lambda:
-  Exclude:
-    - 'app/models/project.rb'
-    - 'app/models/team.rb'
-    - 'spec/controllers/roles_controller_spec.rb'
-    - 'spec/controllers/teams_controller_spec.rb'
-    - 'spec/models/selection/strictness_spec.rb'
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: call, braces
-Style/LambdaCall:
-  Exclude:
-    - 'lib/tasks/single_run.rake'
-    - 'spec/controllers/roles_controller_spec.rb'
-    - 'spec/controllers/teams_controller_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/LineEndConcatenation:
-  Exclude:
-    - 'spec/helpers/application_helper_spec.rb'
-
 # Offense count: 1
 Style/MissingRespondToMissing:
   Exclude:
     - 'app/services/exporters/base.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: separated, grouped
-Style/MixinGrouping:
-  Exclude:
-    - 'app/models/application.rb'
-    - 'app/models/team.rb'
 
 # Offense count: 2
 Style/MixinUsage:
@@ -1032,36 +926,12 @@ Style/MixinUsage:
 Style/MutableConstant:
   Enabled: false
 
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: both, prefix, postfix
-Style/NegatedIf:
-  Exclude:
-    - 'app/models/ability.rb'
-    - 'app/models/rating_criterium.rb'
-    - 'app/models/team_performance.rb'
-
 # Offense count: 86
 # Cop supports --auto-correct.
 # Configuration parameters: Whitelist.
 # Whitelist: be, be_a, be_an, be_between, be_falsey, be_kind_of, be_instance_of, be_truthy, be_within, eq, eql, end_with, include, match, raise_error, respond_to, start_with
 Style/NestedParenthesizedCalls:
   Enabled: false
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, MinBodyLength.
-# SupportedStyles: skip_modifier_ifs, always
-Style/Next:
-  Exclude:
-    - 'lib/tasks/single_run.rake'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/Not:
-  Exclude:
-    - 'app/models/ability.rb'
 
 # Offense count: 14
 # Cop supports --auto-correct.
@@ -1080,20 +950,6 @@ Style/NumericPredicate:
     - 'app/models/rating_criterium.rb'
     - 'app/models/team_performance.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/ParallelAssignment:
-  Exclude:
-    - 'app/mailers/project_mailer.rb'
-    - 'spec/models/project_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowSafeAssignment, AllowInMultilineConditions.
-Style/ParenthesesAroundCondition:
-  Exclude:
-    - 'app/controllers/comments_controller.rb'
-
 # Offense count: 66
 # Cop supports --auto-correct.
 # Configuration parameters: PreferredDelimiters.
@@ -1105,29 +961,6 @@ Style/PercentLiteralDelimiters:
 Style/PerlBackrefs:
   Exclude:
     - 'lib/feed/discovery.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: short, verbose
-Style/PreferredHashMethods:
-  Exclude:
-    - 'app/controllers/teams_controller.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/Proc:
-  Exclude:
-    - 'app/helpers/application_drafts_helper.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: compact, exploded
-Style/RaiseArgs:
-  Exclude:
-    - 'app/models/dev_utils/season_phase_switcher.rb'
-    - 'app/models/rating_criterium.rb'
 
 # Offense count: 4
 # Cop supports --auto-correct.
@@ -1156,12 +989,6 @@ Style/RegexpLiteral:
     - 'spec/mailers/application_form_mailer_spec.rb'
     - 'spec/requests/projects_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/RescueModifier:
-  Exclude:
-    - 'app/models/user.rb'
-
 # Offense count: 6
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
@@ -1173,31 +1000,6 @@ Style/RescueStandardError:
     - 'lib/feed.rb'
     - 'lib/feed/image.rb'
     - 'lib/feed/s3.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: ConvertCodeThatCanStartToReturnNil, Whitelist.
-# Whitelist: present?, blank?, presence, try, try!
-Style/SafeNavigation:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/models/student_application/student_attribute_proxy.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowAsExpressionSeparator.
-Style/Semicolon:
-  Exclude:
-    - 'spec/controllers/mentors/comments_controller_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: only_raise, only_fail, semantic
-Style/SignalException:
-  Exclude:
-    - 'app/models/mentor/application.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -1220,14 +1022,6 @@ Style/StderrPuts:
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
   Enabled: false
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiteralsInInterpolation:
-  Exclude:
-    - 'app/controllers/application_drafts_controller.rb'
 
 # Offense count: 2
 Style/StructInheritance:
@@ -1254,15 +1048,6 @@ Style/SymbolProc:
     - 'lib/selection/distance.rb'
     - 'spec/factories/projects.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, AllowSafeAssignment.
-# SupportedStyles: require_parentheses, require_no_parentheses, require_parentheses_when_complex
-Style/TernaryParentheses:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/url_helper.rb'
-
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.
@@ -1278,18 +1063,6 @@ Style/TrailingCommaInHashLiteral:
     - 'spec/factories/application.rb'
     - 'spec/lib/feed_spec.rb'
     - 'spec/lib/selection/service/flag_applications_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/UnlessElse:
-  Exclude:
-    - 'app/controllers/teams_controller.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/UnneededInterpolation:
-  Exclude:
-    - 'spec/controllers/organizers/projects_controller_spec.rb'
 
 # Offense count: 11
 # Cop supports --auto-correct.

--- a/Gemfile
+++ b/Gemfile
@@ -42,12 +42,14 @@ group :production do
 end
 
 group :development, :test do
-  gem 'byebug', require: !ENV['RM_INFO'] # require parameter is workaround for RubyMine with Rails ~> 4.1
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'ffaker'
-  gem 'pry'
   gem 'rspec-rails'
+
+  gem 'pry-byebug'
+  gem 'pry-doc'
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     builder (3.2.3)
-    byebug (10.0.2)
+    byebug (11.0.1)
     camo (0.1.0)
     cancancan (2.3.0)
     capybara (2.18.0)
@@ -227,9 +227,17 @@ GEM
     powerpack (0.1.2)
     pretender (0.3.4)
       actionpack (>= 4.2)
-    pry (0.11.3)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-doc (1.0.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.11.4)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -390,6 +398,7 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.0.0)
       nokogiri (~> 1.8)
+    yard (0.9.19)
 
 PLATFORMS
   ruby
@@ -402,7 +411,6 @@ DEPENDENCIES
   bootsnap
   bootstrap-kaminari-views
   bootstrap-sass
-  byebug
   camo
   cancancan
   capybara (~> 2.18)
@@ -424,7 +432,9 @@ DEPENDENCIES
   omniauth-github
   pg
   pretender
-  pry
+  pry-byebug
+  pry-doc
+  pry-rails
   puma
   rails (~> 5.2.3)
   rails-controller-testing

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < ActionController::Base
   end
 
   def require_role(role_name)
-    redirect_to '/', alert: "#{role_name.capitalize} required" unless current_user && current_user.roles.includes?(role_name)
+    redirect_to '/', alert: "#{role_name.capitalize} required" unless current_user&.roles&.includes?(role_name)
   end
 
   def login_required

--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class ApplicationDraftsController < ApplicationController
+  STUDENT_ATTRS = %i[name application_about application_motivation application_gender_identification
+                     application_diversity application_age application_coding_level
+                     application_community_engagement application_giving_back application_language_learning_period
+                     application_learning_history application_skills application_code_background application_goals
+                     application_code_samples application_location application_location_lat application_location_lng
+                     application_minimum_money application_money]
+
+  private_constant :STUDENT_ATTRS
+
   before_action :checktime, only: [:new, :create, :update]
   before_action :sign_in_required
   before_action :valid_user_profile_required, only: [:new, :create, :update]
@@ -29,7 +38,7 @@ class ApplicationDraftsController < ApplicationController
     application_draft.assign_attributes(application_draft_params)
     if application_draft.save
       update_student!
-      notice = "Your application draft was saved. You can access it under »#{view_context.link_to "My application", apply_path}«".html_safe
+      notice = "Your application draft was saved. You can access it under »#{view_context.link_to 'My application', apply_path}«".html_safe
       redirect_to [:edit, application_draft], notice: notice
     else
       render :new
@@ -94,16 +103,7 @@ class ApplicationDraftsController < ApplicationController
 
   def student_params
     if application_draft.as_student? and params[:student]
-      params[:student].fetch(current_user.id.to_s, {}).
-        permit(
-          :name, :application_about, :application_motivation, :application_gender_identification, :application_diversity, :application_age,
-          :application_coding_level, :application_community_engagement, :application_giving_back,
-          :application_language_learning_period,
-          :application_learning_history, :application_skills, :application_code_background, :application_goals,
-          :application_code_samples, :application_location,
-          :application_location_lat, :application_location_lng,
-          :application_minimum_money, :application_money
-      )
+      params[:student].fetch(current_user.id.to_s, {}).permit(*STUDENT_ATTRS)
     else
       {}
     end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,7 +11,7 @@ class CommentsController < ApplicationController
   def create
     @comment = Comment.new(comment_params)
 
-    if (@comment.text.present? && @comment.save)
+    if @comment.text.present? && @comment.save
       anchor = ActionView::RecordIdentifier.dom_id(@comment)
     else
       flash[:alert] = "Oh no! We can't save your comment. Please try again?"

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -99,12 +99,12 @@ class TeamsController < ApplicationController
   end
 
   def role_attributes_list
-    unless current_user.admin? ||
+    if current_user.admin? ||
       # If it contains an ID, the user is updating an existing role
-      params.fetch(:roles_attributes, {}).to_unsafe_h.none? { |_, attributes| attributes.has_key? 'id' }
-      [:id, :github_handle, :_destroy] # do not allow to update the actual role
-    else
+      params.fetch(:roles_attributes, {}).to_unsafe_h.none? { |_, attributes| attributes.key? 'id' }
       [:id, :name, :github_handle, :_destroy]
+    else
+      [:id, :github_handle, :_destroy] # do not allow to update the actual role
     end
   end
 

--- a/app/controllers/teams_info_controller.rb
+++ b/app/controllers/teams_info_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class TeamsInfoController < ApplicationController
-  # before_action :normalize_params, only: :index
   before_action { authorize!(:read, :teams_info) unless current_user.try(:admin?) }
 
   private
@@ -10,9 +9,4 @@ class TeamsInfoController < ApplicationController
     Team.ordered
   end
   helper_method :teams
-
-    # def normalize_params
-    #   params[:role] = 'all' if params[:role].blank?
-    #   params[:kind] = 'all' if params[:kind].blank?
-    # end
 end

--- a/app/helpers/application_drafts_helper.rb
+++ b/app/helpers/application_drafts_helper.rb
@@ -26,8 +26,8 @@ module ApplicationDraftsHelper
   end
 
   def private_application_data(student, &block)
-    block ||= Proc.new {}
-    header  = Proc.new do
+    block ||= proc {}
+    header  = proc do
       content_tag :h4, "This section is hidden from the rest of your team"
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,7 @@ module ApplicationHelper
     content = activity.content
     content = render_markdown(content) if activity.kind == 'mailing'
     content = strip_tags(content || '')
-    content = CGI::unescapeHTML(content)
+    content = CGI.unescapeHTML(content)
     content = sanitize(content, tags: [])
     content = truncate(content, options.merge(omission: '', separator: ' ')) { read_more.html_safe }
     content
@@ -131,7 +131,7 @@ module ApplicationHelper
   def status_for(team, member, role_name)
     if role_name == :coach
       role = team.roles.find { |role| role.user == member }
-      if role && role.confirmed?
+      if role&.confirmed?
         content_tag :span, 'Confirmed', class: 'label label-default'
       elsif current_user == member
         link_to 'Confirm', confirm_role_path((role.confirmation_token || 'confirmation-token-missing')), method: :put, class: 'btn btn-sm btn-success'
@@ -171,7 +171,7 @@ module ApplicationHelper
   # stolen from: http://railscasts.com/episodes/228-sortable-table-columns?view=asciicast
   def sortable(column, title = nil)
     title ||= column.to_s.titleize
-    direction = (column.to_s == params[:sort] && params[:direction] == 'asc') ? 'desc' : 'asc'
+    direction = column.to_s == params[:sort] && params[:direction] == 'asc' ? 'desc' : 'asc'
     link_to title, params.except('action', 'controller').permit!.merge(sort: column, direction: direction)
   end
 

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -3,6 +3,6 @@
 module UrlHelper
   def normalize_url(url)
     url = url.strip if url
-    (url.present? && url !~ /^(http|file)/) ? "http://#{url}" : url
+    url.present? && url !~ /^(http|file)/ ? "http://#{url}" : url
   end
 end

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -12,7 +12,8 @@ class ProjectMailer < ActionMailer::Base
 
   def comment(project, comment)
     subject = "[RGSoC] New comment: Project '#{project.name}'"
-    @project, @comment = project, comment
+    @project = project
+    @comment = comment
     rcpts = (project.subscribers - [comment.user]).map(&:email)
     mail subject: subject, to: rcpts
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -65,7 +65,7 @@ class Ability
 
     # FIXME Leave this in until issue #1001 is fixed
     # visibility of email address in user profile
-    can :read_email, User, id: user.id if !user.hide_email?
+    can :read_email, User, id: user.id unless user.hide_email?
     can :read_email, User if user.admin?
     can :read_email, User do |other_user|
       user.confirmed? && (supervises?(other_user, user) || !other_user.hide_email?)
@@ -86,7 +86,7 @@ class Ability
 
     # todo helpdesk team join
     can :join, Team do |team|
-      team.helpdesk_team? and signed_in?(user) and user.confirmed? and not on_team?(user, team)
+      team.helpdesk_team? and signed_in?(user) and user.confirmed? and !on_team?(user, team)
     end
 
     can :crud, Role do |role|

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Application < ApplicationRecord
-  include HasSeason, Rateable
+  include Rateable
+  include HasSeason
 
   PROJECT_VISIBILITY_WEIGHT = ENV['PROJECT_VISIBILITY_WEIGHT'] || 2
   COACHING_COMPANY_WEIGHT = ENV['COACHING_COMPANY_WEIGHT'] || 2
@@ -49,7 +50,7 @@ class Application < ApplicationRecord
   end
 
   def country
-    @country ||= super.present? ? super : (team || Team.new).students.map(&:country).reject(&:blank?).join(', ')
+    @country ||= super.presence || (team || Team.new).students.map(&:country).reject(&:blank?).join(', ')
   end
 
   def location

--- a/app/models/concerns/rateable.rb
+++ b/app/models/concerns/rateable.rb
@@ -17,7 +17,7 @@ module Rateable
     return 0 if rating_points.empty?
     m_pos = rating_points.size / 2
 
-    if rating_points.size % 2 == 1
+    if rating_points.size.odd?
       rating_points[m_pos].round(2)
     else
       mean(rating_points[m_pos - 1..m_pos]).round(2)

--- a/app/models/dev_utils/season_phase_switcher.rb
+++ b/app/models/dev_utils/season_phase_switcher.rb
@@ -11,7 +11,7 @@ module DevUtils
 
     class << self
       def destined(phase)
-        raise ArgumentError.new("#{phase} is not a valid phase") unless phase.in? PHASES
+        raise ArgumentError, "#{phase} is not a valid phase" unless phase.in? PHASES
         send(phase)
       end
 

--- a/app/models/mentor/application.rb
+++ b/app/models/mentor/application.rb
@@ -119,7 +119,7 @@ module Mentor
       def find(id:, projects:, season: Season.current)
         data = data_for(id: id, choice: 1, projects: projects, season: season) ||
                data_for(id: id, choice: 2, projects: projects, season: season) ||
-               fail(ActiveRecord::RecordNotFound)
+               raise(ActiveRecord::RecordNotFound)
         data.instance_eval(&mentorize)
       end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,9 +16,7 @@ class Project < ApplicationRecord
   validates :name, :submitter, :mentor_email, presence: true
 
   scope :not_rejected, -> { where.not(aasm_state: 'rejected') }
-  scope :in_current_season, -> do
-    where(season: Season.transition? ? Season.succ : Season.current)
-  end
+  scope :in_current_season, -> { where(season: Season.transition? ? Season.succ : Season.current) }
 
   before_validation :sanitize_url
   after_create :add_submitter_to_maintainers_list

--- a/app/models/rating_criterium.rb
+++ b/app/models/rating_criterium.rb
@@ -7,12 +7,12 @@ class RatingCriterium
   attr_reader :weight
 
   def initialize(weight, point_names = {})
-    if !weight.is_a? Numeric || (weight < 0 || weight > 1)
-      raise ArgumentError.new("weight must be a number betweent 0 and 1.")
+    unless weight.is_a? Numeric || (weight < 0 || weight > 1)
+      raise ArgumentError, "weight must be a number betweent 0 and 1."
     end
 
-    if !point_names.is_a? Hash
-      raise ArgumentError.new("points must be a hash.")
+    unless point_names.is_a? Hash
+      raise ArgumentError, "points must be a hash."
     end
 
     @weight = weight

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -10,7 +10,7 @@ class Source < ApplicationRecord
   validates :url, presence: true
   validates :kind, presence: true
 
-  scope :for_accepted_teams, ->() { joins(:team).merge(Team.accepted) }
+  scope :for_accepted_teams, -> { joins(:team).merge(Team.accepted) }
 
   def url=(url)
     super(normalize_url(url))

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -39,8 +39,7 @@ class Student < SimpleDelegator
     @current_team ||= Team.joins(:roles)
       .references(:roles)
       .in_current_season
-      .where('roles.user_id' => user.id, 'roles.name' => 'student')
-      .first
+      .find_by('roles.user_id' => user.id, 'roles.name' => 'student')
   end
 
   def current_drafts

--- a/app/models/student_application/student_attribute_proxy.rb
+++ b/app/models/student_application/student_attribute_proxy.rb
@@ -10,7 +10,7 @@ module StudentApplication
     end
 
     def attribute(*args)
-      students[index].send(field, *args) if students[index]
+      students[index]&.send(field, *args)
     end
 
     def matches?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Team < ApplicationRecord
-  include ProfilesHelper, HasSeason
+  include HasSeason
+  include ProfilesHelper
 
   KINDS = %w(full_time part_time)
 
@@ -41,10 +42,6 @@ class Team < ApplicationRecord
   before_create :set_number
   before_save :set_last_checked, if: :checked
 
-  scope :without_recent_log_update, -> {
-    where.not(id: Activity.where(kind: ['status_update', 'feed_entry']).where("created_at > ?", 26.hours.ago).pluck(:team_id))
-  }
-
   scope :full_time, -> { where(kind: %w(full_time sponsored)) }
   scope :part_time, -> { where(kind: %w(part_time voluntary)) }
   scope :accepted, -> { full_time.or(part_time) }
@@ -71,7 +68,7 @@ class Team < ApplicationRecord
   end
 
   def application
-    @application ||= applications.where(season_id: Season.current.id).first
+    @application ||= applications.find_by(season_id: Season.current.id)
   end
 
   # TeamPerformance for Supervisor's Dashboard

--- a/app/models/team_performance.rb
+++ b/app/models/team_performance.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TeamPerformance
-# Internal: calculates a Team's performance score for supervisor's dashboard
+  # Internal: calculates a Team's performance score for supervisor's dashboard
 
   def initialize(team)
     @team = team
@@ -33,7 +33,7 @@ class TeamPerformance
 
   def comments_score
     latest_comment = @team.comments.ordered.first
-    if !buffer_days?
+    unless buffer_days?
       if @team.comments.empty?
         @score += 3
       elsif latest_comment.created_at <= Time.now - 5.days
@@ -49,7 +49,7 @@ class TeamPerformance
   end
 
   def activity_score
-    if !buffer_days?
+    unless buffer_days?
       if @team.activities.empty?
         @score += 3
       elsif @team.last_activity.created_at <= Time.now - 5.days

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -222,7 +222,11 @@ class User < ApplicationRecord
   end
 
   def complete_from_github
-    attrs = Github::User.new(github_handle).attrs rescue {}
+    attrs = begin
+              Github::User.new(github_handle).attrs
+            rescue StandardError
+              {}
+            end
     attrs[:name] = github_handle if attrs[:name].blank?
     attrs = attrs.select { |key, value| send(key).blank? && value.present? }
     assign_attributes(attrs)

--- a/lib/tasks/single_run.rake
+++ b/lib/tasks/single_run.rake
@@ -11,7 +11,7 @@ namespace :single_run do
     in_wrong_season = ->(prj) { prj && prj.season.name != '2017' }
 
     ApplicationDraft.in_current_season.includes(project1: :season, project2: :season).each do |draft|
-      if in_wrong_season.(draft.project1)
+      if in_wrong_season.call(draft.project1)
         project = Project.in_current_season.find_by(name: draft.project1.name)
         draft.project1 = project
         draft.save(validate: false)
@@ -22,15 +22,14 @@ namespace :single_run do
         end
       end
 
-      if in_wrong_season.(draft.project2)
-        project = Project.in_current_season.find_by(name: draft.project2.name)
-        draft.project2 = project
-        draft.save(validate: false)
+      next unless in_wrong_season.call(draft.project2)
+      project = Project.in_current_season.find_by(name: draft.project2.name)
+      draft.project2 = project
+      draft.save(validate: false)
 
-        if app = draft.application
-          app.application_data["project2_id"] = project.id.to_s
-          app.save(validate: false)
-        end
+      if app = draft.application
+        app.application_data["project2_id"] = project.id.to_s
+        app.save(validate: false)
       end
     end
   end
@@ -58,11 +57,10 @@ namespace :single_run do
     Application.rateable.each do |application|
       fav1 = application.application_data['mentor_fav_project1']
       fav2 = application.application_data['mentor_fav_project2']
-      if [fav1, fav2].include?('false')
-        application.application_data.delete('mentor_fav_project1') if fav1 == 'false'
-        application.application_data.delete('mentor_fav_project2') if fav2 == 'false'
-        application.save
-      end
+      next unless [fav1, fav2].include?('false')
+      application.application_data.delete('mentor_fav_project1') if fav1 == 'false'
+      application.application_data.delete('mentor_fav_project2') if fav2 == 'false'
+      application.save
     end
   end
 end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ConferencesController, type: :controller do
 
       it 'should return a 401 response status' do
         post :create, params: { conference: conference_attrs }, xhr: true
-        expect(response).to have_http_status(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 

--- a/spec/controllers/mentors/comments_controller_spec.rb
+++ b/spec/controllers/mentors/comments_controller_spec.rb
@@ -60,8 +60,9 @@ RSpec.describe Mentors::CommentsController, type: :controller do
     end
 
     context 'as an unauthorized user' do
+      before { sign_in user }
+
       it 'redirects to the landing page' do
-        sign_in user
         put :update, params: { id: 1 }
         expect(response).to redirect_to root_path
       end
@@ -70,40 +71,35 @@ RSpec.describe Mentors::CommentsController, type: :controller do
     context 'as a project_maintainer' do
       let!(:project) { create(:project, :in_current_season, :accepted, submitter: user) }
 
+      subject(:request) { put :update, params: params }
+
       before { sign_in user }
 
       context 'when comment exists' do
         let!(:comment) { Mentor::Comment.create(user: user, commentable_id: 1, text: 'something') }
         let(:params)   { { id: comment.id, mentor_comment: { text: 'something else' } } }
+        let(:anchor)   { "mentor_comment_#{comment.id}" }
 
-        subject { put :update, params: params }
-
-        it 'updates the comment' do
-          expect { subject; comment.reload }.to change { comment.text }.
-            from('something').to('something else')
-        end
-
-        it 'redirect_to the mentor application show view' do
-          subject
-          anchor = "mentor_comment_#{comment.id}"
+        it 'updates the comment and redirects to the mentor application show view' do
+          expect { request }.to change { comment.reload.text }.from('something').to('something else')
           expect(response).to redirect_to mentors_application_path(id: 1, anchor: anchor)
         end
       end
 
       context 'when comment does not exist' do
-        it 'returns a 404' do
-          params = { id: 1, mentor_comment: { text: 'something else' } }
+        let(:params) { { id: -1, mentor_comment: { text: 'something else' } } }
 
-          expect { put :update, params: params }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'returns a 404' do
+          expect { request }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
       context 'when comment does not belong to user' do
-        it 'returns a 404' do
-          comment = Mentor::Comment.create(user: build(:user), commentable_id: 1, text: 'something')
-          params  = { id: comment.id, mentor_comment: { text: 'something else' } }
+        let(:comment) { Mentor::Comment.create(user: build(:user), commentable_id: 1, text: 'something') }
+        let(:params)  { { id: comment.id, mentor_comment: { text: 'something else' } } }
 
-          expect { put :update, params: params }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'returns a 404' do
+          expect { request }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end

--- a/spec/controllers/organizers/projects_controller_spec.rb
+++ b/spec/controllers/organizers/projects_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Organizers::ProjectsController, type: :controller do
         it "#{action}s and redirect to show" do
           expect {
             put action, params: { id: project.to_param }
-          }.to change { project.reload.aasm_state }.to "#{state}"
+          }.to change { project.reload.aasm_state }.to state.to_s
           expect(response).to redirect_to [:organizers, :projects]
           expect(flash[:notice]).to be_present
         end

--- a/spec/controllers/organizers/seasons_controller_spec.rb
+++ b/spec/controllers/organizers/seasons_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Organizers::SeasonsController, type: :controller do
   context 'with admin logged in' do
     include_context 'with admin logged in'
 
-    let(:season) { Season.create name: 2015 }
+    let(:season) { create(:season, name: '2015') }
 
     describe 'GET new' do
       it 'renders the new template' do
@@ -49,7 +49,7 @@ RSpec.describe Organizers::SeasonsController, type: :controller do
       end
 
       context 'with invalid data' do
-        let!(:season) { create :season }
+        let!(:season) { create(:season) }
 
         it 'fails updates and renders the edit template' do
           patch :update, params: { id: season.to_param, season: { name: '' } }

--- a/spec/controllers/organizers/teams_controller_spec.rb
+++ b/spec/controllers/organizers/teams_controller_spec.rb
@@ -116,24 +116,32 @@ RSpec.describe Organizers::TeamsController, type: :controller do
       end
     end
 
-    describe "PATCH update" do
+    describe 'PATCH update' do
+      subject(:request) { patch(:update, params: params) }
+
       before { sign_in user }
 
-      context "assign conference attendance" do
-        let(:offer) { create(:conference_attendance) }
-        let(:team) { offer.team }
-        let!(:team_params) do
-          build(:team).attributes.merge(conference_attendances_attributes: {
-            '0' => {
-              conference_id: offer.conference.id, orga_comment: "commment"
+      context 'when assigning conference attendances' do
+        let(:conference)            { create(:conference) }
+        let(:team)                  { create(:team) }
+        let(:params)                { { id: team.id, team: team_params } }
+        let(:conference_attendance) { ConferenceAttendance.last }
+        let(:orga_comment)          { 'Some ideas about how and why' }
+        let(:team_params) do
+          {
+            conference_attendances_attributes: {
+              '0' => { conference_id: conference.id, orga_comment: orga_comment }
             }
-          })
+          }
         end
 
-        it 'orga members can assign conference offer for a team' do
-          expect {
-              patch :update, params: { id: team.id, team: team_params }
-            }.to change { team.conference_attendances.count }.by 1
+        it 'adds creates a new conference attendance for the team' do
+          expect { request }.to change(ConferenceAttendance, :count).by(1)
+          expect(conference_attendance).to have_attributes(
+            team:         team,
+            conference:   conference,
+            orga_comment: orga_comment
+          )
         end
       end
     end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RolesController, type: :controller do
       let!(:role) { create(:role, name: 'student', team: team, user: user) }
 
       let(:randomize_case) do
-        ->(string) do
+        lambda do |string|
           string.each_char.inject('') { |str, c| str << c.send([:downcase, :upcase][rand(2)]) }
         end
       end
@@ -58,7 +58,7 @@ RSpec.describe RolesController, type: :controller do
 
       it 'creates a new Role for existing user with case-insensitive github_handle' do
         existing   = create(:user)
-        role_attrs = valid_attributes.merge(github_handle: randomize_case.(existing.github_handle))
+        role_attrs = valid_attributes.merge(github_handle: randomize_case.call(existing.github_handle))
 
         expect {
           expect { post :create, params: params.merge(role: role_attrs) }.to change(Role, :count).by(1)

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe TeamsController, type: :controller do
           let(:github_handle) { valid_attributes[:roles_attributes].first[:github_handle] }
 
           let(:randomize_case) do
-            ->(string) do
+            lambda do |string|
               string.each_char.inject('') { |str, c| str << c.send([:downcase, :upcase][rand(2)]) }
             end
           end
@@ -209,7 +209,7 @@ RSpec.describe TeamsController, type: :controller do
           end
 
           it 'finds an existing user by case-insensitive github_handle' do
-            existing_user = create :user, github_handle: randomize_case.(github_handle)
+            existing_user = create :user, github_handle: randomize_case.call(github_handle)
             expect {
               patch :update, params: { id: team.to_param, team: valid_attributes }
             }.not_to change { User.count }

--- a/spec/factories/season.rb
+++ b/spec/factories/season.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :season do
-    sequence(:name, '2000')
+    sequence(:name, '2030')
   end
 
   trait :past do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it 'should return link_to role based on student' do
       expect(link_to_user_roles(user)).to eq(
-        "<a href=\"/community?role=coach\">Coach</a> at <a href=\"/teams/#{team1.id}\">Team 29-enim (Sinatra)</a>, " +
+        "<a href=\"/community?role=coach\">Coach</a> at <a href=\"/teams/#{team1.id}\">Team 29-enim (Sinatra)</a>, " \
         "<a href=\"/community?role=mentor\">Mentor</a> at <a href=\"/teams/#{team2.id}\">Team 28-enim</a>"
       )
     end

--- a/spec/helpers/nav_helper_spec.rb
+++ b/spec/helpers/nav_helper_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe NavHelper, type: :helper do
         instance_double(Season,
           application_period?:        false,
           applications_close_at:      2.days.ago.utc,
-          acceptance_notification_at: 1.days.ago.utc
+          acceptance_notification_at: 1.day.ago.utc
         )
       end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -43,9 +43,8 @@ RSpec.describe Ability, type: :model do
       end
 
       context 'when the user is a supervisor of another team' do
-        before do
-         allow(user).to receive(:supervisor?).and_return(true)
-       end
+        before { allow(user).to receive(:supervisor?).and_return(true) }
+
         it { expect(ability).not_to be_able_to(:see_offered_conferences, Team.new) }
       end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -144,7 +144,8 @@ RSpec.describe Project, type: :model do
 
   describe '#to_param' do
     it 'appends the name' do
-      subject.id, subject.name = 4711, 'Hello World'
+      subject.id = 4711
+      subject.name = 'Hello World'
       expect(subject.to_param).to eql '4711-hello-world'
     end
   end

--- a/spec/models/selection/strictness_spec.rb
+++ b/spec/models/selection/strictness_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Selection::Strictness, type: :model do
       # We still want to stub Rating#points, but we need different
       # valus. Return `a` for the first rating, `b` else.
       let(:points) do
-        ->(rating) {
+        lambda { |rating|
           case rating
           when rating1 then 2.0 # reviewer1 for application1
           when rating2 then 6.0 # reviewer1 for application2

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -370,45 +370,6 @@ RSpec.describe Team, type: :model do
         end
       end
     end
-
-    describe '.without_recent_log_update' do
-      let(:team_without) { create :team }
-
-      let(:team_with_old) do
-        team_with_old = create :team
-        create :status_update, created_at: 2.days.ago, team: team_with_old
-        team_with_old
-      end
-
-      let(:team_with_recent_status_update) do
-        team_with_recent_status_update = create :team
-        create :status_update, created_at: 1.hour.ago, team: team_with_recent_status_update
-        team_with_recent_status_update
-      end
-
-      let(:team_with_recent_feed_entry) do
-        team_with_recent_feed_entry = create :team
-        create :activity, :feed_entry, created_at: 1.hour.ago, team: team_with_recent_feed_entry
-        team_with_recent_feed_entry
-      end
-
-      it 'includes the team without any status updates' do
-        team_without
-        expect(described_class.without_recent_log_update).to include(team_without)
-      end
-
-      it 'includes the team with only old updates' do
-        team_with_old
-        expect(described_class.without_recent_log_update).to include(team_with_old)
-      end
-
-      it 'does not include the teams with recent updates' do
-        team_with_recent_status_update
-        team_with_recent_feed_entry
-        expect(described_class.without_recent_log_update).not_to include(team_with_recent_status_update)
-        expect(described_class.without_recent_log_update).not_to include(team_with_recent_feed_entry)
-      end
-    end
   end
 
   describe 'creating a new team' do


### PR DESCRIPTION
This is only a temporary solution for _"silencing"_ a flaky corner of the test suite: linting all factories.

With the names of a season being required to a) be unique and b) within a given range, the sequence used for the name in the factory is very likely to at some point collide with the current year 🙈 
I therefore set it to a value further away from the current year to for not at least silence this.

Maybe we'll even come up with a better solution for this weird `current` thing in the season model 😉 

As a side-fix I also updated the debugging tools to be a bit more convenient (use pry all over).