### PR TITLE
Hide conferences choices for 2020

### DIFF
--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -69,8 +69,8 @@
               = s.link_to_remove 'Remove', class: 'btn btn-default'
       .form-group.form-btn-group
         = f.link_to_add 'Add another source', :sources, class: 'btn btn-primary col-sm-offset-3'
-  - if can?(:update_conference_preferences, @team)
-    = render 'conference_preference_fields', f: f
+<!--   - if can?(:update_conference_preferences, @team) -->
+<!--       = render 'conference_preference_fields', f: f -->
   .actions
     ul.list-inline
       li  = f.submit 'Save', class: 'btn btn-success'


### PR DESCRIPTION
Hides conference preferences in Team creation/edit screen of Teams App as not offered for 2020