### PR TITLE
Fix 500 Error in community_controller#index when filtering by role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get install chromium-chromedriver
   - gem update --system
   - gem --version
-  - gem install bundler
+  - gem install bundler -v 1.17.3
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,6 +135,7 @@ class User < ApplicationRecord
     end
 
     def search(search)
+      return all if search.nil?
       q_user_names = User.where("users.name ILIKE ?", "%#{search}%")
       q_team_names = User.with_teams.where("teams.name ILIKE ?", "%#{search}%")
       (q_user_names + q_team_names).uniq

--- a/spec/controllers/community_controller_spec.rb
+++ b/spec/controllers/community_controller_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe CommunityController, type: :controller do
       end
     end
 
+    context 'with filtering' do
+      it 'filters by role' do
+        get :index, params: { role: 'student' }
+        expect(response).to render_template 'index'
+      end
+
+      it 'filters by interest' do
+        get :index, params: { interest: 'pair' }
+        expect(response).to render_template 'index'
+      end
+    end
+
     context 'with user logged in' do
       before(:each) do
         sign_in create(:student)


### PR DESCRIPTION
This fixes a SQL error on `/community` when filtering by role. 

Spec included.