### PR TITLE
[Bugfix] Joining helpdesk team

### DIFF
--- a/app/controllers/join_controller.rb
+++ b/app/controllers/join_controller.rb
@@ -16,6 +16,8 @@ class JoinController < ApplicationController
   end
 
   def allow_helpdesk
-    redirect_to root_url unless @team.helpdesk_team?
+    unless @team.helpdesk_team?
+      redirect_back fallback_location: teams_url, alert: 'You cannot do that right now.'
+    end
   end
 end

--- a/app/controllers/join_controller.rb
+++ b/app/controllers/join_controller.rb
@@ -16,8 +16,6 @@ class JoinController < ApplicationController
   end
 
   def allow_helpdesk
-    unless @team.helpdesk_team?
-      redirect_back fallback_location: teams_url, alert: 'You cannot do that right now.'
-    end
+    redirect_back fallback_location: teams_url, alert: 'You cannot do that right now.' unless @team.helpdesk_team?
   end
 end

--- a/app/controllers/join_controller.rb
+++ b/app/controllers/join_controller.rb
@@ -16,6 +16,6 @@ class JoinController < ApplicationController
   end
 
   def allow_helpdesk
-    redirect_to root_url unless @team.helpdesk?
+    redirect_to root_url unless @team.helpdesk_team?
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 
 class Ability
   include CanCan::Ability

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 
 class Ability
   include CanCan::Ability
 
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def initialize(user)
     user ||= User.new
 
@@ -108,6 +108,7 @@ class Ability
       user.admin? || (preference.team.students.include? user)
     end
   end # initializer
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def signed_in?(user)
     user.persisted?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,7 +24,9 @@ class Ability
     can :resend_confirmation_instruction, User, id: user.id
     can :read_email, User, hide_email: false
     can :create, Project
-    can [:join, :create], Team
+    can [:join, :create], Team do |team|
+      !on_team?(user, team)
+    end
     can :index, Mailing
     can :read, Mailing do |mailing|
       mailing.recipient? user

--- a/spec/controllers/join_controller_spec.rb
+++ b/spec/controllers/join_controller_spec.rb
@@ -43,6 +43,5 @@ RSpec.describe JoinController, type: :controller do
         expect(response).to redirect_to(teams_url)
       end
     end
-
   end
 end

--- a/spec/controllers/join_controller_spec.rb
+++ b/spec/controllers/join_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require 'cancan/matchers'
+
+RSpec.describe JoinController, type: :controller do
+  render_views
+
+  include_context 'with user logged in'
+
+  let(:user) { create(:user) }
+  let(:team) { create(:team) }
+  let(:current_user) { user }
+  let(:role) { team.roles.build(user: user, name: 'helpdesk') }
+
+  describe "GET new" do
+    before { sign_in user }
+
+    it "assigns team as @team" do
+      get :new, params: { team_id: team.to_param }
+      expect(assigns(:team)).to eq(team)
+    end
+  end
+
+  describe "POST create" do
+    before { sign_in user }
+
+    describe "with valid params" do
+      let(:team) { create(:team, :helpdesk) }
+
+      it "adds the current user to the team" do
+        post :create, params: { team_id: team.to_param }
+        expect(team.roles).to include(role)
+      end
+
+      it "redirects to the user's profile" do
+        post :create, params: { team_id: team.to_param }
+        expect(response).to redirect_to(edit_user_url(user))
+      end
+    end
+
+    describe "with invalid params" do
+      it "redirects to to the previous page" do
+        post :create, params: { team_id: team.to_param }
+        expect(response).to redirect_to(root_url)
+      end
+    end
+
+  end
+end

--- a/spec/controllers/join_controller_spec.rb
+++ b/spec/controllers/join_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe JoinController, type: :controller do
     describe "with invalid params" do
       it "redirects to to the previous page" do
         post :create, params: { team_id: team.to_param }
-        expect(response).to redirect_to(root_url)
+        expect(response).to redirect_to(teams_url)
       end
     end
 


### PR DESCRIPTION
## Fixes

- Allow "Join [Teamname]" button on `/team/:id` page to join the Helpdesk team
- Show error message when trying to join any other team
- Add specs for `JoinController`