### PR TITLE
Allow mentors to update their comments on applications

### DIFF
--- a/app/views/mentors/applications/_comment.html.slim
+++ b/app/views/mentors/applications/_comment.html.slim
@@ -1,5 +1,12 @@
+ruby:
+  comment_path = if comment.persisted? then
+                    mentors_comment_path(comment)
+                  else
+                    mentors_comments_path
+                  end
+
 hr(id="#{dom_id comment}")
-= simple_form_for comment, url: mentors_comments_path do |f|
+= simple_form_for comment, url: comment_path do |f|
   .form-inputs.clearfix
     = f.input :commentable_id, as: :hidden, value: comment.commentable_id
     = f.input :text, as: :text, label: 'My Comment', input_html: { rows: 5 }, hint: 'This is a place for you to take notes for yourself about this application. Your comment is only visible to yourself as well as the selection committee and you can update and remove it as you like.'

--- a/spec/features/mentors/applications/show_spec.rb
+++ b/spec/features/mentors/applications/show_spec.rb
@@ -32,6 +32,33 @@ RSpec.describe 'Application show page', type: :feature do
     expect(page).to have_button 'Create Comment'
   end
 
+  it 'lets the mentor create a comment' do
+    login_as user
+
+    visit mentors_application_path(application)
+
+    fill_in 'My Comment', with: 'Test Comment'
+    click_button 'Create Comment'
+
+    expect(page).to have_content 'Test Comment'
+  end
+
+  it 'lets the mentor update a comment' do
+    login_as user
+
+    visit mentors_application_path(application)
+
+    fill_in 'My Comment', with: 'Test Comment'
+    click_button 'Create Comment'
+
+    expect(page).to have_content 'Test Comment'
+
+    fill_in 'My Comment', with: 'Updated Comment'
+    click_button 'Update Comment'
+
+    expect(page).to have_content 'Updated Comment'
+  end
+
   context 'when the project is 2nd choice' do
     let(:application) { create(:application, :in_current_season, :for_project, project2: project, team: team) }
 


### PR DESCRIPTION
Related issue #960 

- Fixes an issue where mentors are able to leave comments on an application, but are not able to update those comments
- Functionality was already implemented, but the view used an incorrect path
- Added feature tests for both creating a comment and updating it
